### PR TITLE
feat: add session model with api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,16 +27,14 @@
     "@nestjs/platform-express": "^11.0.1",
     "@repo/api-client": "workspace:*",
     "@repo/database": "workspace:*",
+    "@repo/shared-types": "workspace:*",
     "bcrypt": "^6.0.0",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
     "nestjs-zod": "^4.3.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
-    "@repo/shared-types": "workspace:*"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from "./prisma/prisma.module"
 import { UsersModule } from "./users/users.module"
 import { AuthModule } from "./auth/auth.module"
 import { GenerationModule } from "./generation/generation.module"
+import { SessionModule } from "./session/session.module"
 
 @Module({
   imports: [
@@ -16,7 +17,8 @@ import { GenerationModule } from "./generation/generation.module"
     PrismaModule,
     UsersModule,
     AuthModule,
-    GenerationModule
+    GenerationModule,
+    SessionModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/apps/api/src/prisma/selectors/session.selector.ts
+++ b/apps/api/src/prisma/selectors/session.selector.ts
@@ -1,0 +1,39 @@
+import { Prisma } from "@repo/database"
+import { basicUser, publicUser } from "./user.selector"
+
+/**
+ * 세션의 최소 정보를 선택합니다. (id, name, icon)
+ */
+export const basicSession = {
+  id: true,
+  name: true,
+  icon: true
+} satisfies Prisma.SessionSelect
+
+/**
+ * 세션 정보와 함께 소속된 유저들의 최소 정보(basicUser)를 선택합니다.
+ * 주로 세션 목록 조회에 사용됩니다.
+ */
+export const sessionWithBasicUsers = {
+  ...basicSession,
+  users: {
+    select: basicUser
+  },
+  leader: {
+    select: basicUser
+  }
+} satisfies Prisma.SessionSelect
+
+/**
+ * 세션 정보와 함께 소속된 유저들의 공개 정보(publicUser)를 선택합니다.
+ * 주로 `GET /sessions/:id`와 같이 특정 세션을 조회하는 API 응답에서 사용됩니다.
+ */
+export const sessionWithPublicUsers = {
+  ...basicSession,
+  users: {
+    select: publicUser
+  },
+  leader: {
+    select: publicUser
+  }
+} satisfies Prisma.SessionSelect

--- a/apps/api/src/session/session.controller.spec.ts
+++ b/apps/api/src/session/session.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { SessionController } from "./session.controller"
+import { SessionService } from "./session.service"
+
+describe("SessionController", () => {
+  let controller: SessionController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SessionController],
+      providers: [SessionService]
+    }).compile()
+
+    controller = module.get<SessionController>(SessionController)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+})

--- a/apps/api/src/session/session.controller.spec.ts
+++ b/apps/api/src/session/session.controller.spec.ts
@@ -8,7 +8,18 @@ describe("SessionController", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SessionController],
-      providers: [SessionService]
+      providers: [
+        {
+          provide: SessionService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn()
+          }
+        }
+      ]
     }).compile()
 
     controller = module.get<SessionController>(SessionController)

--- a/apps/api/src/session/session.controller.ts
+++ b/apps/api/src/session/session.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseIntPipe,
+  UseGuards
+} from "@nestjs/common"
+import { SessionService } from "./session.service"
+import { CreateSessionDto, UpdateSessionDto } from "@repo/shared-types"
+import { AccessTokenGuard } from "../auth/guards/access-token.guard"
+import { AdminGuard } from "../auth/guards/admin.guard"
+import { Public } from "../auth/decorators/public.decorator"
+
+@Controller("session")
+@UseGuards(AccessTokenGuard)
+export class SessionController {
+  constructor(private readonly sessionService: SessionService) {}
+
+  @Post()
+  @UseGuards(AdminGuard)
+  create(@Body() createSessionDto: CreateSessionDto) {
+    return this.sessionService.create(createSessionDto)
+  }
+
+  @Get()
+  @Public()
+  findAll() {
+    return this.sessionService.findAll()
+  }
+
+  @Get(":id")
+  @Public()
+  findOne(@Param("id", ParseIntPipe) id: number) {
+    return this.sessionService.findOne(id)
+  }
+
+  @Patch(":id")
+  @UseGuards(AdminGuard)
+  update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() updateSessionDto: UpdateSessionDto
+  ) {
+    return this.sessionService.update(id, updateSessionDto)
+  }
+
+  @Delete(":id")
+  @UseGuards(AdminGuard)
+  remove(@Param("id", ParseIntPipe) id: number) {
+    return this.sessionService.remove(id)
+  }
+}

--- a/apps/api/src/session/session.module.ts
+++ b/apps/api/src/session/session.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common"
+import { SessionService } from "./session.service"
+import { SessionController } from "./session.controller"
+
+@Module({
+  controllers: [SessionController],
+  providers: [SessionService]
+})
+export class SessionModule {}

--- a/apps/api/src/session/session.service.spec.ts
+++ b/apps/api/src/session/session.service.spec.ts
@@ -1,12 +1,27 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { SessionService } from "./session.service"
+import { PrismaService } from "../prisma/prisma.service"
 
 describe("SessionService", () => {
   let service: SessionService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SessionService]
+      providers: [
+        SessionService,
+        {
+          provide: PrismaService,
+          useValue: {
+            session: {
+              create: jest.fn(),
+              findMany: jest.fn(),
+              findUnique: jest.fn(),
+              update: jest.fn(),
+              delete: jest.fn()
+            }
+          }
+        }
+      ]
     }).compile()
 
     service = module.get<SessionService>(SessionService)

--- a/apps/api/src/session/session.service.spec.ts
+++ b/apps/api/src/session/session.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { SessionService } from "./session.service"
+
+describe("SessionService", () => {
+  let service: SessionService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SessionService]
+    }).compile()
+
+    service = module.get<SessionService>(SessionService)
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -1,0 +1,143 @@
+import { Injectable } from "@nestjs/common"
+import { CreateSessionDto, UpdateSessionDto } from "@repo/shared-types"
+import { PrismaService } from "../prisma/prisma.service"
+import {
+  NotFoundError,
+  ConflictError,
+  InternalServerError
+} from "@repo/api-client"
+import { Prisma } from "@repo/database"
+import {
+  sessionWithBasicUsers,
+  sessionWithPublicUsers
+} from "../prisma/selectors/session.selector"
+
+@Injectable()
+export class SessionService {
+  constructor(private readonly prisma: PrismaService) {}
+  async create(createSessionDto: CreateSessionDto) {
+    try {
+      const session = await this.prisma.session.create({
+        data: createSessionDto
+      })
+      return this.findOne(session.id)
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        switch (error.code) {
+          case "P2002":
+            // P2002: Unique constraint failed
+            const target = (error.meta?.target as string[]) || []
+            if (target.includes("name")) {
+              throw new ConflictError(
+                `세션 이름(${createSessionDto.name})은 이미 존재합니다.`
+              )
+            }
+            if (target.includes("leaderId")) {
+              throw new ConflictError(
+                `해당 유저(ID: ${createSessionDto.leaderId})는 이미 다른 세션의 리더입니다.`
+              )
+            }
+            break
+          case "P2025":
+            // P2025: An operation failed because it depends on one or more records that were required but not found.
+            throw new NotFoundError("리더 ID가 유효하지 않습니다.")
+        }
+      }
+      // RFC 7807 적용 시, throw error; 로 변경 필요
+      throw new InternalServerError("세션 생성 중 서버 오류가 발생했습니다.")
+    }
+  }
+
+  findAll() {
+    return this.prisma.session.findMany({
+      select: sessionWithBasicUsers,
+      orderBy: {
+        name: "asc"
+      }
+    })
+  }
+
+  async findOne(id: number) {
+    const session = await this.prisma.session.findUnique({
+      where: { id },
+      select: sessionWithPublicUsers
+    })
+    if (!session) {
+      throw new NotFoundError(`${id}에 해당하는 세션을 찾을 수 없습니다.`)
+    }
+    return session
+  }
+
+  async update(id: number, updateSessionDto: UpdateSessionDto) {
+    await this.findOne(id) // 존재 여부 확인
+    try {
+      // DTO에서 관계성 필드와 관련 없는 필드 분리
+      const { leaderId, users, ...scalarData } = updateSessionDto
+      const updatePayload: Prisma.SessionUpdateInput = {
+        ...scalarData
+      }
+
+      // leaderId가 존재하는 경우 관계성 필드 업데이트
+      if (leaderId !== undefined) {
+        updatePayload.leader =
+          leaderId === null
+            ? { disconnect: true }
+            : { connect: { id: leaderId } }
+      }
+
+      // users가 존재하는 경우 관계성 필드 업데이트
+      if (users !== undefined) {
+        updatePayload.users = {
+          set: users.map((userId) => ({ id: userId }))
+        }
+      }
+
+      await this.prisma.session.update({
+        where: { id },
+        data: updatePayload
+      })
+      return this.findOne(id)
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // P2002: Unique constraint failed
+        switch (error.code) {
+          case "P2002":
+            const target = (error.meta?.target as string[]) || []
+            if (target.includes("name")) {
+              throw new ConflictError(
+                `세션 이름(${updateSessionDto.name})은 이미 존재합니다.`
+              )
+            }
+            if (target.includes("leaderId")) {
+              throw new ConflictError(
+                `해당 유저(ID: ${updateSessionDto.leaderId})는 이미 다른 세션의 리더입니다.`
+              )
+            }
+            break
+          case "P2025":
+            // P2025: An operation failed because it depends on one or more records that were required but not found.
+            throw new NotFoundError(
+              "리더 ID 혹은 사용자 ID가 유효하지 않습니다."
+            )
+        }
+      }
+      // RFC 7807 적용 시, throw error; 로 변경 필요
+      throw new InternalServerError(
+        "세션 업데이트 중 서버 오류가 발생했습니다."
+      )
+    }
+  }
+
+  async remove(id: number) {
+    try {
+      const sesssion = await this.findOne(id) // 존재 여부 확인
+      await this.prisma.session.delete({
+        where: { id }
+      })
+      return sesssion
+    } catch (error) {
+      if (error instanceof NotFoundError) throw error // 이미 존재하지 않는 세션에 대한 삭제 요청
+      throw new InternalServerError("세션 삭제 중 서버 오류가 발생했습니다.")
+    }
+  }
+}

--- a/packages/database/prisma/migrations/20250725075004_add_session_model/migration.sql
+++ b/packages/database/prisma/migrations/20250725075004_add_session_model/migration.sql
@@ -1,0 +1,40 @@
+-- CreateEnum
+CREATE TYPE "SessionName" AS ENUM ('VOCAL', 'GUITAR', 'BASS', 'SYNTH', 'DRUM', 'STRINGS', 'WINDS');
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" SERIAL NOT NULL,
+    "name" "SessionName" NOT NULL,
+    "icon" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "leaderId" INTEGER,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_SessionToUser" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_SessionToUser_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_name_key" ON "sessions"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_leaderId_key" ON "sessions"("leaderId");
+
+-- CreateIndex
+CREATE INDEX "_SessionToUser_B_index" ON "_SessionToUser"("B");
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_leaderId_fkey" FOREIGN KEY ("leaderId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SessionToUser" ADD CONSTRAINT "_SessionToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SessionToUser" ADD CONSTRAINT "_SessionToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -8,6 +8,17 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum SessionName {
+  VOCAL   // 보컬
+  GUITAR  // 기타
+  BASS    // 베이스
+  SYNTH   // 신디
+  DRUM    // 드럼
+  STRINGS // 현악기
+  WINDS   // 관악기
+}
+
+
 model User {
   id              Int       @id @default(autoincrement())
   email           String    @unique
@@ -21,10 +32,14 @@ model User {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
-  generationId   Int
-  generation     Generation @relation(fields: [generationId], references: [id], onDelete: Restrict)
+  generationId    Int
+  generation      Generation @relation(fields: [generationId], references: [id], onDelete: Restrict)
 
-  ledGeneration        Generation? @relation("generationLeader")
+  ledGeneration   Generation? @relation("generationLeader")
+
+  sessions        Session[]
+  ledSession      Session?  @relation("sessionLeader")
+
   @@map("users")
 }
 
@@ -34,10 +49,24 @@ model Generation {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
-  leader    User?     @relation("generationLeader", fields: [leaderId], references: [id], onDelete: SetNull)
-  leaderId  Int?      @unique
+  leader          User?     @relation("generationLeader", fields: [leaderId], references: [id], onDelete: SetNull)
+  leaderId        Int?      @unique
 
-  users         User[]
+  users           User[]
 
   @@map("generations")
+}
+
+model Session {
+  id              Int       @id @default(autoincrement())
+  name            SessionName @unique
+  icon            String?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  leader          User?     @relation("sessionLeader", fields: [leaderId], references: [id], onDelete: SetNull)
+  leaderId        Int?      @unique
+
+  users           User[]
+  @@map("sessions")
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*"
+    "@repo/typescript-config": "workspace:*",
+    "@repo/database": "workspace:*"
   }
 }

--- a/packages/shared-types/src/generation/update-generation.schema.ts
+++ b/packages/shared-types/src/generation/update-generation.schema.ts
@@ -6,7 +6,14 @@ import { CreateGenerationSchema } from "./create-generation.schema";
  * @description 기수 업데이트 Zod 스키마
  * 모든 필드를 선택적으로 만들어서 부분 업데이트를 지원합니다.
  */
-export const UpdateGenerationSchema = CreateGenerationSchema.partial().strict();
+export const UpdateGenerationSchema = CreateGenerationSchema.partial()
+  .extend({
+    /**
+     * @description 기수에 속한 사용자들의 ID 배열
+     */
+    users: z.array(z.number().int()).optional(),
+  })
+  .strict();
 
 /**
  * @description 기수 업데이트 DTO 클래스 (백엔드용)

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -10,3 +10,5 @@ export * from "./auth/jwt.types";
 export * from "./constants/regex";
 export * from "./generation/create-generation.schema";
 export * from "./generation/update-generation.schema";
+export * from "./session/create-session.schema";
+export * from "./session/update-session.schema";

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { createZodDto } from "nestjs-zod";
+
+/**
+ * @description 세션 생성 Zod 스키마
+ * 세션 이름과 아이콘, 리더 ID를 포함합니다.
+ */
+export const CreateSessionSchema = z
+  .object({
+    name: z.enum(
+      ["VOCAL", "GUITAR", "BASS", "SYNTH", "DRUM", "STRINGS", "WINDS"],
+      {
+        required_error: "세션 이름은 필수 항목입니다.",
+        invalid_type_error: "세션 이름은 유효한 값이어야 합니다.",
+      },
+    ),
+
+    icon: z
+      .string({ invalid_type_error: "아이콘은 문자열이어야 합니다." })
+      .url({
+        message: "아이콘은 유효한 URL이어야 합니다.",
+      })
+      .optional(),
+
+    leaderId: z
+      .number({ invalid_type_error: "리더 ID는 숫자여야 합니다." })
+      .int("리더 ID는 정수여야 합니다.")
+      .optional(),
+  })
+  .strict();
+
+/**
+ * @description 세션 생성 DTO 클래스 (백엔드용)
+ */
+export class CreateSessionDto extends createZodDto(CreateSessionSchema) {}
+
+/**
+ * @description 세션 생성 타입 (프론트엔드용)
+ */
+export type CreateSession = z.infer<typeof CreateSessionSchema>;

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -1,5 +1,6 @@
-import { z } from "zod";
-import { createZodDto } from "nestjs-zod";
+import { z } from "zod"
+import { createZodDto } from "nestjs-zod"
+import { SessionName } from "@repo/database"
 
 /**
  * @description 세션 생성 Zod 스키마
@@ -7,27 +8,23 @@ import { createZodDto } from "nestjs-zod";
  */
 export const CreateSessionSchema = z
   .object({
-    name: z.enum(
-      ["VOCAL", "GUITAR", "BASS", "SYNTH", "DRUM", "STRINGS", "WINDS"],
-      {
-        required_error: "세션 이름은 필수 항목입니다.",
-        invalid_type_error: "세션 이름은 유효한 값이어야 합니다.",
-      },
-    ),
-
+    name: z.nativeEnum(SessionName, {
+      required_error: "세션 이름은 필수 항목입니다.",
+      invalid_type_error: "세션 이름은 유효한 값이어야 합니다."
+    }),
     icon: z
       .string({ invalid_type_error: "아이콘은 문자열이어야 합니다." })
       .url({
-        message: "아이콘은 유효한 URL이어야 합니다.",
+        message: "아이콘은 유효한 URL이어야 합니다."
       })
       .optional(),
 
     leaderId: z
       .number({ invalid_type_error: "리더 ID는 숫자여야 합니다." })
       .int("리더 ID는 정수여야 합니다.")
-      .optional(),
+      .optional()
   })
-  .strict();
+  .strict()
 
 /**
  * @description 세션 생성 DTO 클래스 (백엔드용)
@@ -37,4 +34,4 @@ export class CreateSessionDto extends createZodDto(CreateSessionSchema) {}
 /**
  * @description 세션 생성 타입 (프론트엔드용)
  */
-export type CreateSession = z.infer<typeof CreateSessionSchema>;
+export type CreateSession = z.infer<typeof CreateSessionSchema>

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -1,6 +1,6 @@
-import { z } from "zod"
-import { createZodDto } from "nestjs-zod"
-import { SessionName } from "@repo/database"
+import { z } from "zod";
+import { createZodDto } from "nestjs-zod";
+import { SessionName } from "@repo/database";
 
 /**
  * @description 세션 생성 Zod 스키마
@@ -10,21 +10,21 @@ export const CreateSessionSchema = z
   .object({
     name: z.nativeEnum(SessionName, {
       required_error: "세션 이름은 필수 항목입니다.",
-      invalid_type_error: "세션 이름은 유효한 값이어야 합니다."
+      invalid_type_error: "세션 이름은 유효한 값이어야 합니다.",
     }),
     icon: z
       .string({ invalid_type_error: "아이콘은 문자열이어야 합니다." })
       .url({
-        message: "아이콘은 유효한 URL이어야 합니다."
+        message: "아이콘은 유효한 URL이어야 합니다.",
       })
       .optional(),
 
     leaderId: z
       .number({ invalid_type_error: "리더 ID는 숫자여야 합니다." })
       .int("리더 ID는 정수여야 합니다.")
-      .optional()
+      .optional(),
   })
-  .strict()
+  .strict();
 
 /**
  * @description 세션 생성 DTO 클래스 (백엔드용)
@@ -34,4 +34,4 @@ export class CreateSessionDto extends createZodDto(CreateSessionSchema) {}
 /**
  * @description 세션 생성 타입 (프론트엔드용)
  */
-export type CreateSession = z.infer<typeof CreateSessionSchema>
+export type CreateSession = z.infer<typeof CreateSessionSchema>;

--- a/packages/shared-types/src/session/update-session.schema.ts
+++ b/packages/shared-types/src/session/update-session.schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { createZodDto } from "nestjs-zod";
+import { CreateSessionSchema } from "./create-session.schema";
+
+/**
+ * @description 세션 업데이트 Zod 스키마
+ * 모든 필드를 선택적으로 만들어서 부분 업데이트를 지원합니다.
+ * users 필드를 추가하여 세션에 속한 사용자 목록을 업데이트할 수 있습니다.
+ */
+export const UpdateSessionSchema = CreateSessionSchema.partial()
+  .extend({
+    /**
+     * @description 세션에 속한 사용자들의 ID 배열
+     */
+    users: z.array(z.number().int()).optional(),
+  })
+  .strict();
+
+/**
+ * @description 세션 업데이트 DTO 클래스 (백엔드용)
+ */
+export class UpdateSessionDto extends createZodDto(UpdateSessionSchema) {}
+
+/**
+ * @description 세션 업데이트 타입 (프론트엔드용)
+ */
+export type UpdateSession = z.infer<typeof UpdateSessionSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,6 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
-      class-transformer:
-        specifier: ^0.5.1
-        version: 0.5.1
-      class-validator:
-        specifier: ^0.14.2
-        version: 0.14.2
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
@@ -8364,7 +8358,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@types/validator@13.15.2': {}
+  '@types/validator@13.15.2':
+    optional: true
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9175,13 +9170,15 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  class-transformer@0.5.1: {}
+  class-transformer@0.5.1:
+    optional: true
 
   class-validator@0.14.2:
     dependencies:
       '@types/validator': 13.15.2
       libphonenumber-js: 1.12.10
       validator: 13.15.15
+    optional: true
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -11188,7 +11185,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libphonenumber-js@1.12.10: {}
+  libphonenumber-js@1.12.10:
+    optional: true
 
   lilconfig@3.1.3: {}
 
@@ -13117,7 +13115,8 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  validator@13.15.15: {}
+  validator@13.15.15:
+    optional: true
 
   vary@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@repo/database':
+        specifier: workspace:*
+        version: link:../database
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.

세션 모델을 정의하고 관련 API를 구현하였습니다.
세션 모델은 User 모델과 다 대 다 관계를 가지도록 했으며 모델의 name의 경우 Prisma의 ENUM을 이용해
특정한 값 이외에는 name 값으로  사용될 수 없도록 했습니다.

Generation 모델의 PATCH API에서 유저 리스트를 직접 설정할 수 있도록 변경했습니다.
## 📸 스크린샷

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.

| AS-IS | TO-BE |
| :---: | :---: |
|       |       |

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.

- Closes #180 
## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.

Session API 내부의 에러 핸들링에 대해 중점적으로 봐주셨으면 합니다.
현재 Session API에 대해서는 api-client 내부의 error를 사용하도록 하였으며, 

추후 RFC 7807 적용을 위해
커스텀 에러(api-client 내부) -> Global ExceptionFilter 를 통해 RFC 7807 형태로 수정 및 메타데이터 적용 -> FE로 최종 Error 반환
의 형태로 에러 핸들링을 진행하고자 합니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 반영 전/후 스크린샷을 첨부했습니다.
- [x] 관련 이슈가 연결되었습니다.
