### PR TITLE
feat: 팀 생성 폼 개선 및 세션 ID 가져오는 유틸리티 함수 추가

### DIFF
--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,3 +1,4 @@
+import { SessionList } from "@repo/shared-types"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -56,4 +57,15 @@ export function getRepresentativeRelativeTime(date: Date | string) {
   } else {
     return `${diffYears}년 전`
   }
+}
+
+export function getSessionIdBySessionName(
+  sessionName: string,
+  sessions: SessionList
+): number {
+  const session = sessions.find((s) => s.name === sessionName)
+  if (!session) {
+    throw new Error(`세션을 찾을 수 없습니다: ${sessionName}`)
+  }
+  return session.id
 }


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

이제 팀 생성이 가능해집니다!
이전 Django 사용 때와는 다르게 세션 ID를 동적으로 서버에서 받아와서 매핑합니다.

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

<img width="290" height="191" alt="image" src="https://github.com/user-attachments/assets/0df48957-4f08-448f-923e-a0a933e6637f" />

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #이슈번호

related to #186 

## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

## ✅ 체크리스트

- [ ] conventional commits 형식을 따르는 title을 작성했습니다.
- [ ] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.
