### PR TITLE
feat(api): Add token-expired-error

### DIFF
--- a/apps/api/src/auth/guards/access-token.guard.ts
+++ b/apps/api/src/auth/guards/access-token.guard.ts
@@ -2,7 +2,7 @@ import { ExecutionContext, Injectable } from "@nestjs/common"
 import { Reflector } from "@nestjs/core"
 import { AuthGuard } from "@nestjs/passport"
 import { IS_PUBLIC_KEY } from "../decorators/public.decorator"
-import { AuthError } from "@repo/api-client"
+import { AuthError, AccessTokenExpiredError } from "@repo/api-client"
 import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
 import { JwtPayload } from "@repo/shared-types"
 
@@ -37,7 +37,7 @@ export class AccessTokenGuard extends AuthGuard("jwt-access") {
   ): TUser {
     if (info) {
       if (info instanceof TokenExpiredError) {
-        throw new AuthError("액세스 토큰이 만료되었습니다.")
+        throw new AccessTokenExpiredError("액세스 토큰이 만료되었습니다.")
       }
 
       if (info instanceof JsonWebTokenError) {

--- a/apps/api/src/auth/guards/refresh-token.guard.ts
+++ b/apps/api/src/auth/guards/refresh-token.guard.ts
@@ -1,6 +1,6 @@
 import { ExecutionContext, Injectable } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
-import { AuthError } from "@repo/api-client"
+import { AuthError, RefreshTokenExpiredError } from "@repo/api-client"
 import { TokenExpiredError, JsonWebTokenError } from "@nestjs/jwt"
 import { JwtPayload } from "@repo/shared-types"
 
@@ -15,7 +15,7 @@ export class RefreshTokenGuard extends AuthGuard("jwt-refresh") {
   ): TUser {
     if (info) {
       if (info instanceof TokenExpiredError) {
-        throw new AuthError("리프레쉬 토큰이 만료되었습니다.")
+        throw new RefreshTokenExpiredError("리프레쉬 토큰이 만료되었습니다.")
       }
 
       if (info instanceof JsonWebTokenError) {

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -258,3 +258,33 @@ export class InvalidPerformanceDateError extends ApiError {
     )
   }
 }
+
+// ----------------------------------
+// Token Specific Errors
+// ----------------------------------
+
+/**
+ * 리프레시 토큰이 유효하지 않거나 만료되었을 때 발생하는 오류입니다.
+ */
+export class RefreshTokenExpiredError extends ApiError {
+  readonly type = "/errors/token/refresh-token-expired"
+  readonly status = 401
+  readonly title = "Refresh Token Expired"
+
+  constructor(detail?: string, instance?: string) {
+    super("리프레시 토큰이 만료되었습니다.", detail, instance)
+  }
+}
+
+/**
+ * 액세스 토큰이 유효하지 않거나 만료되었을 때 발생하는 오류입니다.
+ */
+export class AccessTokenExpiredError extends ApiError {
+  readonly type = "/errors/token/access-token-expired"
+  readonly status = 401
+  readonly title = "Access Token Expired"
+
+  constructor(detail?: string, instance?: string) {
+    super("액세스 토큰이 만료되었습니다.", detail, instance)
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -37,7 +37,9 @@ import {
   SessionNotFoundError,
   UnprocessableEntityError,
   ValidationError,
-  InvalidPerformanceDateError
+  InvalidPerformanceDateError,
+  RefreshTokenExpiredError,
+  AccessTokenExpiredError
 } from "./errors"
 
 /**
@@ -82,6 +84,10 @@ function createErrorFromProblemDocument(problemDoc: ProblemDocument): ApiError {
       return new ReferencedEntityNotFoundError(detail, instance)
     case "/errors/performance/invalid-performance-date":
       return new InvalidPerformanceDateError(detail, instance)
+    case "/errors/token/refresh-token-expired":
+      return new RefreshTokenExpiredError(detail, instance)
+    case "/errors/token/access-token-expired":
+      return new AccessTokenExpiredError(detail, instance)
     default:
       // API 서버에서 알 수 없는 에러가 전달될 경우
       // detail과 instance가 없을 수 있습니다.


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

FE에서 Token 관련 에러를 쉽게 처리할 수 있도록, `Token-Expired-Error` 를 추가하였습니다.

`Token-Expired-Error`는 `Token 가드`가 적용되어 있는 API로 요청을 보내질 때, 해당 토큰이 만료되어 있는 경우에만 발생합니다.
Refresh 토큰과 Access 토큰이 만료되었을 때, 각각 다른 에러를 발생시킵니다.
- Refresh 토큰이 만료되었을 때 - `RefreshTokenExpiredError`
- Access 토큰이 만료되었을 때 - `AccessTokenExpiredError`

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

**기존 에러 Response**
<img width="318" height="192" alt="image" src="https://github.com/user-attachments/assets/2ebc73fe-6677-4cec-bb8c-14b2a929ddaf" />
단순히 `AuthError`를 반환하며, detail을 통해 어떤 종류의 `AuthError` 인지를 파악해야 합니다.

**새롭게 도입된 TokenExpiredError**
<img width="352" height="188" alt="image" src="https://github.com/user-attachments/assets/f2d6a41c-ba50-4510-9639-80bf0ea5b96c" />
<img width="357" height="189" alt="image" src="https://github.com/user-attachments/assets/2541c4fd-7d05-493c-aec2-f187f6cb16cc" />

각 에러의 type 부분을 통해 어떤 종류의 `AuthError` 인지를 바로 파악할 수 있습니다.

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #이슈번호

Closes #212 

## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

이번에는 크게 없을 것 같네요 ㅎㅎ

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
