### PR TITLE
206 reservation mobile

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
@@ -1,13 +1,17 @@
-// MonthBlock.tsx
 import dayjs, { Dayjs } from "dayjs"
+import { Dispatch, SetStateAction } from "react"
 
 interface MobileMonthBlockProps {
+  focusDay: Dayjs
+  setFocusDay: Dispatch<SetStateAction<Dayjs>>
   days: Dayjs[]
   currentMonth: Dayjs
   onSelect?(d: Dayjs): void
 }
 
 export default function MobileMonthBlock({
+  focusDay,
+  setFocusDay,
   days,
   currentMonth
 }: MobileMonthBlockProps) {
@@ -15,14 +19,20 @@ export default function MobileMonthBlock({
     <div className="grid grid-cols-7 border-gray-100">
       {days.map((d, i) => {
         const isThisMonth = d.month() === currentMonth.month()
-        const isToday = d.isSame(dayjs(), "day") // ✅ 오늘 날짜 비교
+        const isToday = d.isSame(dayjs(), "day")
+        const isFocused = d.isSame(focusDay, "day") // ✅ 선택된 날짜 확인
 
         return (
-          <div key={i} className="flex-1 h-12">
+          <div
+            key={i}
+            className="flex-1 flex justify-center items-center h-12"
+            onClick={() => setFocusDay(d)} // ✅ 날짜 클릭 시 focusDay 갱신
+          >
             <div
-              className={`flex h-full font-medium text-base justify-center items-center
-          ${isThisMonth ? "text-black" : "text-neutral-300"} 
-          ${isToday ? "text-third" : ""}`}
+              className={`flex h-2/3 w-[60%] font-medium text-base justify-center items-center cursor-pointer
+                ${isThisMonth ? "text-black" : "text-neutral-300"} 
+                ${isToday ? "text-third" : ""} 
+                ${isFocused ? "bg-blue-50 rounded-full" : ""}`}
             >
               {d.date()}
             </div>

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
@@ -15,7 +15,6 @@ export default function MobileMonthBlock({
     <div className="grid grid-cols-7 border-gray-100">
       {days.map((d, i) => {
         const isThisMonth = d.month() === currentMonth.month()
-        const isToday = d.isSame(new Date(), "day")
         return (
           <div key={i} className="flex-1 h-12">
             <div

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
@@ -1,5 +1,5 @@
 // MonthBlock.tsx
-import { Dayjs } from "dayjs"
+import dayjs, { Dayjs } from "dayjs"
 
 interface MobileMonthBlockProps {
   days: Dayjs[]
@@ -15,11 +15,14 @@ export default function MobileMonthBlock({
     <div className="grid grid-cols-7 border-gray-100">
       {days.map((d, i) => {
         const isThisMonth = d.month() === currentMonth.month()
+        const isToday = d.isSame(dayjs(), "day") // ✅ 오늘 날짜 비교
+
         return (
           <div key={i} className="flex-1 h-12">
             <div
               className={`flex h-full font-medium text-base justify-center items-center
-                ${isThisMonth ? "text-black" : "text-neutral-300"}`}
+          ${isThisMonth ? "text-black" : "text-neutral-300"} 
+          ${isToday ? "text-third" : ""}`}
             >
               {d.date()}
             </div>

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
@@ -1,5 +1,8 @@
-import { Dayjs } from "dayjs"
+"use client"
+
+import dayjs, { Dayjs } from "dayjs"
 import MobileMonthBlock from "./MobileMonthBlock"
+import { useState } from "react"
 
 interface MobileCalendarFieldProps {
   currentMonday: Dayjs
@@ -8,6 +11,7 @@ interface MobileCalendarFieldProps {
 export default function MobileCalendarField({
   currentMonday
 }: MobileCalendarFieldProps) {
+  const [focusDay, setFocusDay] = useState<Dayjs>(dayjs())
   const DayLabel = ["M", "T", "W", "T", "F", "S", "S"]
 
   // 1) 이 달의 첫째 날
@@ -38,7 +42,12 @@ export default function MobileCalendarField({
           </div>
         ))}
       </div>
-      <MobileMonthBlock days={daysInGrid} currentMonth={currentMonth} />
+      <MobileMonthBlock
+        focusDay={focusDay}
+        setFocusDay={setFocusDay}
+        days={daysInGrid}
+        currentMonth={currentMonth}
+      />
     </div>
   )
 }

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
@@ -27,7 +27,7 @@ export default function MobileCalendarField({
     daysInGrid.push(d)
   }
   return (
-    <div className="w-full h-auto px-2 relative flex flex-col mx-auto bg-white pt-16 pb-5">
+    <div className="w-full h-auto px-2 relative flex flex-col mx-auto rounded-lg bg-white pt-16 pb-5">
       <div className="w-full flex">
         {DayLabel.map((Day, i) => (
           <div

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard.tsx
@@ -1,0 +1,22 @@
+import { DateSplit } from "@/lib/utils"
+
+export interface Reservation {
+  start: string
+  end: string
+  user: string
+  title: string
+}
+
+interface MobileMyReservationCardProps {
+  reservation: Reservation
+}
+
+export default function MobileMyReservationCard({
+  reservation
+}: MobileMyReservationCardProps) {
+  return (
+    <div className="w-full rounded-lg flex bg-white h-28">
+      <div className="w-16 h-full">{DateSplit(reservation).day}</div>
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard.tsx
@@ -1,11 +1,7 @@
-import { DateSplit } from "@/lib/utils"
-
-export interface Reservation {
-  start: string
-  end: string
-  user: string
-  title: string
-}
+import { ReservationSplit } from "@/lib/utils"
+import dayjs from "dayjs"
+import { Clock, UserRound } from "lucide-react"
+import { Reservation } from "."
 
 interface MobileMyReservationCardProps {
   reservation: Reservation
@@ -14,9 +10,35 @@ interface MobileMyReservationCardProps {
 export default function MobileMyReservationCard({
   reservation
 }: MobileMyReservationCardProps) {
+  const splitedReservation = ReservationSplit(reservation)
+  const startDay = dayjs(reservation.start).format("YYYY-MM-DD")
+  const today = dayjs().format("YYYY-MM-DD")
+
+  const isToday = startDay === today
   return (
-    <div className="w-full rounded-lg flex bg-white h-28">
-      <div className="w-16 h-full">{DateSplit(reservation).day}</div>
+    <div className="w-full rounded-lg flex bg-white h-24">
+      <div
+        className={`min-w-[84px] flex justify-center items-center flex-col gap-[2px] ${isToday ? `text-third` : `text-neutral-600`}`}
+      >
+        <div className="font-semibold text-base">
+          {splitedReservation.dayOfTheWeek}
+        </div>
+        <div className={`font-semibold text-2xl`}>{splitedReservation.day}</div>
+      </div>
+      <div className="w-[2px] my-3 bg-gray-100" />
+      <div className="w-full h-full flex flex-col justify-center text-gray-600 pl-6">
+        <div className="flex gap-2 text-[10px] items-center">
+          <Clock size={10} />
+          <span className="text-xs">{`${splitedReservation.startTime} - ${splitedReservation.endTime}`}</span>
+        </div>
+        <div className="flex gap-2 text-[10px] items-center">
+          <UserRound size={10} />
+          <span className="text-xs">{reservation.user}</span>
+        </div>
+        <div className="zinc-600 pt-2 text-xs font-semibold">
+          {reservation.title}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileReservationStatusCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileReservationStatusCard.tsx
@@ -1,0 +1,7 @@
+export default function MobileReservationStatusCard() {
+  return (
+    <div>
+      <></>
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileReservationStatusCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/MobileReservationStatusCard.tsx
@@ -1,7 +1,16 @@
 export default function MobileReservationStatusCard() {
   return (
-    <div>
-      <></>
+    <div className="flex w-full pt-5">
+      <div className="flex w-full flex-col">
+        {Array.from({ length: 15 }).map((_, i) => (
+          <div
+            className="min-w-16 w-1/5 h-28 flex justify-center -translate-x-1 font-medium text-[18px] pt-3 text-neutral-700"
+            key={i}
+          >
+            {(i + 7) % 12 === 0 ? "12:00" : ((i + 7) % 12) + ":00"}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/index.tsx
@@ -1,0 +1,98 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import MobileReservationStatusCard from "./MobileReservationStatusCard"
+import MobileMyReservationCard from "./MobileMyReservationCard"
+
+const fakeReservation = [
+  {
+    start: "2025-09-21T09:00:00",
+    end: "2025-09-21T09:59:00",
+    user: "김수연 외 2명",
+    title: "아침 회의"
+  },
+  {
+    start: "2025-09-21T10:30:00",
+    end: "2025-09-21T11:29:00",
+    user: "박지훈 외 1명",
+    title: "스터디 모임"
+  },
+  {
+    start: "2025-09-21T12:00:00",
+    end: "2025-09-21T12:59:00",
+    user: "이민호 외 3명",
+    title: "팀 점심 회식"
+  },
+  {
+    start: "2025-09-21T13:30:00",
+    end: "2025-09-21T14:29:00",
+    user: "최지현",
+    title: "개인 상담"
+  },
+  {
+    start: "2025-09-21T15:00:00",
+    end: "2025-09-21T15:59:00",
+    user: "정은지 외 4명",
+    title: "프로젝트 발표 연습"
+  },
+  {
+    start: "2025-09-21T16:00:00",
+    end: "2025-09-21T16:59:00",
+    user: "오세훈 외 2명",
+    title: "스터디 그룹"
+  },
+  {
+    start: "2025-09-21T17:30:00",
+    end: "2025-09-21T18:29:00",
+    user: "김유진 외 1명",
+    title: "과제 토론"
+  },
+  {
+    start: "2025-09-21T18:30:00",
+    end: "2025-09-21T19:29:00",
+    user: "박민지 외 3명",
+    title: "저녁 회식"
+  },
+  {
+    start: "2025-09-21T19:30:00",
+    end: "2025-09-21T20:29:00",
+    user: "이도현",
+    title: "개인 연구"
+  },
+  {
+    start: "2025-09-21T21:00:00",
+    end: "2025-09-21T21:59:00",
+    user: "윤아람 외 2명",
+    title: "동아리 모임"
+  }
+]
+
+export default function MobileReservationField() {
+  return (
+    <Tabs defaultValue="reservationStatus" className="w-full">
+      <TabsList className="flex h-14 *:h-full *:text-lg bg-neutral-50 justify-center gap-3">
+        <TabsTrigger
+          value="reservationStatus"
+          className="flex-1 data-[state=active]:bg-third rounded-xl data-[state=active]:text-white bg-white text-neutral-700"
+        >
+          예약 현황
+        </TabsTrigger>
+        <TabsTrigger
+          value="myReservations"
+          className="flex-1 data-[state=active]:bg-third rounded-xl data-[state=active]:text-white bg-white text-neutral-700"
+        >
+          나의 예약
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="reservationStatus" className="w-full">
+        <MobileReservationStatusCard />
+      </TabsContent>
+      <TabsContent
+        value="myReservations"
+        className="w-full flex flex-col gap-3"
+      >
+        {fakeReservation.map((reservation, i) => (
+          <MobileMyReservationCard key={i} reservation={reservation} />
+        ))}
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileReservationField/index.tsx
@@ -2,73 +2,23 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import MobileReservationStatusCard from "./MobileReservationStatusCard"
 import MobileMyReservationCard from "./MobileMyReservationCard"
 
-const fakeReservation = [
-  {
-    start: "2025-09-21T09:00:00",
-    end: "2025-09-21T09:59:00",
-    user: "김수연 외 2명",
-    title: "아침 회의"
-  },
-  {
-    start: "2025-09-21T10:30:00",
-    end: "2025-09-21T11:29:00",
-    user: "박지훈 외 1명",
-    title: "스터디 모임"
-  },
-  {
-    start: "2025-09-21T12:00:00",
-    end: "2025-09-21T12:59:00",
-    user: "이민호 외 3명",
-    title: "팀 점심 회식"
-  },
-  {
-    start: "2025-09-21T13:30:00",
-    end: "2025-09-21T14:29:00",
-    user: "최지현",
-    title: "개인 상담"
-  },
-  {
-    start: "2025-09-21T15:00:00",
-    end: "2025-09-21T15:59:00",
-    user: "정은지 외 4명",
-    title: "프로젝트 발표 연습"
-  },
-  {
-    start: "2025-09-21T16:00:00",
-    end: "2025-09-21T16:59:00",
-    user: "오세훈 외 2명",
-    title: "스터디 그룹"
-  },
-  {
-    start: "2025-09-21T17:30:00",
-    end: "2025-09-21T18:29:00",
-    user: "김유진 외 1명",
-    title: "과제 토론"
-  },
-  {
-    start: "2025-09-21T18:30:00",
-    end: "2025-09-21T19:29:00",
-    user: "박민지 외 3명",
-    title: "저녁 회식"
-  },
-  {
-    start: "2025-09-21T19:30:00",
-    end: "2025-09-21T20:29:00",
-    user: "이도현",
-    title: "개인 연구"
-  },
-  {
-    start: "2025-09-21T21:00:00",
-    end: "2025-09-21T21:59:00",
-    user: "윤아람 외 2명",
-    title: "동아리 모임"
-  }
-]
+export interface Reservation {
+  start: string
+  end: string
+  user: string
+  title: string
+}
 
-export default function MobileReservationField() {
+interface MobileMyReservationFieldProps {
+  myReservation: Reservation[]
+}
+
+export default function MobileReservationField({
+  myReservation
+}: MobileMyReservationFieldProps) {
   return (
     <Tabs defaultValue="reservationStatus" className="w-full">
-      <TabsList className="flex h-14 *:h-full *:text-lg bg-neutral-50 justify-center gap-3">
+      <TabsList className="flex h-14 *:h-full *:text-md *:min-[400px]:text-lg bg-neutral-50 justify-center gap-3">
         <TabsTrigger
           value="reservationStatus"
           className="flex-1 data-[state=active]:bg-third rounded-xl data-[state=active]:text-white bg-white text-neutral-700"
@@ -89,7 +39,7 @@ export default function MobileReservationField() {
         value="myReservations"
         className="w-full flex flex-col gap-3"
       >
-        {fakeReservation.map((reservation, i) => (
+        {myReservation.map((reservation, i) => (
           <MobileMyReservationCard key={i} reservation={reservation} />
         ))}
       </TabsContent>

--- a/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/ReservationCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/ReservationCard.tsx
@@ -1,23 +1,42 @@
 import { Clock, UserRound } from "lucide-react"
+import { Reservation } from "../MobileReservationField"
+import { ReservationSplit } from "@/lib/utils"
+import dayjs from "dayjs"
 
-export default function ReservationCard() {
+interface ReservationCardProps {
+  reservation: Reservation
+}
+
+export default function ReservationCard({ reservation }: ReservationCardProps) {
+  const splitedReservation = ReservationSplit(reservation)
+  const startDay = dayjs(reservation.start).format("YYYY-MM-DD")
+  const today = dayjs().format("YYYY-MM-DD")
+  const isToday = startDay === today
   return (
     <div className="w-full h-20 flex items-center bg-neutral-50 rounded-md">
-      <div className="w-[74px] text-zinc-700 flex flex-col items-center justify-center h-full">
-        <span className="text-base font-semibold leading-tight">Mon</span>
-        <span className="text-2xl font-semibold leading-8">07</span>
+      <div
+        className={`w-[74px] ${isToday ? `*:text-third` : `*:text-neutral-600`} text-zinc-700 flex flex-col items-center justify-center h-full`}
+      >
+        <span className="text-base font-semibold leading-tight">
+          {splitedReservation.dayOfTheWeek}
+        </span>
+        <span className="text-2xl font-semibold leading-8">
+          {splitedReservation.day}
+        </span>
       </div>
       <div className="w-[1px] h-2/3 bg-gray-200" />
       <div className="flex-1 text-zinc-600 gap-[2px] flex-col justify-center flex pl-5 h-full">
         <div className="flex justify-start gap-2 items-center">
           <Clock size={12} />
-          <span className="text-[10px] font-normal">12:00AM - 11:59PM</span>
+          <span className="text-[10px] font-normal">{`${splitedReservation.startTime} - ${splitedReservation.endTime}`}</span>
         </div>
         <div className="flex justify-start gap-2 items-center">
           <UserRound size={12} />
-          <span className="text-[10px] font-normal">김수연 외 3명</span>
+          <span className="text-[10px] font-normal">{reservation.user}</span>
         </div>
-        <span className="text-zinc-600 font-semibold text-xs">밤편지 합주</span>
+        <span className="text-zinc-600 font-semibold text-xs">
+          {reservation.title}
+        </span>
       </div>
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/index.tsx
@@ -1,6 +1,13 @@
+import { Reservation } from "../MobileReservationField"
 import ReservationCard from "./ReservationCard"
 
-export default function MyReservationField() {
+interface MyReservationFieldProps {
+  myReservation: Reservation[]
+}
+
+export default function MyReservationField({
+  myReservation
+}: MyReservationFieldProps) {
   const monthNames = [
     "January",
     "February",
@@ -26,7 +33,9 @@ export default function MyReservationField() {
       </span>
       <div className="w-full flex flex-col pt-3 gap-[10px]">
         {/* TODO: API 연결 시, map 함수 도입 */}
-        <ReservationCard />
+        {myReservation.map((reservation, i) => (
+          <ReservationCard key={i} reservation={reservation} />
+        ))}
       </div>
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/clubroom/page.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/page.tsx
@@ -13,6 +13,7 @@ import isoWeek from "dayjs/plugin/isoWeek"
 import WeekLabel from "../_components/WeekLable"
 import MonthCalendarField from "../_components/MonthCalendarField"
 import MobileCalendarField from "../_components/MobileCalendarField"
+import MobileReservationField from "../_components/MobileReservationField"
 dayjs.extend(isoWeek)
 
 const ReservationPage = () => {
@@ -111,6 +112,9 @@ const ReservationPage = () => {
           mode="month"
           className="top-12 flex justify-between w-full px-5"
         />
+      </div>
+      <div className="mx-auto max-w-[400px] md:hidden pt-3">
+        <MobileReservationField />
       </div>
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/clubroom/page.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/page.tsx
@@ -44,6 +44,52 @@ const ReservationPage = () => {
   const daysInCalendar = Array.from({ length: 42 }, (_, i) =>
     calendarStart.add(i, "day")
   )
+
+  const fakeReservation = [
+    {
+      start: "2025-09-27T09:00:00",
+      end: "2025-09-27T09:59:00",
+      user: "김수연 외 2명",
+      title: "아침 회의"
+    },
+    {
+      start: "2025-09-28T10:30:00",
+      end: "2025-09-28T11:29:00",
+      user: "박지훈 외 1명",
+      title: "스터디 모임"
+    },
+    {
+      start: "2025-09-28T12:00:00",
+      end: "2025-09-28T12:59:00",
+      user: "이민호 외 3명",
+      title: "팀 점심 회식"
+    },
+    {
+      start: "2025-09-28T13:30:00",
+      end: "2025-09-28T14:29:00",
+      user: "최지현",
+      title: "개인 상담"
+    },
+    {
+      start: "2025-09-28T15:00:00",
+      end: "2025-09-28T15:59:00",
+      user: "정은지 외 4명",
+      title: "프로젝트 발표 연습"
+    },
+    {
+      start: "2025-09-28T16:00:00",
+      end: "2025-09-28T16:59:00",
+      user: "오세훈 외 2명",
+      title: "스터디 그룹"
+    },
+    {
+      start: "2025-09-28T17:30:00",
+      end: "2025-09-28T18:29:00",
+      user: "김유진 외 1명",
+      title: "과제 토론"
+    }
+  ]
+
   return (
     <div>
       <DefaultPageHeader
@@ -57,7 +103,7 @@ const ReservationPage = () => {
       {/* PC 페이지 */}
       <div className={`w-full min-h-[739px] hidden md:flex gap-5`}>
         <div className="w-1/4">
-          <MyReservationField />
+          <MyReservationField myReservation={fakeReservation} />
         </div>
         <div className="w-3/4">
           <Tabs defaultValue="week">
@@ -114,7 +160,7 @@ const ReservationPage = () => {
         />
       </div>
       <div className="mx-auto max-w-[400px] md:hidden pt-3">
-        <MobileReservationField />
+        <MobileReservationField myReservation={fakeReservation} />
       </div>
     </div>
   )

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,3 +1,4 @@
+import { Reservation } from "@/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -56,5 +57,16 @@ export function getRepresentativeRelativeTime(date: Date | string) {
     return `${diffMonths}개월 전`
   } else {
     return `${diffYears}년 전`
+  }
+}
+
+export function DateSplit(reservation: Reservation) {
+  const date = new Date(reservation.start)
+
+  return {
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+    startTime: `${date.getHours()}:${date.getMinutes()}`,
+    endTime: `${new Date(reservation.end).getHours()}:${new Date(reservation.end).getMinutes()}`
   }
 }

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Reservation } from "@/app/(general)/(light)/reservations/_components/MobileReservationField/MobileMyReservationCard"
+import { Reservation } from "@/app/(general)/(light)/reservations/_components/MobileReservationField"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -60,13 +60,24 @@ export function getRepresentativeRelativeTime(date: Date | string) {
   }
 }
 
-export function DateSplit(reservation: Reservation) {
+export function ReservationSplit(reservation: Reservation) {
   const date = new Date(reservation.start)
 
   return {
     month: date.getMonth() + 1,
     day: date.getDate(),
-    startTime: `${date.getHours()}:${date.getMinutes()}`,
-    endTime: `${new Date(reservation.end).getHours()}:${new Date(reservation.end).getMinutes()}`
+    startTime: `${date.getHours()}:${date.getMinutes()}${date.getMinutes() == 0 ? "0" : ""}`,
+    endTime: `${new Date(reservation.end).getHours()}:${new Date(reservation.end).getMinutes()}`,
+    dayOfTheWeek: dayOfTheWeekList[date.getDay()]
   }
+}
+
+const dayOfTheWeekList: { [key: number]: string } = {
+  0: "Mon",
+  1: "Tue",
+  2: "Wed",
+  3: "Thu",
+  4: "Fri",
+  5: "Sat",
+  6: "Sun"
 }


### PR DESCRIPTION

## 🚀 작업 내용

자원예약 페이지의 모바일 UI를 어느정도 완성하였습니다.

## 📸 스크린샷(선택)

<img width="393" height="840" alt="image" src="https://github.com/user-attachments/assets/289a269b-21b0-4830-a68c-b549d337cd66" />
<img width="393" height="835" alt="image" src="https://github.com/user-attachments/assets/c7567666-9b25-4869-9945-5d77ea21fe92" />

## 🔗 관련 이슈

close #206 

## 🙏 리뷰어에게

> UI를 어느정도 갖춰놓은 상태이고, 이후에 백엔드가 어느정도 완성되면 데이터를 가져와서 표시하는 로직을 완성하려 합니다.
> '나의 예약현황'은 데이터를 Fetch 해오기만 하면 바로 완성되는 상태입니다
> Add Schedule을 하는 과정과, 이를 백앤드에 보낸 뒤 다시 fetch해오는 과정은 아직 완성되지 않았습니다.
> 일단 컴포넌트 UI를 반영하는 이슈를 빠르게 중간고사 전까지 처리하려고 노력하고, 그 컴포넌트들을 가지고 Add Schedule까지 완성하겠습니다.

## ✅ 체크리스트

- ✅ conventional commits 형식을 따르는 title을 작성했습니다.
- ✅ 적절한 label을 1개 이상 추가했습니다.
- ✅ 관련 이슈가 연결되었습니다.
