### PR TITLE
chore: icons changed to lucide

### DIFF
--- a/app/(general)/teams/_components/TeamListTable/columns.tsx
+++ b/app/(general)/teams/_components/TeamListTable/columns.tsx
@@ -1,13 +1,15 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown } from "lucide-react"
+import {
+  ArrowUpDown,
+  EllipsisVertical,
+  Paperclip,
+  Pencil,
+  Trash
+} from "lucide-react"
 import Link from "next/link"
 import React from "react"
-import { BsThreeDotsVertical } from "react-icons/bs"
-import { FiPaperclip } from "react-icons/fi"
-import { GoPencil } from "react-icons/go"
-import { GoTrash } from "react-icons/go"
 
 import SessionBadge from "@/components/SessionBadge"
 import StatusBadge from "@/components/StatusBadge"
@@ -118,7 +120,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
       if (songYoutubeVideoId) {
         return (
           <Link href={songYoutubeVideoId}>
-            <FiPaperclip size={24} />
+            <Paperclip size={24} />
           </Link>
         )
       }
@@ -136,7 +138,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
               className="flex w-full items-center justify-center p-0"
             >
               <span className="sr-only">Open menu</span>
-              <BsThreeDotsVertical className="h-4 w-4" />
+              <EllipsisVertical className="h-5 w-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="rounded-none text-sm">
@@ -145,7 +147,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
                 href={ROUTES.TEAM.EDIT(row.original.id).url}
                 className="flex h-full w-full items-center justify-center gap-x-2 px-6 py-2"
               >
-                <GoPencil />
+                <Pencil />
                 편집하기
               </Link>
             </DropdownMenuItem>
@@ -154,7 +156,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
                 href="#" // TODO: 삭제 로직 추가
                 className="flex h-full w-full items-center justify-center gap-x-2 px-6 py-2"
               >
-                <GoTrash />
+                <Trash />
                 삭제하기
               </Link>
             </DropdownMenuItem>

--- a/app/(general)/teams/_components/TeamListTable/data-table.tsx
+++ b/app/(general)/teams/_components/TeamListTable/data-table.tsx
@@ -11,10 +11,9 @@ import {
   SortingState,
   useReactTable
 } from "@tanstack/react-table"
+import { CirclePlus, Filter } from "lucide-react"
 import Link from "next/link"
 import { useReducer, useState } from "react"
-import { CiCirclePlus } from "react-icons/ci"
-import { TbFilter } from "react-icons/tb"
 
 import TeamListTableFilter, {
   FilterValue
@@ -295,7 +294,7 @@ export function TeamListDataTable<TValue>({
           {/* 생성 버튼 */}
           <Button asChild className="h-8 rounded-md py-1">
             <Link href={ROUTES.TEAM.CREATE.url}>
-              <CiCirclePlus size={22} />
+              <CirclePlus size={22} />
               &nbsp;Create
             </Link>
           </Button>
@@ -310,7 +309,7 @@ export function TeamListDataTable<TValue>({
                 variant={filterOpen ? "outline" : undefined}
               >
                 <div>
-                  <TbFilter size={22} />
+                  <Filter size={22} />
                   &nbsp;Filter
                 </div>
               </Button>

--- a/app/(general)/teams/create/_components/TeamCreateForm/FirstPage/YoutubeDialog.tsx
+++ b/app/(general)/teams/create/_components/TeamCreateForm/FirstPage/YoutubeDialog.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { Youtube } from "lucide-react"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
-import { FaYoutube } from "react-icons/fa"
 import { z } from "zod"
 
 import basicInfoSchema, {
@@ -64,7 +64,7 @@ const YoutubeDialog = ({ form, fieldName }: YoutubeDialog) => {
           onClick={() => setOpen(true)}
         >
           <div className="flex items-center justify-center gap-x-1">
-            <FaYoutube size={24} />
+            <Youtube size={24} />
             Youtube Embed
           </div>
         </Button>

--- a/app/(general)/teams/create/_components/TeamCreateForm/FirstPage/index.tsx
+++ b/app/(general)/teams/create/_components/TeamCreateForm/FirstPage/index.tsx
@@ -1,6 +1,6 @@
+import { CircleAlert } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
-import { AiFillExclamationCircle } from "react-icons/ai"
 import { z } from "zod"
 
 import Description from "@/app/(general)/teams/create/_components/TeamCreateForm/Description"
@@ -64,7 +64,7 @@ const FirstPage = ({
         <div>
           {/* 설명 */}
           <Description header="공연 및 곡 정보" className="mb-6">
-            <AiFillExclamationCircle />
+            <CircleAlert />
             <HoverCard>
               <HoverCardTrigger>
                 입력 시 주의사항을 확인해주세요
@@ -223,7 +223,7 @@ const FirstPage = ({
           >
             <div className="flex w-full items-center justify-between">
               <div className="flex items-center justify-between gap-x-2">
-                <AiFillExclamationCircle />
+                <CircleAlert />
                 자유롭게 팀을 홍보해주세요
               </div>
 

--- a/app/(general)/teams/create/_components/TeamCreateForm/Paginator.tsx
+++ b/app/(general)/teams/create/_components/TeamCreateForm/Paginator.tsx
@@ -1,5 +1,5 @@
+import { ArrowLeft, ArrowRight } from "lucide-react"
 import { GoDot, GoDotFill } from "react-icons/go"
-import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io"
 
 import { Button } from "@/components/ui/button"
 
@@ -36,7 +36,7 @@ const Paginator = ({
         onClick={onPrevious}
         type="button"
       >
-        <IoIosArrowBack className="me-3" />
+        <ArrowLeft className="me-3" />
         {previousButtonLabel ?? "Back"}
       </Button>
       <div className="flex items-center gap-x-3">
@@ -56,7 +56,7 @@ const Paginator = ({
         type="button"
       >
         {nextButtonLabel ?? "Next"}
-        <IoIosArrowForward className="ms-3" />
+        <ArrowRight className="ms-3" />
       </Button>
     </div>
   )

--- a/app/(general)/teams/create/_components/TeamCreateForm/SecondPage/index.tsx
+++ b/app/(general)/teams/create/_components/TeamCreateForm/SecondPage/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
+import { CircleAlert } from "lucide-react"
 import { useForm } from "react-hook-form"
-import { AiFillExclamationCircle } from "react-icons/ai"
 import { z } from "zod"
 
 import Description from "@/app/(general)/teams/create/_components/TeamCreateForm/Description"
@@ -41,7 +41,7 @@ const SecondPage = ({
         <div>
           {/* 설명 */}
           <Description header="세션 정보" className="mb-6">
-            <AiFillExclamationCircle />
+            <CircleAlert />
             곡에 필요한 모든 세션을 체크해주세요
           </Description>
 

--- a/app/(general)/teams/create/_components/TeamCreateForm/ThirdPage/index.tsx
+++ b/app/(general)/teams/create/_components/TeamCreateForm/ThirdPage/index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
 import { zodResolver } from "@hookform/resolvers/zod"
+import { CircleAlert } from "lucide-react"
 import { useSession } from "next-auth/react"
 import { useEffect, useState } from "react"
 import { FieldErrors, useForm } from "react-hook-form"
-import { AiFillExclamationCircle } from "react-icons/ai"
 import { z } from "zod"
 
 import Description from "@/app/(general)/teams/create/_components/TeamCreateForm/Description"
@@ -63,7 +63,7 @@ const ThirdPage = ({
     <Form {...form}>
       <form>
         <Description header="팀원 정보" className="mb-6">
-          <AiFillExclamationCircle />
+          <CircleAlert />
           이미 멤버가 확정된 세션의 경우, 해당 세션에 체크표시 후 멤버를
           선택해주세요
           <br />

--- a/components/Header/_component/Profile.tsx
+++ b/components/Header/_component/Profile.tsx
@@ -1,15 +1,10 @@
 "use client"
 
+import { LoaderCircle, LogOut, Moon, Settings, User, Users } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { signOut, useSession } from "next-auth/react"
 import React from "react"
-import { CgSpinner } from "react-icons/cg"
-import { CiSettings } from "react-icons/ci"
-import { HiOutlineUserGroup } from "react-icons/hi2"
-import { IoIosLogOut } from "react-icons/io"
-import { IoPersonOutline } from "react-icons/io5"
-import { MdOutlineDarkMode } from "react-icons/md"
 
 import {
   DropdownMenu,
@@ -60,7 +55,7 @@ function Profile() {
     return (
       <>
         {status === "loading" ? (
-          <CgSpinner className="animate-spin text-white" size={30} />
+          <LoaderCircle className="animate-spin text-white" size={30} />
         ) : (
           <div className="flex justify-center gap-x-5 font-bold text-white">
             <Link href={ROUTES.LOGIN.url}>로그인</Link>|
@@ -96,24 +91,24 @@ function Profile() {
 
         <DropdownMenuSeparator />
         <MenuItem
-          icon={<IoPersonOutline size={iconSize} />}
+          icon={<User size={iconSize} />}
           href={ROUTES.PROFILE.INDEX.url}
         >
           내 프로필
         </MenuItem>
-        <MenuItem icon={<HiOutlineUserGroup size={iconSize} />} href="#">
+        <MenuItem icon={<Users size={iconSize} />} href="#">
           참여 중인 팀
         </MenuItem>
 
         <DropdownMenuSeparator />
-        <MenuItem icon={<CiSettings size={iconSize} />} href="#">
+        <MenuItem icon={<Settings size={iconSize} />} href="#">
           설정
         </MenuItem>
         <DropdownMenuItem
           className="flex items-center justify-start gap-x-3 hover:cursor-pointer"
           onSelect={(e) => e.preventDefault()}
         >
-          <MdOutlineDarkMode size={iconSize} />
+          <Moon size={iconSize} />
           <Switch
             onCheckedChange={(v) => {
               localStorage.setItem("theme", v ? "dark" : "light")
@@ -128,7 +123,7 @@ function Profile() {
           onSelect={() => signOut()}
           className="flex h-full w-full items-center justify-start gap-x-3 p-2 hover:cursor-pointer"
         >
-          <IoIosLogOut size={iconSize} />
+          <LogOut size={iconSize} />
           로그아웃
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/components/Header/_component/Sidebar/SheetInnerContent.tsx
+++ b/components/Header/_component/Sidebar/SheetInnerContent.tsx
@@ -1,7 +1,13 @@
-import { FileText, ImageIcon, LogIn, Megaphone, Music4 } from "lucide-react"
+import {
+  FileText,
+  ImageIcon,
+  Instagram,
+  LogIn,
+  Megaphone,
+  Music4,
+  Youtube
+} from "lucide-react"
 import Link from "next/link"
-import { FaInstagram } from "react-icons/fa"
-import { RiYoutubeLine } from "react-icons/ri"
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Separator } from "@/components/ui/separator"
@@ -67,11 +73,11 @@ const SheetInnerContent = () => {
           LINKS
         </div>
         <div className="flex h-[41.4%] w-full items-center text-gray-500">
-          <RiYoutubeLine size={30} className={iconcolor} />
+          <Youtube size={30} className={iconcolor} />
           <div className="pl-4 text-lg font-medium text-gray-500">YouTube</div>
         </div>
         <div className="flex h-[41.4%] w-full items-center text-gray-500">
-          <FaInstagram size={30} className={iconcolor} />
+          <Instagram size={30} className={iconcolor} />
           <div className="pl-4 text-lg font-medium text-gray-500">
             Instagram
           </div>

--- a/components/Header/_component/Sidebar/index.tsx
+++ b/components/Header/_component/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { RxHamburgerMenu } from "react-icons/rx"
+import { Menu } from "lucide-react"
 
 import {
   Sheet,
@@ -11,7 +11,7 @@ const Sidebar = () => {
   return (
     <Sheet>
       <SheetTrigger>
-        <RxHamburgerMenu className="h-9 w-9 text-white" />
+        <Menu className="h-9 w-9 text-white" />
       </SheetTrigger>
       <SheetContent>
         <SheetInnerContent />


### PR DESCRIPTION
close #85 

npm uninstall하여 react 아이콘 모듈을 지웠더니 페이지 별로 들어가봐야 오류가 뜨고, react 아이콘이 그 페이지에 있다는 걸 알 수 있어서 그냥 검색에 from "react-icons 라고 쳐서 진행했습니다!
아래와 같이 아이콘들을 변경했습니다. 디테일한 디자인들은 페이지 별로 Issue와 Branch를 만들어서 작업하겠습니다.

1. 팀 목록 페이지 아이콘
![image](https://github.com/user-attachments/assets/9a31b4a8-be7f-4dcc-b115-6032dc410285)

2. 팀 생성 페이지 아이콘
![image](https://github.com/user-attachments/assets/d7a58319-8cc0-4c04-9295-b9dba73dc91f)
![image](https://github.com/user-attachments/assets/231d99ff-49d2-434a-bdb0-c707adf5af61)


3. 모바일 사이드바 아이콘
![image](https://github.com/user-attachments/assets/27179e32-9203-4578-831b-627482158693)
![image](https://github.com/user-attachments/assets/653edcba-7315-42e9-8e9d-363778de5e2f)

4. PC 네비게이션바 아이콘
![image](https://github.com/user-attachments/assets/f05e8ce8-0a15-4b71-8b80-ad20a5e57a2f)

ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ
![image](https://github.com/user-attachments/assets/9b9688a8-1dab-4751-8d4f-9312227d39f4)

아직 react - icon이 좀 남아있는데, 디자인이 아직 없는 performances 페이지이거나 lucides 아이콘에서 찾을 수 없는 요소들입니다. 

