### PR TITLE
Generation 모델 관계성 선언 및 API 구현 

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { GenerationModule } from './generation/generation.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AuthModule } from './auth/auth.module';
     PrismaModule,
     UsersModule,
     AuthModule,
+    GenerationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -7,7 +7,6 @@ import {
   UseGuards,
   Req,
   Res,
-  Get,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AccessTokenGuard } from './guards/access-token.guard';
@@ -31,6 +30,7 @@ export class AuthController {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'none',
       maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+      path: '/',
     });
 
     const { refreshToken, ...response } = result;
@@ -50,6 +50,7 @@ export class AuthController {
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'none',
         maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+        path: '/',
       });
     }
 
@@ -57,18 +58,18 @@ export class AuthController {
     return response;
   }
 
-  @UseGuards(AccessTokenGuard)
   @Post('logout')
+  @UseGuards(AccessTokenGuard)
   @HttpCode(HttpStatus.OK)
   async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const { sub: userId } = req.user as { sub: number };
     await this.authService.logout(userId);
-    res.clearCookie('refresh_token');
+    res.clearCookie('refresh_token', { path: '/' });
     return { message: '성공적으로 로그아웃되었습니다.' };
   }
 
-  @UseGuards(RefreshTokenGuard)
   @Post('refresh')
+  @UseGuards(RefreshTokenGuard)
   @HttpCode(HttpStatus.OK)
   async refreshTokens(
     @Req() req: Request,
@@ -84,6 +85,7 @@ export class AuthController {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'none',
       maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+      path: '/',
     });
 
     return {

--- a/apps/api/src/auth/decorators/public.decorator.ts
+++ b/apps/api/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/auth/guards/access-token.guard.ts
+++ b/apps/api/src/auth/guards/access-token.guard.ts
@@ -1,5 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class AccessTokenGuard extends AuthGuard('jwt-access') {}
+export class AccessTokenGuard extends AuthGuard('jwt-access') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    // 1. Reflector를 사용해 'isPublic' 메타데이터를 확인
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // 2. 'isPublic'이 true이면, 즉시 접근을 허용
+    if (isPublic) {
+      return true;
+    }
+
+    // 3. 'isPublic'이 아니면, 원래의 JWT 인증 로직을 실행
+    return super.canActivate(context);
+  }
+}

--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -1,0 +1,21 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { JwtPayload } from 'shared-types';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as JwtPayload;
+
+    if (user && user.isAdmin) {
+      return true;
+    }
+
+    throw new ForbiddenException('관리자 권한이 필요합니다.');
+  }
+}

--- a/apps/api/src/auth/strategies/access-token.strategy.ts
+++ b/apps/api/src/auth/strategies/access-token.strategy.ts
@@ -2,14 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-
-type JwtPayload = {
-  sub: number;
-  email: string;
-  name: string;
-  iat?: number; // issued at
-  exp?: number; // expiration time
-};
+import { JwtPayload } from 'shared-types'; // Adjust the import path as necessary
 
 @Injectable()
 export class AccessTokenStrategy extends PassportStrategy(

--- a/apps/api/src/auth/strategies/refresh-token.strategy.ts
+++ b/apps/api/src/auth/strategies/refresh-token.strategy.ts
@@ -3,14 +3,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-
-type JwtPayload = {
-  sub: number;
-  email: string;
-  name: string;
-  iat?: number; // issued at
-  exp?: number; // expiration time
-};
+import { JwtPayload } from 'shared-types';
 
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(

--- a/apps/api/src/generation/generation.controller.spec.ts
+++ b/apps/api/src/generation/generation.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenerationController } from './generation.controller';
+import { GenerationService } from './generation.service';
+
+describe('GenerationController', () => {
+  let controller: GenerationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GenerationController],
+      providers: [GenerationService],
+    }).compile();
+
+    controller = module.get<GenerationController>(GenerationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/generation/generation.controller.ts
+++ b/apps/api/src/generation/generation.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
+import { GenerationService } from './generation.service';
+import { CreateGenerationDto, UpdateGenerationDto } from 'shared-types';
+import { AccessTokenGuard } from '../auth/guards/access-token.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { Public } from '../auth/decorators/public.decorator';
+
+@Controller('generation')
+@UseGuards(AccessTokenGuard)
+export class GenerationController {
+  constructor(private readonly generationService: GenerationService) {}
+
+  @Post()
+  @UseGuards(AdminGuard)
+  create(@Body() createGenerationDto: CreateGenerationDto) {
+    return this.generationService.create(createGenerationDto);
+  }
+
+  @Get()
+  @Public()
+  findAll() {
+    return this.generationService.findAll();
+  }
+
+  @Get(':id')
+  @Public()
+  findOne(@Param('id') id: number) {
+    return this.generationService.findOne(id);
+  }
+
+  @Patch(':id')
+  @UseGuards(AdminGuard)
+  update(
+    @Param('id') id: number,
+    @Body() updateGenerationDto: UpdateGenerationDto,
+  ) {
+    return this.generationService.update(id, updateGenerationDto);
+  }
+
+  @Delete(':id')
+  @UseGuards(AdminGuard)
+  remove(@Param('id') id: number) {
+    return this.generationService.remove(id);
+  }
+}

--- a/apps/api/src/generation/generation.module.ts
+++ b/apps/api/src/generation/generation.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GenerationService } from './generation.service';
+import { GenerationController } from './generation.controller';
+
+@Module({
+  controllers: [GenerationController],
+  providers: [GenerationService],
+})
+export class GenerationModule {}

--- a/apps/api/src/generation/generation.service.spec.ts
+++ b/apps/api/src/generation/generation.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenerationService } from './generation.service';
+
+describe('GenerationService', () => {
+  let service: GenerationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GenerationService],
+    }).compile();
+
+    service = module.get<GenerationService>(GenerationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/generation/generation.service.ts
+++ b/apps/api/src/generation/generation.service.ts
@@ -1,0 +1,123 @@
+import {
+  basicGeneration,
+  generationWithMinimalUsers,
+  generationWithBasicUsers,
+} from './../prisma/selectors/generation.selector';
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@repo/database';
+import { CreateGenerationDto, UpdateGenerationDto } from 'shared-types';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class GenerationService {
+  constructor(private readonly prisma: PrismaService) {}
+  async create(createGenerationDto: CreateGenerationDto) {
+    try {
+      const generation = await this.prisma.generation.create({
+        data: createGenerationDto,
+      });
+      return this.findOne(generation.id);
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+          const target = (error.meta?.target as string[]) || [];
+          if (target.includes('order')) {
+            throw new ConflictException(
+              `해당 기수(${createGenerationDto.order})는 이미 존재합니다.`,
+            );
+          }
+          if (target.includes('leaderId')) {
+            throw new ConflictException(
+              `해당 유저(ID: ${createGenerationDto.leaderId})는 이미 다른 기수의 리더입니다.`,
+            );
+          }
+        }
+        // RFC 7807 적용 시, throw error; 로 변경 필요
+        throw new InternalServerErrorException(
+          '기수 생성 중 서버 오류가 발생했습니다.',
+        );
+      }
+    }
+  }
+
+  async findAll() {
+    const generations = await this.prisma.generation.findMany({
+      select: generationWithMinimalUsers,
+      orderBy: {
+        order: 'desc',
+      },
+    });
+
+    return generations;
+  }
+
+  async findOne(id: number) {
+    const generation = await this.prisma.generation.findUnique({
+      where: { id },
+      select: generationWithBasicUsers,
+    });
+    if (!generation) {
+      throw new NotFoundException(
+        `ID ${id}에 해당하는 기수를 찾을 수 없습니다.`,
+      );
+    }
+    return generation;
+  }
+
+  async update(id: number, updateGenerationDto: UpdateGenerationDto) {
+    await this.findOne(id); // Ensure the generation exists before updating
+    try {
+      await this.prisma.generation.update({
+        where: { id },
+        data: updateGenerationDto,
+      });
+      return this.findOne(id);
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+          const target = (error.meta?.target as string[]) || [];
+          if (target.includes('order')) {
+            throw new ConflictException(
+              `해당 기수(${updateGenerationDto.order})는 이미 존재합니다.`,
+            );
+          }
+          if (target.includes('leaderId')) {
+            throw new ConflictException(
+              `해당 유저(ID: ${updateGenerationDto.leaderId})는 이미 다른 기수의 리더입니다.`,
+            );
+          }
+        }
+        // RFC 7807 적용 시, throw error; 로 변경 필요
+        throw new InternalServerErrorException(
+          '기수 업데이트 중 서버 오류가 발생했습니다.',
+        );
+      }
+    }
+  }
+  async remove(id: number) {
+    const generation = await this.findOne(id); // Ensure the generation exists before removing
+    try {
+      await this.prisma.generation.delete({
+        where: { id },
+      });
+      return generation;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2003') {
+          throw new ConflictException(
+            '해당 기수에 소속된 유저가 있어 삭제할 수 없습니다.',
+          );
+        }
+      }
+      // RFC 7807 적용 시, throw error; 로 변경 필요
+      throw new InternalServerErrorException(
+        '기수 삭제 중 서버 오류가 발생했습니다.',
+      );
+    }
+  }
+}

--- a/apps/api/src/generation/generation.service.ts
+++ b/apps/api/src/generation/generation.service.ts
@@ -1,7 +1,6 @@
 import {
-  basicGeneration,
-  generationWithMinimalUsers,
   generationWithBasicUsers,
+  generationWithPublicUsers,
 } from './../prisma/selectors/generation.selector';
 import {
   ConflictException,
@@ -11,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@repo/database';
 import { CreateGenerationDto, UpdateGenerationDto } from 'shared-types';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class GenerationService {
@@ -47,7 +46,7 @@ export class GenerationService {
 
   async findAll() {
     const generations = await this.prisma.generation.findMany({
-      select: generationWithMinimalUsers,
+      select: generationWithBasicUsers,
       orderBy: {
         order: 'desc',
       },
@@ -59,7 +58,7 @@ export class GenerationService {
   async findOne(id: number) {
     const generation = await this.prisma.generation.findUnique({
       where: { id },
-      select: generationWithBasicUsers,
+      select: generationWithPublicUsers,
     });
     if (!generation) {
       throw new NotFoundException(

--- a/apps/api/src/prisma/selectors/generation.selector.ts
+++ b/apps/api/src/prisma/selectors/generation.selector.ts
@@ -1,0 +1,27 @@
+import { Prisma } from '@repo/database';
+import { minimalUser, basicUser } from './user.selector';
+
+export const basicGeneration = {
+  id: true,
+  order: true,
+} satisfies Prisma.GenerationSelect;
+
+export const generationWithMinimalUsers = {
+  ...basicGeneration,
+  users: {
+    select: minimalUser,
+  },
+  leader: {
+    select: minimalUser,
+  },
+} satisfies Prisma.GenerationSelect;
+
+export const generationWithBasicUsers = {
+  ...basicGeneration,
+  users: {
+    select: basicUser,
+  },
+  leader: {
+    select: basicUser,
+  },
+} satisfies Prisma.GenerationSelect;

--- a/apps/api/src/prisma/selectors/generation.selector.ts
+++ b/apps/api/src/prisma/selectors/generation.selector.ts
@@ -1,21 +1,18 @@
 import { Prisma } from '@repo/database';
-import { minimalUser, basicUser } from './user.selector';
+import { basicUser, publicUser } from './user.selector';
 
+/**
+ * 기수의 최소 정보를 선택합니다. (id, order)
+ */
 export const basicGeneration = {
   id: true,
   order: true,
 } satisfies Prisma.GenerationSelect;
 
-export const generationWithMinimalUsers = {
-  ...basicGeneration,
-  users: {
-    select: minimalUser,
-  },
-  leader: {
-    select: minimalUser,
-  },
-} satisfies Prisma.GenerationSelect;
-
+/**
+ * 기수 정보와 함께 소속된 유저들의 최소 정보(basicUser)를 선택합니다.
+ * 주로 기수 목록 조회에 사용됩니다.
+ */
 export const generationWithBasicUsers = {
   ...basicGeneration,
   users: {
@@ -23,5 +20,19 @@ export const generationWithBasicUsers = {
   },
   leader: {
     select: basicUser,
+  },
+} satisfies Prisma.GenerationSelect;
+
+/**
+ * 기수 정보와 함께 소속된 유저들의 공개 정보(publicUser)를 선택합니다.
+ * 주로 `GET /generations/:id`와 같이 특정 기수를 조회하는 API 응답에서 사용됩니다.
+ */
+export const generationWithPublicUsers = {
+  ...basicGeneration,
+  users: {
+    select: publicUser,
+  },
+  leader: {
+    select: publicUser,
   },
 } satisfies Prisma.GenerationSelect;

--- a/apps/api/src/prisma/selectors/user.selector.ts
+++ b/apps/api/src/prisma/selectors/user.selector.ts
@@ -1,23 +1,29 @@
 import { Prisma } from '@repo/database';
 import { basicGeneration } from './generation.selector';
 
-export const minimalUser = {
+/**
+ * 유저의 최소 정보(id, 이름, 닉네임)를 선택합니다.
+ * 해당 select는 주로 목록 조회에 사용됩니다.
+ */
+export const basicUser = {
   id: true,
   name: true,
   nickname: true,
 } satisfies Prisma.UserSelect;
 
-export const basicUser = {
-  ...minimalUser,
-  name: true,
-} satisfies Prisma.UserSelect;
-
+/**
+ * 외부에 공개 가능한 유저 정보를 선택합니다.
+ * 주로 `GET /users/:id`와 같이 특정 유저를 조회하는 API 응답에서 사용됩니다.
+ */
 export const publicUser = {
   ...basicUser,
   bio: true,
   image: true,
 } satisfies Prisma.UserSelect;
 
+/**
+ * 민감한 정보를 포함한 유저의 모든 정보를 선택합니다. (주로 관리자용)
+ */
 export const privateUser = {
   ...publicUser,
   isAdmin: true,
@@ -25,6 +31,9 @@ export const privateUser = {
   updatedAt: true,
 } satisfies Prisma.UserSelect;
 
+/**
+ * 유저의 공개 정보와 함께 소속된 기수의 기본 정보를 선택합니다.
+ */
 export const userWithGeneration = {
   ...publicUser,
   generation: {

--- a/apps/api/src/prisma/selectors/user.selector.ts
+++ b/apps/api/src/prisma/selectors/user.selector.ts
@@ -1,0 +1,33 @@
+import { Prisma } from '@repo/database';
+import { basicGeneration } from './generation.selector';
+
+export const minimalUser = {
+  id: true,
+  name: true,
+  nickname: true,
+} satisfies Prisma.UserSelect;
+
+export const basicUser = {
+  ...minimalUser,
+  name: true,
+} satisfies Prisma.UserSelect;
+
+export const publicUser = {
+  ...basicUser,
+  bio: true,
+  image: true,
+} satisfies Prisma.UserSelect;
+
+export const privateUser = {
+  ...publicUser,
+  isAdmin: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.UserSelect;
+
+export const userWithGeneration = {
+  ...publicUser,
+  generation: {
+    select: basicGeneration,
+  },
+} satisfies Prisma.UserSelect;

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -10,7 +10,7 @@ import { Prisma } from '@repo/database';
 
 @Injectable()
 export class UsersService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async create(createUserDto: CreateUserDto) {
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);

--- a/packages/database/prisma/migrations/20250712095520_implement_generation_model/migration.sql
+++ b/packages/database/prisma/migrations/20250712095520_implement_generation_model/migration.sql
@@ -1,0 +1,37 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isActive` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `isStaff` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `isSuperuser` on the `users` table. All the data in the column will be lost.
+  - Added the required column `generationId` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "isActive",
+DROP COLUMN "isStaff",
+DROP COLUMN "isSuperuser",
+ADD COLUMN     "generationId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "generations" (
+    "id" SERIAL NOT NULL,
+    "order" DECIMAL(3,1) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "leaderId" INTEGER,
+
+    CONSTRAINT "generations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "generations_order_key" ON "generations"("order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "generations_leaderId_key" ON "generations"("leaderId");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_generationId_fkey" FOREIGN KEY ("generationId") REFERENCES "generations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "generations" ADD CONSTRAINT "generations_leaderId_fkey" FOREIGN KEY ("leaderId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -16,13 +16,28 @@ model User {
   nickname        String    @unique
   bio             String?
   image           String?
-  isActive        Boolean   @default(true) 
   isAdmin         Boolean   @default(false) 
-  isSuperuser     Boolean   @default(false) 
-  isStaff         Boolean   @default(false) 
   hashedRefreshToken    String?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
+  generationId   Int
+  generation     Generation @relation(fields: [generationId], references: [id], onDelete: Restrict)
+
+  ledGeneration        Generation? @relation("GenerationLeader")
   @@map("users")
+}
+
+model Generation {
+  id              Int       @id @default(autoincrement())
+  order           Decimal   @db.Decimal(3, 1) @unique
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  leader    User?     @relation("GenerationLeader", fields: [leaderId], references: [id], onDelete: SetNull)
+  leaderId  Int?      @unique
+
+  users         User[]
+
+  @@map("generations")
 }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -24,7 +24,7 @@ model User {
   generationId   Int
   generation     Generation @relation(fields: [generationId], references: [id], onDelete: Restrict)
 
-  ledGeneration        Generation? @relation("GenerationLeader")
+  ledGeneration        Generation? @relation("generationLeader")
   @@map("users")
 }
 
@@ -34,7 +34,7 @@ model Generation {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
-  leader    User?     @relation("GenerationLeader", fields: [leaderId], references: [id], onDelete: SetNull)
+  leader    User?     @relation("generationLeader", fields: [leaderId], references: [id], onDelete: SetNull)
   leaderId  Int?      @unique
 
   users         User[]

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
+    "@nestjs/mapped-types": "^2.1.0",
     "class-validator": "^0.14.2"
   }
 }

--- a/packages/shared-types/src/auth/jwt.types.ts
+++ b/packages/shared-types/src/auth/jwt.types.ts
@@ -1,0 +1,8 @@
+export interface JwtPayload {
+  sub: number;
+  email: string;
+  name: string;
+  isAdmin: boolean;
+  iat?: number; // issued at
+  exp?: number; // expiration time
+}

--- a/packages/shared-types/src/decorators/is-in-half-steps.decorator.ts
+++ b/packages/shared-types/src/decorators/is-in-half-steps.decorator.ts
@@ -1,0 +1,27 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from "class-validator";
+
+export function IsInHalfSteps(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: "IsInHalfSteps",
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          return typeof value === "number" && value % 0.5 === 0; // you can return a Promise<boolean> here as well, if you want to make async validation
+        },
+        defaultMessage(args: ValidationArguments) {
+          return (
+            args.constraints?.[0] ||
+            `${args.property} must be in half-step increments (e.g., 0.5, 1, 1.5)`
+          );
+        },
+      },
+    });
+  };
+}

--- a/packages/shared-types/src/generation/create-generation.dto.ts
+++ b/packages/shared-types/src/generation/create-generation.dto.ts
@@ -1,0 +1,12 @@
+import { IsNumber, IsOptional } from "class-validator";
+import { IsInHalfSteps } from "../decorators/is-in-half-steps.decorator";
+
+export class CreateGenerationDto {
+  @IsNumber({}, { message: "기수는 숫자여야 합니다." })
+  @IsInHalfSteps({ message: "기수는 0.5 단위여야 합니다." })
+  order!: number;
+
+  @IsOptional()
+  @IsNumber({}, { message: "리더 ID는 숫자여야 합니다." })
+  leaderId?: number;
+}

--- a/packages/shared-types/src/generation/update-generation.dto.ts
+++ b/packages/shared-types/src/generation/update-generation.dto.ts
@@ -1,0 +1,4 @@
+import { CreateGenerationDto } from "./create-generation.dto";
+import { PartialType } from "@nestjs/mapped-types";
+
+export class UpdateGenerationDto extends PartialType(CreateGenerationDto) {}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -6,4 +6,7 @@ export * from "./Team";
 export * from "./User";
 export * from "./user/create-user.dto";
 export * from "./user/login-user.dto";
+export * from "./auth/jwt.types";
 export * from "./constants/regex";
+export * from "./generation/create-generation.dto";
+export * from "./generation/update-generation.dto";

--- a/packages/shared-types/src/user/create-user.dto.ts
+++ b/packages/shared-types/src/user/create-user.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsNotEmpty, Matches, MinLength } from "class-validator";
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsNumber,
+  Matches,
+  MinLength,
+} from "class-validator";
 import { PASSWORD_REGEX } from "../constants/regex";
 /**
  * @description 유저 생성을 위한 순수 데이터 타입 (프론트엔드용)
@@ -8,17 +14,16 @@ export type CreateUser = {
   password: string;
   name: string;
   nickname: string;
+  generationId: number;
 };
 
 /**
  * @description 유저 생성을 위한 DTO 클래스 (백엔드 유효성 검사용)
  */
 export class CreateUserDto implements CreateUser {
-  @IsEmail(undefined, { message: "유효한 이메일 주소를 입력해주세요." })
-  @IsNotEmpty({ message: "이메일은 비워둘 수 없습니다." })
+  @IsEmail({}, { message: "유효한 이메일 주소를 입력해주세요." })
   email!: string;
 
-  @IsNotEmpty({ message: "비밀번호는 비워둘 수 없습니다." })
   @MinLength(8, { message: "비밀번호는 최소 8자 이상이어야 합니다." })
   @Matches(PASSWORD_REGEX, {
     message: "비밀번호는 영문, 숫자를 모두 포함해야 합니다.",
@@ -30,4 +35,7 @@ export class CreateUserDto implements CreateUser {
 
   @IsNotEmpty({ message: "닉네임은 비워둘 수 없습니다." })
   nickname!: string;
+
+  @IsNumber({}, { message: "기수 ID는 숫자여야 합니다." })
+  generationId!: number;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
 
   packages/shared-types:
     dependencies:
+      '@nestjs/mapped-types':
+        specifier: ^2.1.0
+        version: 2.1.0(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
@@ -1372,6 +1375,19 @@ packages:
     resolution: {integrity: sha512-v7YRsW3Xi8HNTsO+jeHSEEqelX37TVWgwt+BcxtkG/OfXJEOs6GZdbdza200d6KqId1pJQZ6UPj1F0M6E+mxaA==}
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
+  '@nestjs/mapped-types@2.1.0':
+    resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/passport@11.0.5':
     resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
@@ -7618,6 +7634,14 @@ snapshots:
       '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@types/jsonwebtoken': 9.0.7
       jsonwebtoken: 9.0.2
+
+  '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
   '@nestjs/passport@11.0.5(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
     dependencies:


### PR DESCRIPTION
### Description
Prisma 내에 Generation 모델을 선언하고 관련 API를 구현하였습니다.

- JWT에서 사용되는 Payload를 관리하기 위해 별도의 interface 파일로 분리하였습니다.
- 로그인 없이도 특정 API 요청이 가능하도록 @Public() 데코레이터를 추가하였습니다.
- API 요청 시, 데이터의 반환 정도를 미리 정의하기 위해 selector 파일을 만들었습니다.
- 특정 숫자가 0.5로 나누어 떨어지는 확인하기 위해 커스텀 데코레이터(@IsInHalfSteps())를 추가했습니다.


https://github.com/skku-amang/main/blob/886788e2f93245b41aa820ccc902d06e63d8d209/packages/shared-types/src/auth/jwt.types.ts#L1-L8
**JwtPayload**는 JWT 내부에 들어가는 **Payload**의 **interface** 입니다. 해당 interface를 import해 JWT를 생성 혹은 참조할 때 사용합니다.

https://github.com/skku-amang/main/blob/886788e2f93245b41aa820ccc902d06e63d8d209/apps/api/src/auth/guards/access-token.guard.ts#L7-L27
**isPublic** 데코레이터를 추가하였습니다. **AccessTokenGuard**는 **isPublic**가 적용되어 있는 API에 대해서는 **accessToken 인증**을 하지 않고 인증을 허가해줍니다.
추후, **Role** 기반 인증도 염두에 두고 있습니다.

https://github.com/skku-amang/main/blob/886788e2f93245b41aa820ccc902d06e63d8d209/apps/api/src/prisma/selectors/user.selector.ts#L1-L33
https://github.com/skku-amang/main/blob/886788e2f93245b41aa820ccc902d06e63d8d209/apps/api/src/prisma/selectors/generation.selector.ts#L1-L27
API 응답 시, 정보 반환 정도를 미리 정의하기 위해 **selector** 파일을 만들어 사용하였습니다. **selector** 파일을 사용할 경우 데이터 반환 정도가 미리 결정되어 최소한의 정보 반환을 보장하며, 사용자의 중요 데이터가 유출되는 것을 막아줍니다.

https://github.com/skku-amang/main/blob/886788e2f93245b41aa820ccc902d06e63d8d209/packages/shared-types/src/decorators/is-in-half-steps.decorator.ts#L7-L27
class-validator내에 특정 number가 0.5의 배수인지 확인하는 데코레이터가 없어 하나 커스텀 데코레이터를 추가하였습니다.

검사하고자 하는 속성에 다음과 같이 추가하면 사용할 수 있습니다.
_@IsInHalfSteps({ message: "기수는 0.5 단위여야 합니다." })_  

close #161