### PR TITLE
모바일 네비게이션 바 (새로운 디자인 적용

### DIFF
--- a/components/Header/_component/sheet.tsx
+++ b/components/Header/_component/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-11 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute z-10 left-5 top-5 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-6 w-6" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+}

--- a/components/Header/_component/sheetcontetprops.tsx
+++ b/components/Header/_component/sheetcontetprops.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link"
+import { FaCalendar, FaDoorOpen, FaGuitar, FaInstagram, FaList, FaPeopleArrows, FaYoutube } from "react-icons/fa"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Separator } from "@/components/ui/separator"
+import ROUTES from "@/constants/routes"
+
+const SheetContentProps = () => {
+
+ return (
+
+    <div className="flex flex-col w-full h-full">
+       <Link href={ROUTES.LOGIN.url} className="flex w-full h-[10%] justify-start items-center py-[4%]">
+            <Avatar className="w-12 h-12">
+                <AvatarImage src="https://github.com/shadcn.png" />
+                <AvatarFallback>CN</AvatarFallback>
+            </Avatar> 
+            <div className="w-full pl-4">
+                <div className="w-full h-full text-black font-semibold text-lg text-center">로그인 <br/>해주세요</div>
+            </div>             
+        </Link>
+        <Separator/>
+        <div className="w-full h-[40%] pt-[2%]">
+            <div className="w-full h-[12%] text-gray-500 text-base pb-[8%]">MAIN</div>
+            <Link href={ROUTES.NOTICE.LIST.url} className='flex items-center font-medium text-lg text-gray-500 w-full h-[22%]'>
+                <FaCalendar size={25} style={{ color: '#BEBEBE' }}/>
+                <div className="text-gray-500 font-medium text-lg pl-4">공지사항</div>
+            </Link>
+            <Link href={ROUTES.PERFORMANCE.LIST.url} className='flex items-center font-medium text-lg text-gray-500 w-full h-[22%]'>
+                <FaList size={25} style={{ color: '#BEBEBE' }} />
+                <div className="text-gray-500 font-medium text-lg pl-4">공연목록</div>
+            </Link>
+            <Link href={ROUTES.TEAM.LIST.url} className='flex items-center font-medium text-lg text-gray-500 w-full h-[22%]'>
+                <FaGuitar size={25} style={{ color: '#BEBEBE' }}/>
+                <div className="text-gray-500 font-medium text-lg pl-4">세션지원</div>
+            </Link>
+            <Link href={ROUTES.MEMBER.LIST.url} className='flex items-center font-medium text-lg text-gray-500 w-full h-[22%]'>
+                <FaPeopleArrows size={25} style={{ color: '#BEBEBE' }}/>
+                <div className="text-gray-500 font-medium text-lg pl-4">멤버목록</div>                
+            </Link>
+        </div>
+        <Separator/>
+        <div className="flex flex-col justify-start w-full h-[24%] pt-[2%]">
+            <div className="w-full h-[21.6%] text-gray-500 text-base pb-[13.3%]">LINKS</div>
+            <div className='flex items-center text-gray-500 w-full h-[41.4%]'>
+                <FaYoutube size={30} style={{ color: '#BEBEBE' }} />
+                <div className='text-gray-500 font-medium text-lg pl-4'>YouTube</div>
+            </div>
+            <div className='flex items-center text-gray-500 w-full h-[41.4%]'>
+                <FaInstagram size={30} style={{ color: '#BEBEBE' }} />
+                <div className='text-gray-500 font-medium text-lg pl-4'>Instagram</div>
+            </div>
+        </div>
+        <Link href={ROUTES.LOGIN.url} className="flex justify-center items-center gap-4 w-full h-[9%] pt-[85%]">
+            <FaDoorOpen size={30} style={{ color: '#023664' }} />
+            <div className="text-xl font-medium text-primary">Login Account</div>
+        </Link>
+    </div>
+ )
+
+}
+
+export default SheetContentProps

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,7 +1,10 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useState } from 'react'
+import { RxHamburgerMenu } from "react-icons/rx";
+
+import { Sheet, SheetContent, SheetTrigger } from '@/components/Header/_component/sheet';
+import SheetContentProps from '@/components/Header/_component/sheetcontetprops';
 
 import ROUTES from '../../constants/routes'
 import { cn } from '../../lib/utils'
@@ -22,75 +25,27 @@ const Header = ({
     { name: '맴버목록', url: ROUTES.MEMBER.LIST.url, active: true }
   ]
 
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
-
-  return (
+  return (  
     <header
       className={cn(
         position,
-        'top-0 z-10 flex h-full w-full justify-center bg-primary backdrop-blur'
+        'top-0 z-10 flex h-full w-full bg-primary justify-center'
       )}
       style={{ height }}
     >
       {/* Mobile */}
-      <nav className="flex  w-full items-center justify-between md:hidden">
-        <div
-          className="h-full flex-col items-center justify-center pl-4"
-          onClick={() => setIsSidebarOpen(true)}
-        >
-          <div className="flex h-full flex-col justify-center gap-[0.3rem]">
-            <div className="h-[0.2rem] w-8 bg-white"></div>
-            <div className="h-[0.2rem] w-8 bg-white"></div>
-            <div className="h-[0.2rem] w-8 bg-white"></div>
-          </div>
-        </div>
-        <div className="fixed ml-[45%] flex items-center">
-          <Link href={ROUTES.HOME.url}>
-            <Image src="/Logo.png" alt="logo" width={47} height={47} />
-          </Link>
-        </div>
-        <div className="mr-10"></div>
+      <nav className="relative flex justify-between items-center w-11/12 h-full visible md:hidden">
+        <div className="w-9 f-full bg-none"></div>
+        <Link href="/">
+          <Image src="/Logo.png" alt="logo" width={50} height={50} />
+        </Link>
+        <Sheet>
+        <SheetTrigger><RxHamburgerMenu className="text-white w-9 h-9"/></SheetTrigger>
+          <SheetContent>
+            <SheetContentProps/>
+         </SheetContent>
+        </Sheet>
       </nav>
-
-      <div
-        className={`fixed left-0 top-0 flex h-screen w-[43%] transform flex-col justify-center bg-gray-800 text-white ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} transition-transform duration-300 ease-in-out`}
-      >
-        <div className="flex h-[90%] flex-col items-start justify-center">
-          <Link
-            href={ROUTES.NOTICE.LIST.url}
-            className="flex w-full flex-1 items-center justify-center text-2xl font-black"
-          >
-            공지사항
-          </Link>
-          <Link
-            href={ROUTES.PERFORMANCE.LIST.url}
-            className="flex w-full flex-1 items-center justify-center text-2xl font-black"
-          >
-            공연목록
-          </Link>
-          <Link
-            href={ROUTES.TEAM.LIST.url}
-            className="flex w-full flex-1 items-center justify-center text-2xl font-black"
-          >
-            세션지원
-          </Link>
-          <Link
-            href={ROUTES.MEMBER.LIST.url}
-            className="flex w-full flex-1 items-center justify-center text-2xl font-black"
-          >
-            멤버목록
-          </Link>
-        </div>
-        <div className="flex-1 justify-center">
-          <Profile />
-        </div>
-      </div>
-      {isSidebarOpen && (
-        <div
-          className="h-screen w-full"
-          onClick={() => setIsSidebarOpen(false)}
-        ></div>
-      )}
 
       {/* Tablet & Desktop */}
       <nav className="hidden h-full w-full items-center px-10 md:visible md:flex">
@@ -118,6 +73,7 @@ const Header = ({
         </div>
       </nav>
     </header>
+    
   )
 }
 

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+}


### PR DESCRIPTION
네비게이션 바의 새로운 디자인을 적용해보았습니다.

- sheet.tsx의 className을 조절해 ui폴더에서 바로 쓰기는 힘들 거 같아서, _component 폴더를 만들었습니다. 대신 복사된 sheet.tsx에서 최대한 안쓰는 코드를 제거해 무게를 줄였습니다
- 저번에 합의한 Lucide 아이콘을 적용했습니다. 유튜브와 인스타그램 아이콘은 Lucide 아이콘 적용이 안돼서 그대로 썼는데 디자인이 비슷해서 괜찮다 생각했습니다. (Lucide 적용은 -> npm install lucide-react 설치 후 했음)

![image](https://github.com/user-attachments/assets/5dd85bda-fd73-4e48-bbca-590d73b3f762) => Lucide의 유튜브와 인스타그램 아이콘은 다음과 같이 뜹니다.