### PR TITLE
SearchBar 컴포넌트 제작

### DIFF
--- a/apps/web/app/test/_components/SearchBar.tsx
+++ b/apps/web/app/test/_components/SearchBar.tsx
@@ -1,0 +1,25 @@
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import { Search } from "lucide-react"
+
+interface SearchBarProps {
+  className?: string
+}
+
+export default function SearchBar({ className }: SearchBarProps) {
+  return (
+    <div className="relative">
+      <Input
+        placeholder="검색"
+        className={cn(
+          "w-80 h-10 placeholder:opacity-100 focus:placeholder:opacity-0 hover:cursor-pointer placeholder:transition-opacity placeholder:duration-500 focus-visible:ring-0 text-neutral-400 text-base font-normal leading-normal py-2 pl-[50px] hover:shadow-[0px_0px_0px_1px_rgba(104,113,130,0.36)] shadow-[0px_1px_2px_0px_rgba(64,63,84,0.10)] pr-[13px] rounded-[20px] border-gray-200 border-[1px]",
+          className
+        )}
+      />
+      <Search
+        className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 stroke-1 font-light"
+        size={24}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/test/page.tsx
+++ b/apps/web/app/test/page.tsx
@@ -1,0 +1,14 @@
+import SearchBar from "./_components/SearchBar"
+
+// apps/web/app/test/page.tsx
+export default function TestPage() {
+  return (
+    <div className="p-10">
+      <h1 className="text-2xl pb-7 font-bold">UI 테스트 페이지</h1>
+
+      {/* SearchBar */}
+      <h2># SearchBar</h2>
+      <SearchBar />
+    </div>
+  )
+}


### PR DESCRIPTION
close #170 

 디자인된 SearchBar 컴포넌트를 제작하였습니다.

<img width="457" height="241" alt="image" src="https://github.com/user-attachments/assets/631b26b5-ecec-412d-abd5-f33fa99a13db" />


- 공연 목록 페이지에 직접 접근할 수가 없어서, 별도로 /test/page.tsx 를 만들어서 디자이너(수연이)가 확인할 수 있도록 했습니다.
- apps/web/app/api/auth/[...nextauth]/route.ts를 일단 route.ts.disabled 이런 식으로 바꿔 놓고 제작을 한 뒤에 제작한 컴포넌트만 코밋하는 식으로 작업했습니다.
- 일단 이렇게 test 페이지 안에 컴포넌트를 모아놓고 백앤드 작업이 완료되면 맞는 위치에 적용시킬 생각이었는데 어떨까요?








