### PR TITLE
refactor(fe, be): convert http exception into custom error form

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,8 +1,5 @@
-import {
-  ForbiddenException,
-  Injectable,
-  UnauthorizedException
-} from "@nestjs/common"
+import { Injectable } from "@nestjs/common"
+import { ForbiddenError, AuthError } from "@repo/api-client"
 import { ConfigService } from "@nestjs/config"
 import { JwtService } from "@nestjs/jwt"
 import { CreateUserDto, JwtPayload, LoginUserDto } from "@repo/shared-types"
@@ -31,9 +28,7 @@ export class AuthService {
   async login(loginDto: LoginUserDto) {
     const user = await this.usersService.findOneByEmail(loginDto.email)
     if (!user || !(await bcrypt.compare(loginDto.password, user.password))) {
-      throw new UnauthorizedException(
-        "이메일 또는 비밀번호가 올바르지 않습니다."
-      )
+      throw new AuthError("이메일 또는 비밀번호가 올바르지 않습니다.")
     }
 
     const tokens = await this.getTokens(
@@ -82,7 +77,7 @@ export class AuthService {
   async refreshTokens(userId: number, refreshToken: string) {
     const user = await this.usersService.findOneById(userId)
     if (!user || !user.hashedRefreshToken) {
-      throw new ForbiddenException("Access Denied")
+      throw new ForbiddenError("Access Denied")
     }
 
     const refreshTokenMatches = await bcrypt.compare(
@@ -90,7 +85,7 @@ export class AuthService {
       user.hashedRefreshToken
     )
     if (!refreshTokenMatches) {
-      throw new ForbiddenException("Access Denied")
+      throw new ForbiddenError("Access Denied")
     }
 
     const tokens = await this.getTokens(

--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -1,9 +1,5 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  ForbiddenException,
-  Injectable
-} from "@nestjs/common"
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common"
+import { ForbiddenError } from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
 
 @Injectable()
@@ -16,6 +12,6 @@ export class AdminGuard implements CanActivate {
       return true
     }
 
-    throw new ForbiddenException("관리자 권한이 필요합니다.")
+    throw new ForbiddenError("관리자 권한이 필요합니다.")
   }
 }

--- a/apps/api/src/common/filters/all-error.filter.ts
+++ b/apps/api/src/common/filters/all-error.filter.ts
@@ -1,0 +1,52 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpStatus,
+  HttpException
+} from "@nestjs/common"
+import { HttpAdapterHost } from "@nestjs/core"
+import { Failure } from "@repo/api-client"
+
+@Catch()
+export class AllErrorFilter implements ExceptionFilter {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  //TODO: Logger를 사용하여 상세한 에러 로그를 남기도록 수정해야 합니다.
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const { httpAdapter } = this.httpAdapterHost
+    const ctx = host.switchToHttp()
+    const request = ctx.getRequest<Request>()
+
+    // 별도의 Logger를 사용하여 에러 로그를 남기도록 수정할 예정입니다.
+    console.error("Unhandled Error:", exception)
+
+    const httpStatus =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR
+
+    const detail =
+      exception instanceof HttpException
+        ? (exception.getResponse() as any)?.message || exception.message
+        : "서버에서 처리되지 않은 오류가 발생했습니다."
+
+    const responseBody = {
+      isSuccess: false,
+      isFailure: true,
+      error: {
+        type: "/errors/internal-server-error",
+        status: httpStatus,
+        title: "Internal Server Error",
+        detail: detail,
+        instance: request.url
+      }
+    } satisfies Failure
+
+    httpAdapter.reply(
+      ctx.getResponse(),
+      responseBody,
+      HttpStatus.INTERNAL_SERVER_ERROR
+    )
+  }
+}

--- a/apps/api/src/common/filters/all-error.filter.ts
+++ b/apps/api/src/common/filters/all-error.filter.ts
@@ -6,7 +6,7 @@ import {
   HttpException
 } from "@nestjs/common"
 import { HttpAdapterHost } from "@nestjs/core"
-import { Failure } from "@repo/api-client"
+import { Failure, InternalServerError } from "@repo/api-client"
 
 @Catch()
 export class AllErrorFilter implements ExceptionFilter {
@@ -29,16 +29,19 @@ export class AllErrorFilter implements ExceptionFilter {
     const detail =
       exception instanceof HttpException
         ? (exception.getResponse() as any)?.message || exception.message
-        : "서버에서 처리되지 않은 오류가 발생했습니다."
+        : (exception as any)?.message ||
+          "서버에서 처리되지 않은 오류가 발생했습니다."
+
+    const internalServerError = new InternalServerError()
 
     const responseBody = {
       isSuccess: false,
       isFailure: true,
       error: {
-        type: "/errors/internal-server-error",
+        type: internalServerError.type,
         status: httpStatus,
-        title: "Internal Server Error",
-        detail: detail,
+        title: internalServerError.title,
+        detail,
         instance: request.url
       }
     } satisfies Failure

--- a/apps/api/src/common/filters/api-error.filter.ts
+++ b/apps/api/src/common/filters/api-error.filter.ts
@@ -1,13 +1,12 @@
 import { ExceptionFilter, Catch, ArgumentsHost } from "@nestjs/common"
 import { HttpAdapterHost } from "@nestjs/core"
-import { ApiError, ApiResult, Failure } from "@repo/api-client"
+import { ApiError, Failure } from "@repo/api-client"
 
 @Catch(ApiError)
 export class ApiErrorFilter implements ExceptionFilter {
   constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
 
   catch(exception: ApiError, host: ArgumentsHost): void {
-    console.error("API Error:", exception)
     const { httpAdapter } = this.httpAdapterHost
     const ctx = host.switchToHttp()
     const request = ctx.getRequest<Request>()

--- a/apps/api/src/common/filters/api-error.filter.ts
+++ b/apps/api/src/common/filters/api-error.filter.ts
@@ -1,0 +1,29 @@
+import { ExceptionFilter, Catch, ArgumentsHost } from "@nestjs/common"
+import { HttpAdapterHost } from "@nestjs/core"
+import { ApiError, ApiResult, Failure } from "@repo/api-client"
+
+@Catch(ApiError)
+export class ApiErrorFilter implements ExceptionFilter {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(exception: ApiError, host: ArgumentsHost): void {
+    console.error("API Error:", exception)
+    const { httpAdapter } = this.httpAdapterHost
+    const ctx = host.switchToHttp()
+    const request = ctx.getRequest<Request>()
+
+    const responseBody = {
+      isSuccess: false,
+      isFailure: true,
+      error: {
+        type: exception.type,
+        status: exception.status,
+        title: exception.title,
+        detail: exception.detail,
+        instance: request.url
+      }
+    } satisfies Failure
+
+    httpAdapter.reply(ctx.getResponse(), responseBody, exception.status)
+  }
+}

--- a/apps/api/src/common/interceptors/api-result.interceptor.ts
+++ b/apps/api/src/common/interceptors/api-result.interceptor.ts
@@ -1,0 +1,27 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler
+} from "@nestjs/common"
+import { Observable } from "rxjs"
+import { map } from "rxjs/operators"
+import { ApiResult } from "@repo/api-client"
+
+@Injectable()
+export class ApiResultInterceptor<T>
+  implements NestInterceptor<T, ApiResult<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler
+  ): Observable<ApiResult<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        isSuccess: true,
+        isFailure: false,
+        data
+      }))
+    )
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import cookieParser from "cookie-parser"
 import { ZodValidationPipe } from "nestjs-zod"
 import { AppModule } from "./app.module"
 import { ApiErrorFilter } from "./common/filters/api-error.filter"
+import { AllErrorFilter } from "./common/filters/all-error.filter"
 import { ApiResultInterceptor } from "./common/interceptors/api-result.interceptor"
 
 async function bootstrap() {
@@ -11,7 +12,10 @@ async function bootstrap() {
   const httpAdapterHost = app.get(HttpAdapterHost)
   app.use(cookieParser())
   app.useGlobalPipes(new ZodValidationPipe())
-  app.useGlobalFilters(new ApiErrorFilter(httpAdapterHost))
+  app.useGlobalFilters(
+    new AllErrorFilter(httpAdapterHost),
+    new ApiErrorFilter(httpAdapterHost)
+  )
   app.useGlobalInterceptors(new ApiResultInterceptor())
   const configService = app.get(ConfigService)
   await app.listen(configService.get<number>("PORT") ?? 8000)

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,13 +1,18 @@
 import { ConfigService } from "@nestjs/config"
-import { NestFactory } from "@nestjs/core"
+import { HttpAdapterHost, NestFactory } from "@nestjs/core"
 import cookieParser from "cookie-parser"
 import { ZodValidationPipe } from "nestjs-zod"
 import { AppModule } from "./app.module"
+import { ApiErrorFilter } from "./common/filters/api-error.filter"
+import { ApiResultInterceptor } from "./common/interceptors/api-result.interceptor"
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
+  const httpAdapterHost = app.get(HttpAdapterHost)
   app.use(cookieParser())
   app.useGlobalPipes(new ZodValidationPipe())
+  app.useGlobalFilters(new ApiErrorFilter(httpAdapterHost))
+  app.useGlobalInterceptors(new ApiResultInterceptor())
   const configService = app.get(ConfigService)
   await app.listen(configService.get<number>("PORT") ?? 8000)
 }

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -4,7 +4,7 @@ import { PrismaService } from "../prisma/prisma.service"
 import {
   NotFoundError,
   ConflictError,
-  InternalServerError
+  UnprocessableEntityError
 } from "@repo/api-client"
 import { Prisma } from "@repo/database"
 import {
@@ -40,11 +40,10 @@ export class SessionService {
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
-            throw new NotFoundError("리더 ID가 유효하지 않습니다.")
+            throw new UnprocessableEntityError("리더 ID가 유효하지 않습니다.")
         }
       }
-      // RFC 7807 적용 시, throw error; 로 변경 필요
-      throw new InternalServerError("세션 생성 중 서버 오류가 발생했습니다.")
+      throw error
     }
   }
 
@@ -116,28 +115,24 @@ export class SessionService {
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
-            throw new NotFoundError(
+            throw new UnprocessableEntityError(
               "리더 ID 혹은 사용자 ID가 유효하지 않습니다."
             )
         }
       }
-      // RFC 7807 적용 시, throw error; 로 변경 필요
-      throw new InternalServerError(
-        "세션 업데이트 중 서버 오류가 발생했습니다."
-      )
+      throw error
     }
   }
 
   async remove(id: number) {
+    const sesssion = await this.findOne(id) // 존재 여부 확인
     try {
-      const sesssion = await this.findOne(id) // 존재 여부 확인
       await this.prisma.session.delete({
         where: { id }
       })
       return sesssion
     } catch (error) {
-      if (error instanceof NotFoundError) throw error // 이미 존재하지 않는 세션에 대한 삭제 요청
-      throw new InternalServerError("세션 삭제 중 서버 오류가 발생했습니다.")
+      throw error
     }
   }
 }

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -125,12 +125,12 @@ export class SessionService {
   }
 
   async remove(id: number) {
-    const sesssion = await this.findOne(id) // 존재 여부 확인
+    const session = await this.findOne(id) // 존재 여부 확인
     try {
       await this.prisma.session.delete({
         where: { id }
       })
-      return sesssion
+      return session
     } catch (error) {
       throw error
     }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,8 +1,5 @@
-import {
-  ConflictException,
-  Injectable,
-  InternalServerErrorException
-} from "@nestjs/common"
+import { Injectable } from "@nestjs/common"
+import { ConflictError } from "@repo/api-client"
 import { Prisma } from "@repo/database"
 import { CreateUserDto } from "@repo/shared-types"
 import * as bcrypt from "bcrypt"
@@ -33,12 +30,11 @@ export class UsersService {
       ) {
         const target = (error.meta?.target as string[]) || []
         if (target.includes("email"))
-          throw new ConflictException("이미 사용중인 이메일입니다.")
+          throw new ConflictError("이미 사용중인 이메일입니다.")
         if (target.includes("nickname"))
-          throw new ConflictException("이미 사용중인 닉네임입니다.")
+          throw new ConflictError("이미 사용중인 닉네임입니다.")
       }
-      // RFC 7807 적용 시, throw error; 로 변경 필요
-      throw new InternalServerErrorException()
+      throw error
     }
   }
 

--- a/packages/api-client/src/api-result.ts
+++ b/packages/api-client/src/api-result.ts
@@ -1,14 +1,14 @@
-import { ApiError } from "./errors"
+import { ProblemDocument } from "./errors"
 
 export type Success<T> = {
   isSuccess: true
   isFailure: false
   data: T
 }
-export type Failure<E = ApiError> = {
+export type Failure = {
   isSuccess: false
   isFailure: true
-  error: E
+  error: ProblemDocument
 }
 
-export type ApiResult<T, E = ApiError> = Success<T> | Failure<E>
+export type ApiResult<T> = Success<T> | Failure

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -1,3 +1,15 @@
+/**
+ * RFC 7807 표준을 따르는 에러 데이터 객체 타입
+ * JSON으로 직렬화되어 클라이언트에 전달되는 실제 데이터의 형태입니다.
+ */
+export type ProblemDocument = {
+  type: string
+  title: string
+  status: number
+  detail?: string
+  instance?: string
+}
+
 export abstract class ApiError extends Error {
   abstract readonly type: string
   abstract readonly status: number
@@ -5,7 +17,8 @@ export abstract class ApiError extends Error {
 
   constructor(
     message: string,
-    public readonly detail?: string
+    public readonly detail?: string,
+    public readonly instance?: string
   ) {
     super(message)
     this.name = this.constructor.name
@@ -17,8 +30,8 @@ export class NotFoundError extends ApiError {
   readonly status = 404
   readonly title = "Not Found"
 
-  constructor(detail?: string) {
-    super("요청하신 리소스를 찾을 수 없습니다", detail)
+  constructor(detail?: string, instance?: string) {
+    super("요청하신 리소스를 찾을 수 없습니다", detail, instance)
   }
 }
 
@@ -27,8 +40,8 @@ export class InternalServerError extends ApiError {
   readonly status = 500
   readonly title = "Internal Server Error"
 
-  constructor(detail?: string) {
-    super("서버에서 오류가 발생했습니다", detail)
+  constructor(detail?: string, instance?: string) {
+    super("서버에서 오류가 발생했습니다", detail, instance)
   }
 }
 
@@ -37,8 +50,8 @@ export class ValidationError extends ApiError {
   readonly status = 400
   readonly title = "Validation Error"
 
-  constructor(detail?: string) {
-    super("입력값이 올바르지 않습니다", detail)
+  constructor(detail?: string, instance?: string) {
+    super("입력값이 올바르지 않습니다", detail, instance)
   }
 }
 
@@ -47,8 +60,8 @@ export class AuthError extends ApiError {
   readonly status = 401
   readonly title = "Authentication Error"
 
-  constructor(detail?: string) {
-    super("유효한 인증 정보가 필요합니다.", detail)
+  constructor(detail?: string, instance?: string) {
+    super("유효한 인증 정보가 필요합니다.", detail, instance)
   }
 }
 
@@ -57,36 +70,17 @@ export class ForbiddenError extends ApiError {
   readonly status = 403
   readonly title = "Forbidden"
 
-  constructor(detail?: string) {
-    super("접근 권한이 없습니다", detail)
+  constructor(detail?: string, instance?: string) {
+    super("접근 권한이 없습니다", detail, instance)
   }
 }
 
-/**
- * 요청이 서버의 현재 상태와 충돌하는 경우 발생하는 오류입니다.
- * @example 중복된 데이터 생성 시
- */
 export class ConflictError extends ApiError {
   readonly type = "/errors/conflict"
   readonly status = 409
   readonly title = "Conflict"
 
-  constructor(detail?: string) {
-    super("이미 존재하는 데이터입니다", detail)
-  }
-}
-
-/**
- * 요청 내용 자체에 문제가 있는 경우 발생하는 오류입니다.
- * JSON 문법은 올바르지만, 요청된 엔티티가 유효하지 않거나 처리할 수 없는 경우에 사용됩니다.
- * @example 유효하지 않은 외래 키 참조
- */
-export class UnprocessableEntityError extends ApiError {
-  readonly type = "/errors/unprocessable-entity"
-  readonly status = 422
-  readonly title = "Unprocessable Entity"
-
-  constructor(detail?: string) {
-    super("처리할 수 없는 엔티티입니다", detail)
+  constructor(detail?: string, instance?: string) {
+    super("이미 존재하는 데이터입니다", detail, instance)
   }
 }

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -75,6 +75,10 @@ export class ForbiddenError extends ApiError {
   }
 }
 
+/**
+ * 요청이 서버의 현재 상태와 충돌하는 경우 발생하는 오류입니다.
+ * @example 중복된 데이터 생성 시
+ */
 export class ConflictError extends ApiError {
   readonly type = "/errors/conflict"
   readonly status = 409
@@ -82,5 +86,20 @@ export class ConflictError extends ApiError {
 
   constructor(detail?: string, instance?: string) {
     super("이미 존재하는 데이터입니다", detail, instance)
+  }
+}
+
+/**
+ * 요청 내용 자체에 문제가 있는 경우 발생하는 오류입니다.
+ * JSON 문법은 올바르지만, 요청된 엔티티가 유효하지 않거나 처리할 수 없는 경우에 사용됩니다.
+ * @example 유효하지 않은 외래 키 참조
+ */
+export class UnprocessableEntityError extends ApiError {
+  readonly type = "/errors/unprocessable-entity"
+  readonly status = 422
+  readonly title = "Unprocessable Entity"
+
+  constructor(detail?: string, instance?: string) {
+    super("처리할 수 없는 엔티티입니다", detail, instance)
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -53,7 +53,9 @@ function createErrorFromProblemDocument(problemDoc: ProblemDocument): ApiError {
     case "/errors/internal-server-error":
       return new InternalServerError(detail, instance)
     default:
-      return new InternalServerError(detail, instance)
+      // API 서버에서 알 수 없는 에러가 전달될 경우
+      // detail과 instance가 없을 수 있습니다.
+      return new InternalServerError()
   }
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -81,7 +81,7 @@ export default class ApiClient {
   /**
    * 내부 API 요청 헬퍼 메소드
    */
-  private async _request<T>(
+  private async _request<T, E>(
     endpoint: string, // 예: "/api/posts", "/api/projects/1" (항상 '/'로 시작 가정)
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -123,7 +123,7 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async createPerformance(performanceData: CreatePerformance) {
-    return this._request<Performance>(
+    return this._request<Performance, ValidationError | InternalServerError>(
       `/api/performances`,
       "POST",
       performanceData
@@ -136,7 +136,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getPerformanceById(id: number) {
-    return this._request<Performance>(`/api/performances/${id}`, "GET")
+    return this._request<Performance, NotFoundError | InternalServerError>(
+      `/api/performances/${id}`,
+      "GET"
+    )
   }
 
   /**
@@ -144,7 +147,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getPerformances() {
-    return this._request<Performance[]>(`/api/performances`, "GET")
+    return this._request<Performance[], InternalServerError>(
+      `/api/performances`,
+      "GET"
+    )
   }
 
   /**
@@ -157,11 +163,10 @@ export default class ApiClient {
     id: number,
     performanceData: UpdatePerformance
   ) {
-    return this._request<Performance>(
-      `/api/performances/${id}`,
-      "PATCH",
-      performanceData
-    )
+    return this._request<
+      Performance,
+      NotFoundError | ValidationError | InternalServerError
+    >(`/api/performances/${id}`, "PATCH", performanceData)
   }
 
   /**
@@ -172,7 +177,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async deletePerformance(id: number) {
-    return this._request<null>(`/api/performances/${id}`, "DELETE")
+    return this._request<
+      null,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/performances/${id}`, "DELETE")
   }
 
   /**
@@ -184,11 +192,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async createTeam(performanceId: number, teamData: CreateTeam) {
-    return this._request<Team>(
-      `/api/performances/${performanceId}/teams`,
-      "POST",
-      teamData
-    )
+    return this._request<
+      Team,
+      | ValidationError
+      | AuthError
+      | ForbiddenError
+      | NotFoundError
+      | InternalServerError
+    >(`/api/performances/${performanceId}/teams`, "POST", teamData)
   }
 
   /**
@@ -197,7 +208,7 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getTeamsByPerformance(performanceId: number) {
-    return this._request<Team[]>(
+    return this._request<Team[], NotFoundError | InternalServerError>(
       `/api/performances/${performanceId}/teams`,
       "GET"
     )
@@ -209,7 +220,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getTeamById(id: number) {
-    return this._request<Team>(`/api/teams/${id}`, "GET")
+    return this._request<Team, NotFoundError | InternalServerError>(
+      `/api/teams/${id}`,
+      "GET"
+    )
   }
 
   /**
@@ -221,7 +235,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async updateTeam(id: number, teamData: UpdateTeam) {
-    return this._request<Team>(`/api/teams/${id}`, "PATCH", teamData)
+    return this._request<
+      Team,
+      | AuthError
+      | ForbiddenError
+      | NotFoundError
+      | ValidationError
+      | InternalServerError
+    >(`/api/teams/${id}`, "PATCH", teamData)
   }
 
   /**
@@ -232,7 +253,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async deleteTeam(id: number) {
-    return this._request<null>(`/api/teams/${id}`, "DELETE")
+    return this._request<
+      null,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/teams/${id}`, "DELETE")
   }
 
   /**
@@ -246,11 +270,10 @@ export default class ApiClient {
     teamId: number,
     teamApplicationData: TeamApplication
   ) {
-    return this._request<Team>(
-      `/api/teams/${teamId}/apply`,
-      "POST",
-      teamApplicationData
-    )
+    return this._request<
+      Team,
+      AuthError | NotFoundError | ConflictError | InternalServerError
+    >(`/api/teams/${teamId}/apply`, "POST", teamApplicationData)
   }
 
   /**
@@ -265,11 +288,10 @@ export default class ApiClient {
     teamId: number,
     teamApplicationData: TeamApplication
   ) {
-    return this._request<Team>(
-      `/api/teams/${teamId}/cancel`,
-      "POST",
-      teamApplicationData
-    )
+    return this._request<
+      Team,
+      AuthError | NotFoundError | UnprocessableEntityError | InternalServerError
+    >(`/api/teams/${teamId}/cancel`, "POST", teamApplicationData)
   }
 
   /**
@@ -280,7 +302,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async createGeneration(generationData: CreateGeneration) {
-    return this._request<Generation>(`/api/generations`, "POST", generationData)
+    return this._request<
+      Generation,
+      AuthError | ForbiddenError | ValidationError | InternalServerError
+    >(`/api/generations`, "POST", generationData)
   }
 
   /**
@@ -289,7 +314,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getGenerationById(id: number) {
-    return this._request<Generation>(`/api/generations/${id}`, "GET")
+    return this._request<Generation, NotFoundError | InternalServerError>(
+      `/api/generations/${id}`,
+      "GET"
+    )
   }
 
   /**
@@ -297,7 +325,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getGenerations() {
-    return this._request<Generation[]>(`/api/generations`, "GET")
+    return this._request<Generation[], InternalServerError>(
+      `/api/generations`,
+      "GET"
+    )
   }
 
   /**
@@ -309,11 +340,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async updateGeneration(id: number, generationData: UpdateGeneration) {
-    return this._request<Generation>(
-      `/api/generations/${id}`,
-      "PATCH",
-      generationData
-    )
+    return this._request<
+      Generation,
+      | AuthError
+      | ForbiddenError
+      | NotFoundError
+      | ValidationError
+      | InternalServerError
+    >(`/api/generations/${id}`, "PATCH", generationData)
   }
 
   /**
@@ -324,7 +358,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async deleteGeneration(id: number) {
-    return this._request<null>(`/api/generations/${id}`, "DELETE")
+    return this._request<
+      null,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/generations/${id}`, "DELETE")
   }
 
   /**
@@ -335,7 +372,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async createSession(sessionData: CreateSession) {
-    return this._request<Session>(`/api/sessions`, "POST", sessionData)
+    return this._request<
+      Session,
+      AuthError | ForbiddenError | ValidationError | InternalServerError
+    >(`/api/sessions`, "POST", sessionData)
   }
 
   /**
@@ -344,7 +384,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getSessionById(id: number) {
-    return this._request<Session>(`/api/sessions/${id}`, "GET")
+    return this._request<Session, NotFoundError | InternalServerError>(
+      `/api/sessions/${id}`,
+      "GET"
+    )
   }
 
   /**
@@ -352,7 +395,7 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getSessions() {
-    return this._request<Session[]>(`/api/sessions`, "GET")
+    return this._request<Session[], InternalServerError>(`/api/sessions`, "GET")
   }
 
   /**
@@ -364,7 +407,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async updateSession(id: number, sessionData: UpdateSession) {
-    return this._request<Session>(`/api/sessions/${id}`, "PATCH", sessionData)
+    return this._request<
+      Session,
+      | AuthError
+      | ForbiddenError
+      | NotFoundError
+      | ValidationError
+      | InternalServerError
+    >(`/api/sessions/${id}`, "PATCH", sessionData)
   }
 
   /**
@@ -375,7 +425,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async deleteSession(id: number) {
-    return this._request<null>(`/api/sessions/${id}`, "DELETE")
+    return this._request<
+      null,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/sessions/${id}`, "DELETE")
   }
 
   /**
@@ -387,7 +440,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async createUser(userData: CreateUser) {
-    return this._request<User>(`/api/users`, "POST", userData)
+    return this._request<
+      User,
+      | AuthError
+      | ForbiddenError
+      | ValidationError
+      | ConflictError
+      | InternalServerError
+    >(`/api/users`, "POST", userData)
   }
 
   /**
@@ -398,7 +458,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getUserById(id: number) {
-    return this._request<User>(`/api/users/${id}`, "GET")
+    return this._request<
+      User,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/users/${id}`, "GET")
   }
 
   /**
@@ -408,7 +471,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async getUsers() {
-    return this._request<User[]>(`/api/users`, "GET")
+    return this._request<
+      User[],
+      AuthError | ForbiddenError | InternalServerError
+    >(`/api/users`, "GET")
   }
 
   /**
@@ -420,7 +486,14 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async updateUser(id: number, userData: UpdateUser) {
-    return this._request<User>(`/api/users/${id}`, "PATCH", userData)
+    return this._request<
+      User,
+      | AuthError
+      | ForbiddenError
+      | NotFoundError
+      | ValidationError
+      | InternalServerError
+    >(`/api/users/${id}`, "PATCH", userData)
   }
 
   /**
@@ -431,7 +504,10 @@ export default class ApiClient {
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public async deleteUser(id: number) {
-    return this._request<null>(`/api/users/${id}`, "DELETE")
+    return this._request<
+      null,
+      AuthError | ForbiddenError | NotFoundError | InternalServerError
+    >(`/api/users/${id}`, "DELETE")
   }
 
   /**
@@ -442,7 +518,13 @@ export default class ApiClient {
    * @throws {InternalServerError}
    */
   public async register(userData: CreateUser) {
-    return this._request<User>("/api/register", "POST", userData)
+    return this._request<
+      User,
+      | ValidationError
+      | ConflictError
+      | UnprocessableEntityError
+      | InternalServerError
+    >("/api/register", "POST", userData)
   }
 
   /**
@@ -451,7 +533,11 @@ export default class ApiClient {
    * @throws {InternalServerError}
    */
   public async login(loginUser: LoginUser) {
-    return this._request<User>("/api/login", "POST", loginUser)
+    return this._request<User, AuthError | InternalServerError>(
+      "/api/login",
+      "POST",
+      loginUser
+    )
   }
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -110,7 +110,7 @@ export default class ApiClient {
       if (data.isSuccess) {
         return data.data
       }
-      throw createErrorFromProblemDocument(data.error as ApiError)
+      throw createErrorFromProblemDocument(data.error satisfies ProblemDocument)
     } catch {
       // 네트워크 에러만 클라이언트에서 처리
       throw new InternalServerError()


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]
백엔드에서 발생하는 응답이 항상 `ApiResult` 형태를 갖출수 있도록 수정했습니다.
또한, 기존 백엔드 코드에서 사용하던 HttpException을 제거하고 새롭게 만들어진 Custom Error로 변경했습니다.

api-client에서 request에 들어가던 Error 부분을 제거했습니다. 
[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

백엔드에서 발생하는 응답이 항상 `ApiResult` 형태를 갖출수 있도록 수정했습니다.
또한, 기존 백엔드 코드에서 사용하던 HttpException을 제거하고 새롭게 만들어진 Custom Error로 변경했습니다.

api-client에서 request에 들어가던 Error 부분을 제거했습니다. 

https://github.com/skku-amang/main/blob/a1b0f3901ce5e9bb95ac89a6d429827f4ead60f3/apps/api/src/common/filters/api-error.filter.ts#L14-L26
api-error.filter를 Global Filter로 추가해 ApiError 형식의 모든 Error가 ApiResult 형식으로 반환될 수 있도록 하였습니다.

https://github.com/skku-amang/main/blob/a1b0f3901ce5e9bb95ac89a6d429827f4ead60f3/apps/api/src/common/filters/all-error.filter.ts#L24-L50
api-error.filter에서 처리되지 못한 에러(NestJS 내부 에러 등 Unhandled Error를 의미합니다) 또한, ApiResult 형식으로 반환될 수 있도록 하기 위해 all-error.filter를 추가하였습니다. 

Global Filter에서의 적용 순서는 api-error.filter -> all-error.filter 입니다. 즉, api-error.filter에서 처리되지 않은 에러들에 대해서만 all-error.filter에서 처리됩니다.

https://github.com/skku-amang/main/blob/a1b0f3901ce5e9bb95ac89a6d429827f4ead60f3/packages/api-client/src/api-result.ts#L1-L14
Failure 형식을 BE에서도 사용가능 하도록 ProblemDocument 형식으로 변경하였습니다.

https://github.com/skku-amang/main/blob/a1b0f3901ce5e9bb95ac89a6d429827f4ead60f3/apps/api/src/session/session.service.ts#L134-L135
기존에 InternalError를 반환하던 error를 throw error 로 변경 후, all-error.filter에서 처리되도록 변경했습니다.
단순히 InternalError를 반환한다면 error 내부의 stack과 관련된 정보가 삭제될 수 있어, 관련 내용을 logging 후, all-error.filter에서 InternalError로 반환될 수 있도록 하였습니다.

https://github.com/skku-amang/main/blob/a1b0f3901ce5e9bb95ac89a6d429827f4ead60f3/apps/api/src/common/interceptors/api-result.interceptor.ts#L15-L24
intercepor를 사용해, 성공적으로 반환된 데이터가 항상 ApiResult 형태로 변환 후, 반환되도록 수정하였습니다.

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

**작업 전 에러 응답**
<img width="614" height="531" alt="image" src="https://github.com/user-attachments/assets/e0f702c3-5d84-42d4-94bc-e283785b07ee" />
기존 커스텀 에러 사용 시, NestJS가 해당 에러에 대해 파악하지 못해 항상 500 Internal Error를 반환했습니다.

**작업 후 에러 응답**
<img width="527" height="526" alt="image" src="https://github.com/user-attachments/assets/5dc40a2d-97f2-43a9-a270-2b581583febb" />
모든 에러가 error filter를 통해 처리되므로 NestJS가 해당 응답에 대해 파악할 수 있게 되었고 이로 인해 정상적인 에러 응답이 반환됩니다.

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #이슈번호
#166 이슈와 관련있으나 아직 nestjs-zod에서 발생하는 ValidationError 에러 처리는 수행되지 않아, 추후 PR에서 close될 예정입니다.
## 🙏 리뷰어에게
새롭게 생성된 **filter**, **interceptor**에 대해 봐주세요.
또한, api-client에서 _request 메서드에서 Error 부분을 지운 것에 대해서 리뷰해보았으면 합니다.

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
