### PR TITLE
feat(api): type-safe jwt error handling

### DIFF
--- a/apps/api/src/auth/guards/access-token.guard.ts
+++ b/apps/api/src/auth/guards/access-token.guard.ts
@@ -3,6 +3,7 @@ import { Reflector } from "@nestjs/core"
 import { AuthGuard } from "@nestjs/passport"
 import { IS_PUBLIC_KEY } from "../decorators/public.decorator"
 import { AuthError } from "@repo/api-client"
+import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
 
 @Injectable()
 export class AccessTokenGuard extends AuthGuard("jwt-access") {
@@ -28,16 +29,15 @@ export class AccessTokenGuard extends AuthGuard("jwt-access") {
 
   handleRequest(err: any, user: any, info: any) {
     if (info) {
-      switch (info.name) {
-        case "TokenExpiredError":
-          throw new AuthError("액세스 토큰이 만료되었습니다.")
-        case "JsonWebTokenError":
-          throw new AuthError("유효하지 않은 형식의 액세스 토큰입니다.")
-        default:
-          throw new AuthError(
-            "액세스 토큰 인증 중 알 수 없는 오류가 발생했습니다."
-          )
+      if (info instanceof TokenExpiredError) {
+        throw new AuthError("액세스 토큰이 만료되었습니다.")
       }
+
+      if (info instanceof JsonWebTokenError) {
+        throw new AuthError("유효하지 않은 형식의 액세스 토큰입니다.")
+      }
+
+      throw new AuthError("액세스 토큰 인증 중 알 수 없는 오류가 발생했습니다.")
     }
 
     // `validate` 함수에서 발생한 에러를 상위로 전파합니다.

--- a/apps/api/src/auth/guards/access-token.guard.ts
+++ b/apps/api/src/auth/guards/access-token.guard.ts
@@ -4,6 +4,7 @@ import { AuthGuard } from "@nestjs/passport"
 import { IS_PUBLIC_KEY } from "../decorators/public.decorator"
 import { AuthError } from "@repo/api-client"
 import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
+import { JwtPayload } from "@repo/shared-types"
 
 @Injectable()
 export class AccessTokenGuard extends AuthGuard("jwt-access") {
@@ -27,7 +28,13 @@ export class AccessTokenGuard extends AuthGuard("jwt-access") {
     return super.canActivate(context)
   }
 
-  handleRequest(err: any, user: any, info: any) {
+  handleRequest<TUser = JwtPayload>(
+    err: any,
+    user: any,
+    info: any,
+    context: ExecutionContext,
+    status?: any
+  ): TUser {
     if (info) {
       if (info instanceof TokenExpiredError) {
         throw new AuthError("액세스 토큰이 만료되었습니다.")

--- a/apps/api/src/auth/guards/refresh-token.guard.ts
+++ b/apps/api/src/auth/guards/refresh-token.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common"
+import { ExecutionContext, Injectable } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
 import { AuthError } from "@repo/api-client"
 import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"

--- a/apps/api/src/auth/guards/refresh-token.guard.ts
+++ b/apps/api/src/auth/guards/refresh-token.guard.ts
@@ -1,21 +1,23 @@
 import { Injectable } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
 import { AuthError } from "@repo/api-client"
+import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
 
 @Injectable()
 export class RefreshTokenGuard extends AuthGuard("jwt-refresh") {
   handleRequest(err: any, user: any, info: any) {
     if (info) {
-      switch (info.name) {
-        case "TokenExpiredError":
-          throw new AuthError("리프레쉬 토큰이 만료되었습니다.")
-        case "JsonWebTokenError":
-          throw new AuthError("유효하지 않은 형식의 리프레쉬 토큰입니다.")
-        default:
-          throw new AuthError(
-            "리프레쉬 토큰 인증 중 알 수 없는 오류가 발생했습니다."
-          )
+      if (info instanceof TokenExpiredError) {
+        throw new AuthError("리프레쉬 토큰이 만료되었습니다.")
       }
+
+      if (info instanceof JsonWebTokenError) {
+        throw new AuthError("유효하지 않은 형식의 리프레쉬 토큰입니다.")
+      }
+
+      throw new AuthError(
+        "리프레쉬 토큰 인증 중 알 수 없는 오류가 발생했습니다."
+      )
     }
 
     // `validate` 함수에서 발생한 에러를 상위로 전파합니다.

--- a/apps/api/src/auth/guards/refresh-token.guard.ts
+++ b/apps/api/src/auth/guards/refresh-token.guard.ts
@@ -6,7 +6,7 @@ import { JwtPayload } from "@repo/shared-types"
 
 @Injectable()
 export class RefreshTokenGuard extends AuthGuard("jwt-refresh") {
-  handleRequest<TUser = JwtPayload>(
+  handleRequest<TUser = JwtPayload & { refreshToken: string }>(
     err: any,
     user: any,
     info: any,

--- a/apps/api/src/auth/guards/refresh-token.guard.ts
+++ b/apps/api/src/auth/guards/refresh-token.guard.ts
@@ -2,10 +2,17 @@ import { Injectable } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
 import { AuthError } from "@repo/api-client"
 import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
+import { JwtPayload } from "@repo/shared-types"
 
 @Injectable()
 export class RefreshTokenGuard extends AuthGuard("jwt-refresh") {
-  handleRequest(err: any, user: any, info: any) {
+  handleRequest<TUser = JwtPayload>(
+    err: any,
+    user: any,
+    info: any,
+    context: ExecutionContext,
+    status?: any
+  ): TUser {
     if (info) {
       if (info instanceof TokenExpiredError) {
         throw new AuthError("리프레쉬 토큰이 만료되었습니다.")


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

- 기존 TokenGuard 에서 Auth 에러 처리를 위해 사용하던 `info handling`을 변경하였습니다.

1. 기존 `info.name`을 직접 비교했던 부분을 `@repo/shared-types`을 이용하여, 내부 클래스와 비교하는 방식으로 변경하였습니다.
2. `handleRequest`에서 기존에 사용되던 TUser 제네릭 타입 선언을 추가하였습니다. TUser 타입은 JWT 인증 시에 PayLoad 형식으로 사용하던 `JwtPayload` 형식을 사용하였습니다.

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #이슈번호
closes #201 

## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
