### PR TITLE
feat(api, database): Seeding basic data using Prisma client

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -5,15 +5,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*"
-      ]
-    }
-  },
+  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "dev": "tsc --watch",
     "check-types": "tsc --noEmit",
     "format": "prettier --check \"src/**/*.ts\"",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -20,16 +20,20 @@
     "lint": "eslint \"src/**/*.ts\" --fix",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev --skip-generate",
-    "db:deploy": "prisma migrate deploy"
+    "db:deploy": "prisma migrate deploy",
+    "db:seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "^6.11.1"
+    "@prisma/client": "^6.11.1",
+    "bcrypt": "^6.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@types/bcrypt": "^5.0.2",
     "@types/node": "^24.1.0",
-    "prisma": "^6.11.1"
+    "prisma": "^6.11.1",
+    "ts-node": "^10.9.2"
   },
   "prettier": "@repo/eslint-config/prettier.config"
 }

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "../generated/prisma"
+import { seedSessions, seedGenerations, seedUsers } from "./seeds"
+const prisma = new PrismaClient()
+
+const main = async () => {
+  console.log("Seeding started...")
+  await seedSessions(prisma)
+  await seedGenerations(prisma)
+  await seedUsers(prisma)
+  console.log("Seeding finished.")
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })

--- a/packages/database/prisma/seeds/01-sessions.seed.ts
+++ b/packages/database/prisma/seeds/01-sessions.seed.ts
@@ -1,0 +1,15 @@
+import { PrismaClient, SessionName } from "../../generated/prisma"
+
+export const seedSessions = async (prisma: PrismaClient) => {
+  console.log("Seeding sessions...")
+
+  for (const name of Object.values(SessionName)) {
+    await prisma.session.upsert({
+      where: { name },
+      create: { name },
+      update: {}
+    })
+  }
+
+  console.log("Seeding sessions completed.")
+}

--- a/packages/database/prisma/seeds/02-generations.seed.ts
+++ b/packages/database/prisma/seeds/02-generations.seed.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from "../../generated/prisma"
+
+export const seedGenerations = async (prisma: PrismaClient) => {
+  console.log("Seeding generations...")
+  for (let order = 23.0; order <= 37; order += 0.5) {
+    await prisma.generation.upsert({
+      where: { order },
+      create: { order },
+      update: {}
+    })
+  }
+
+  console.log("Seeding generations completed.")
+}

--- a/packages/database/prisma/seeds/03-user.seed.ts
+++ b/packages/database/prisma/seeds/03-user.seed.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from "../../generated/prisma"
+import * as bcrypt from "bcrypt"
+
+export const seedUsers = async (prisma: PrismaClient) => {
+  console.log("Seeding users...")
+
+  const defaultPassword = process.env.SEED_DEFAULT_PASSWORD
+  if (!defaultPassword) {
+    console.error("SEED_DEFAULT_PASSWORD is not set.")
+    return
+  }
+
+  const generation = await prisma.generation.findFirst()
+  if (!generation) {
+    console.error("No generation found.")
+    return
+  }
+
+  const hashedPassword = await bcrypt.hash(defaultPassword, 10)
+  await prisma.user.upsert({
+    where: {
+      nickname: "관리자"
+    },
+    create: {
+      name: "관리자",
+      email: "admin@amang.com",
+      password: hashedPassword,
+      nickname: "관리자",
+      generationId: generation.id,
+      isAdmin: true
+    },
+    update: {}
+  })
+
+  await prisma.user.upsert({
+    where: {
+      nickname: "사용자"
+    },
+    create: {
+      name: "사용자",
+      email: "user@amang.com",
+      password: hashedPassword,
+      nickname: "사용자",
+      generationId: generation.id
+    },
+    update: {}
+  })
+  console.log("Seeding users completed.")
+}

--- a/packages/database/prisma/seeds/index.ts
+++ b/packages/database/prisma/seeds/index.ts
@@ -1,0 +1,3 @@
+export * from "./01-sessions.seed"
+export * from "./02-generations.seed"
+export * from "./03-user.seed"

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "@repo/typescript-config/base",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
+    "rootDir": "src",
     "declaration": true
   },
-  "include": ["src", "prisma"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "./dist",
     "declaration": true
   },
-  "include": ["src"],
+  "include": ["src", "prisma"],
   "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@prisma/client':
         specifier: ^6.11.1
         version: 6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2)
+      bcrypt:
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -352,12 +355,18 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/bcrypt':
+        specifier: ^5.0.2
+        version: 5.0.2
       '@types/node':
         specifier: ^24.1.0
         version: 24.2.0
       prisma:
         specifier: ^6.11.1
         version: 6.13.0(typescript@5.9.2)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.13.3)(@types/node@24.2.0)(typescript@5.9.2)
 
   packages/eslint-config:
     devDependencies:
@@ -12986,6 +12995,26 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.17.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.3
+
+  ts-node@10.9.2(@swc/core@1.13.3)(@types/node@24.2.0)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.2.0
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3

--- a/turbo.json
+++ b/turbo.json
@@ -32,11 +32,15 @@
       "cache": false
     },
     "db:migrate": {
-      "cache": false,
-      "persistent": true
+      "cache": false
     },
     "db:deploy": {
       "cache": false
+    },
+    "db:seed": {
+      "cache": false,
+      "dependsOn": ["^db:generate", "^db:migrate"],
+      "env": ["DATABASE_URL", "SEED_DEFAULT_PASSWORD"]
     }
   },
   "globalEnv": ["NODE_ENV", "PORT", "DATABASE_URL"]


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

Amang 프로젝트 동작을 위해 필요한 기초 데이터를 손쉽게 넣을 수 있는 Seed 스크립트를 작성했습니다.
Seed 작업은 현재 3개 스크립트를 통해 동작합니다.
모든 Seeding 작업은 upsert를 통해 동작합니다. _(데이터가 없을 경우 **create**를 수행하며, 이미 존재하는 경우에는 아무런 작업을 하지 않습니다.)_

- `seedSessions` - Prisma 내부에 ENUM 형식으로 구현되어 있는 `SessionName`을 가져와 DB에서 생성 가능한 모든 Session을 생성합니다.
- `seedGenerations` - 23.0기부터 37.0기까지의 기수 데이터를 생성합니다.
- `seedUsers` - `관리자` 계정과 `일반 유저` 계정을 테스트를 위해 생성합니다. 이 때 2개 계정의 차이로는 `관리자` 계정만이 `isAdmin` 속성이 `true`로 설정되어 있습니다.
2개 계정의 비밀번호는 모두 `database` 프로젝트의 env 파일에서 가져오도록 설정했습니다.

`db:seed` 명령어를 package.json과 turbo.json에 추가하였습니다. pnpm turbo db:seed를 사용할 경우 모든 seeding 작업을 손쉽게 수행할 수 있습니다.
`db:migrate` 명령어의 persistent를 제거했습니다. prisma.schema 파일의 내용을 DB에 적용하는 작업이라 persistent 속성은 필요없을 것 같네요

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #이슈번호

close #199 

## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

seeding 스크립트에 수정하고 싶으신 부분이 있으시면 Comment 남겨주세요

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
