### PR TITLE
fix: 팀 상세 페이지 렌더링 에러 수정

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton.tsx
@@ -10,21 +10,18 @@ import { cn } from "@/lib/utils"
 import { type SessionName } from "@repo/database"
 
 interface ApplyButtonProps {
-  session: SessionName
-  memberSessionIndex: number
-  selectedSessionsWithIndex: string[]
-  toggleSelectedSessionWithIndex: (memberSessionWithWithIndex: string) => void
+  sessionName: SessionName
+  sessionIndex: number
+  isSelected: boolean
+  onToggle: () => void
 }
 
 const ApplyButton = ({
-  session,
-  memberSessionIndex,
-  selectedSessionsWithIndex,
-  toggleSelectedSessionWithIndex
+  sessionName,
+  sessionIndex,
+  isSelected,
+  onToggle
 }: ApplyButtonProps) => {
-  const memberSessionWithIndex = `${session}__${memberSessionIndex}`
-  const isSelected = selectedSessionsWithIndex.includes(memberSessionWithIndex)
-
   const [isLargeScreen, setIsLargeScreen] = useState(false) // 768px 이상
   const [isMediumScreen, setIsMediumScreen] = useState(false) // 410px 이상
   const [isSmallScreen, setIsSmallScreen] = useState(false) // 410px 이하
@@ -49,10 +46,7 @@ const ApplyButton = ({
   }, [])
 
   return (
-    <button
-      className="relative h-full w-full"
-      onClick={() => toggleSelectedSessionWithIndex(memberSessionWithIndex)}
-    >
+    <button className="relative h-full w-full" onClick={onToggle}>
       <div
         className={cn(
           "relative flex h-[100px] w-full items-center overflow-hidden rounded bg-slate-50 max-[470px]:h-[60px] md:h-[160px] md:w-[250px] md:overflow-visible",
@@ -65,10 +59,10 @@ const ApplyButton = ({
         <Image
           src={
             isSelected
-              ? SESSIONIMAGE.PRESSED[session]
-              : SESSIONIMAGE.UNPRESSED[session]
+              ? SESSIONIMAGE.PRESSED[sessionName]
+              : SESSIONIMAGE.UNPRESSED[sessionName]
           }
-          alt={`${session} session image`}
+          alt={`${sessionName} session image`}
           className="absolute left-0 top-0"
           // 화면 크기에 따라 width와 height 설정
           width={
@@ -93,8 +87,8 @@ const ApplyButton = ({
         />
         {/* 세션명 */}
         <div className="absolute right-[8px] z-10 text-center text-sm font-semibold text-slate-600 md:right-[16px] md:text-2xl">
-          {session}
-          {memberSessionIndex}
+          {sessionName}
+          {sessionIndex}
         </div>
       </div>
       <div

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
@@ -2,18 +2,16 @@ import DeleteEditButton from "@/app/(general)/(dark)/performances/[id]/teams/[te
 import FreshmenFixedBadge from "@/components/TeamBadges/FreshmenFixedBadge"
 import StatusBadge from "@/components/TeamBadges/StatusBadge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import {
-  formatGenerationOrder,
-  getRepresentativeRelativeTime
-} from "@/lib/utils"
-import { MemberSessionSet, Team } from "@repo/shared-types"
+import { isTeamSatisfied } from "@/lib/team/teamSession"
+import { getRepresentativeRelativeTime } from "@/lib/utils"
+import { TeamDetail } from "@repo/shared-types"
 
 interface BasicInfoProps {
-  team: Team
+  team: TeamDetail
 }
 
 const BasicInfo = ({ team }: BasicInfoProps) => {
-  const memberSessionSet = new MemberSessionSet(team.memberSessions ?? [])
+  const isSatisfied = isTeamSatisfied(team.teamSessions ?? [])
 
   return (
     <div className="relative h-fit w-full rounded-2xl bg-white px-10 py-14 text-lg font-semibold shadow-md md:w-[466px] md:px-[40px] md:py-[60px]">
@@ -35,11 +33,10 @@ const BasicInfo = ({ team }: BasicInfoProps) => {
       {/* 팀장 */}
       <div className="mb-6 flex items-center justify-start gap-x-[8px] md:mb-[24px] md:gap-x-[10px]">
         <Avatar className="h-[24px] w-[24px] md:h-[48px] md:w-[48px]">
-          <AvatarImage src="https://github.com/shadcn.png" />
+          <AvatarImage src={team.leader?.image ?? undefined} />
           <AvatarFallback>{team.leader?.name.substring(0, 1)}</AvatarFallback>
         </Avatar>
         <div className="text-xs font-medium leading-3 text-primary md:text-base">
-          {formatGenerationOrder(team.leader.generation.order)}기&nbsp;
           {team.leader.name}
         </div>
         <div className=" text-xs font-light leading-3 text-gray-400 md:text-base md:font-normal">
@@ -54,7 +51,7 @@ const BasicInfo = ({ team }: BasicInfoProps) => {
             {team.songName}
           </h3>
           <StatusBadge
-            status={memberSessionSet.isSatisfied ? "Inactive" : "Active"}
+            status={isSatisfied ? "Inactive" : "Active"}
             className="mb-1 h-5 w-20 justify-center max-sm:text-xs md:h-[32px] md:w-[130px]"
           />
         </div>

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/DeleteEditButton.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/DeleteEditButton.tsx
@@ -6,11 +6,11 @@ import Link from "next/link"
 import TeamDeleteButton from "@/components/TeamDeleteButton"
 import { Button } from "@/components/ui/button"
 import ROUTES from "@/constants/routes"
-import { Team } from "@repo/shared-types"
+import { TeamDetail } from "@repo/shared-types"
 
 interface DeleteEditButtonProps {
   performanceId: number
-  team: Team
+  team: TeamDetail
   className?: string
   accessToken?: string
 }
@@ -22,7 +22,7 @@ const DeleteEditButton = ({ team, className }: DeleteEditButtonProps) => {
       <Button asChild variant="outline" className="px-2 py-1 shadow">
         <Link
           className="text-white hover:animate-none"
-          href={ROUTES.PERFORMANCE.TEAM.EDIT(team.performance.id, team.id)}
+          href={ROUTES.PERFORMANCE.TEAM.EDIT(team.performanceId, team.id)}
         >
           <Edit3 strokeWidth={1} size={20} className="text-gray-600" />
         </Link>
@@ -31,7 +31,7 @@ const DeleteEditButton = ({ team, className }: DeleteEditButtonProps) => {
       {/* 삭제 버튼 */}
       <TeamDeleteButton
         teamId={team.id}
-        redirectUrl={ROUTES.PERFORMANCE.TEAM.LIST(team.performance.id)}
+        redirectUrl={ROUTES.PERFORMANCE.TEAM.LIST(team.performanceId)}
       >
         <div className="rounded-md border p-2 shadow transition-colors hover:bg-accent">
           <Trash2 strokeWidth={1} size={20} className="text-gray-600" />

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -3,18 +3,19 @@ import { useSession } from "next-auth/react"
 
 import useTeamApplication from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { formatGenerationOrder } from "@/lib/utils"
 import { SessionName } from "@repo/database"
-import { Team, User } from "@repo/shared-types"
+import { TeamDetail } from "@repo/shared-types"
+
+type TeamMember = TeamDetail["teamSessions"][number]["members"][number]["user"]
 
 interface MemberSessionCardProps {
   teamId: number
   sessionId: number
   sessionName: SessionName
   sessionIndex: number
-  user: User
+  user: TeamMember
   // eslint-disable-next-line no-unused-vars
-  onUnapplySuccess: (team: Team) => void
+  onUnapplySuccess: (team: TeamDetail) => void
 }
 
 // TODO: Table으로 변경
@@ -56,8 +57,7 @@ const MemberSessionCard = ({
             {sessionIndex}
           </div>
           <div className="text-sm font-normal leading-3 text-slate-700 md:text-xl md:font-medium md:leading-relaxed">
-            {/* TODO: Prisma 타입에서 외래 키인 `generation` 타입 추론 가능하게 설정 */}
-            {formatGenerationOrder(user.generationId)}기 {user.name}
+            {user.name}
           </div>
           <div className="hidden text-sm text-gray-400 md:block">
             #{user.nickname}
@@ -65,7 +65,7 @@ const MemberSessionCard = ({
         </div>
 
         {/* 탈퇴 버튼 */}
-        {user.id.toString() === authSession.data?.id && (
+        {user.id.toString() === authSession.data?.user.id && (
           <button
             className="absolute right-0 flex h-6 w-6 justify-center rounded-full bg-destructive "
             onClick={handleUnapply}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
@@ -1,5 +1,6 @@
 import { useToast } from "@/components/hooks/use-toast"
-import { useTeamApplication as useTeamApplicationOriginal } from "@/hooks/api/useTeam"
+import { useApplyToTeam } from "@/hooks/api/useTeam"
+import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 
 type SelectedSessionWithIndex = {
@@ -9,10 +10,28 @@ type SelectedSessionWithIndex = {
 
 const useTeamApplication = (teamId: number) => {
   const { toast } = useToast()
-  const teamApplication = useTeamApplicationOriginal(teamId)
+  const queryClient = useQueryClient()
   const [selectedSessions, setSelectedSessions] = useState<
     SelectedSessionWithIndex[]
   >([])
+
+  const applyMutation = useApplyToTeam({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["team", teamId] })
+      toast({
+        title: "지원 완료",
+        description: "팀에 지원이 완료되었습니다."
+      })
+      setSelectedSessions([])
+    },
+    onError: () => {
+      toast({
+        title: "지원 실패",
+        description: "팀 지원 중 오류가 발생했습니다.",
+        variant: "destructive"
+      })
+    }
+  })
 
   const isSelected = (sessionId: number, index: number) => {
     return selectedSessions.some(
@@ -49,7 +68,7 @@ const useTeamApplication = (teamId: number) => {
   }
 
   const onSubmit = async () => {
-    teamApplication.mutateAsync(selectedSessions)
+    await applyMutation.mutateAsync([teamId, selectedSessions])
   }
 
   return {

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
@@ -74,6 +74,7 @@ const useTeamApplication = (teamId: number) => {
   return {
     selectedSessions,
     setSelectedSessions,
+    isSelected,
     onAppendSession,
     onRemoveSession,
     onSubmit

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -6,15 +6,19 @@ import { useSession } from "next-auth/react"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
 
+import ApplyButton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton"
 import BasicInfo from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo"
 import DeleteEditButton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/DeleteEditButton"
+import MemberSessionCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard"
 import SessionSetCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard"
 import Loading from "@/app/_(errors)/Loading"
 import NotFoundPage from "@/app/_(errors)/NotFound"
 import OleoPageHeader from "@/components/PageHeaders/OleoPageHeader"
 import SessionBadge from "@/components/TeamBadges/SessionBadge"
+import { Button } from "@/components/ui/button"
 import ROUTES from "@/constants/routes"
 import { useTeam } from "@/hooks/api/useTeam"
+import { getMissingIndices } from "@/lib/team/teamSession"
 import YoutubePlayer from "@/lib/youtube/Player"
 import useTeamApplication from "./_hooks/useTeamApplication"
 
@@ -33,7 +37,13 @@ const TeamDetail = (props: TeamDetailProps) => {
   const id = props.params.teamId
 
   const { data: team, isLoading, isError } = useTeam(id)
-  const { selectedSessions } = useTeamApplication(id)
+  const {
+    selectedSessions,
+    isSelected,
+    onAppendSession,
+    onRemoveSession,
+    onSubmit
+  } = useTeamApplication(id)
 
   if (session.status === "unauthenticated") router.push(ROUTES.LOGIN)
 
@@ -112,24 +122,28 @@ const TeamDetail = (props: TeamDetailProps) => {
         {/* 세션 구성 */}
         <div className="flex h-full w-[93%] flex-col gap-y-5 md:w-[662px]">
           {/* 세션 구성 */}
-          {team.teamSessions && (
+          {team.teamSessions && team.teamSessions.length > 0 && (
             <SessionSetCard
               header="세션구성"
               className="h-fit bg-white shadow-md"
             >
               <div className="flex flex-wrap gap-x-2 gap-y-2 pt-[20px] md:pt-[40px]">
-                {team.teamSessions.map((ts) =>
-                  ts.members.map((member) => {
-                    const sessionWithIndex = `${ts.session.name}${member.index}`
+                {team.teamSessions.map((ts) => {
+                  // capacity만큼의 슬롯을 모두 표시 (1부터 capacity까지)
+                  return Array.from(
+                    { length: ts.capacity },
+                    (_, i) => i + 1
+                  ).map((index) => {
+                    const sessionWithIndex = `${ts.session.name}${index}`
                     return (
                       <SessionBadge
-                        key={sessionWithIndex}
+                        key={`${ts.session.id}-${index}`}
                         session={sessionWithIndex}
                         className="h-[22px] w-[56px] justify-center rounded bg-slate-200 px-[5px] py-[6px] text-xs hover:bg-slate-300 md:h-[34px] md:w-[74px] md:rounded-[20px] md:text-base"
                       />
                     )
                   })
-                )}
+                })}
               </div>
             </SessionSetCard>
           )}
@@ -149,6 +163,24 @@ const TeamDetail = (props: TeamDetailProps) => {
                 </div>
               </div>
               <Separator className="hidden h-[1.5px] w-full bg-slate-200 md:block" />
+              {team.teamSessions?.map((ts) =>
+                ts.members.map((member) => (
+                  <MemberSessionCard
+                    key={`${ts.session.id}-${member.index}`}
+                    teamId={id}
+                    sessionId={ts.session.id}
+                    sessionName={ts.session.name}
+                    sessionIndex={member.index}
+                    user={member.user}
+                    onUnapplySuccess={() => {}}
+                  />
+                ))
+              )}
+              {team.teamSessions?.every((ts) => ts.members.length === 0) && (
+                <div className="py-4 text-center text-sm text-gray-400">
+                  아직 참여한 멤버가 없습니다.
+                </div>
+              )}
             </div>
           </SessionSetCard>
 
@@ -167,6 +199,46 @@ const TeamDetail = (props: TeamDetailProps) => {
                 수 있습니다
               </li>
             </ul>
+
+            {/* 빈 자리 세션 버튼들 */}
+            <div className="grid grid-cols-2 gap-3 md:flex md:flex-wrap">
+              {team.teamSessions?.map((ts) => {
+                const missingIndices = getMissingIndices(ts)
+                return missingIndices.map((index) => {
+                  const selected = isSelected(ts.session.id, index)
+                  return (
+                    <ApplyButton
+                      key={`apply-${ts.session.id}-${index}`}
+                      sessionName={ts.session.name}
+                      sessionIndex={index}
+                      isSelected={selected}
+                      onToggle={() => {
+                        if (selected) {
+                          onRemoveSession(ts.session.id, index)
+                        } else {
+                          onAppendSession(ts.session.id, index)
+                        }
+                      }}
+                    />
+                  )
+                })
+              })}
+            </div>
+
+            {/* 지원하기 버튼 */}
+            {selectedSessions.length > 0 && (
+              <Button className="mt-6 w-full" onClick={onSubmit}>
+                선택한 세션에 지원하기 ({selectedSessions.length}개)
+              </Button>
+            )}
+
+            {team.teamSessions?.every(
+              (ts) => getMissingIndices(ts).length === 0
+            ) && (
+              <div className="py-4 text-center text-sm text-gray-400">
+                모든 세션이 마감되었습니다.
+              </div>
+            )}
           </SessionSetCard>
         </div>
       </div>

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -78,13 +78,14 @@ const TeamDetail = (props: TeamDetailProps) => {
 
       {/*수정 및 삭제 (모바일)*/}
       {session.data &&
-        (session.data.isAdmin ||
-          (session.data.id && +session.data.id === team.leaderId)) && (
+        (session.data.user.isAdmin ||
+          (session.data.user.id &&
+            +session.data.user.id === team.leaderId)) && (
           <div className="block h-auto w-[93%] justify-items-end pb-5  md:hidden  min-[878px]:w-11/12 lg:w-5/6">
             <DeleteEditButton
               performanceId={performanceId}
               team={team}
-              accessToken={session.data?.access}
+              accessToken={session.data?.accessToken}
             />
           </div>
         )}
@@ -111,31 +112,24 @@ const TeamDetail = (props: TeamDetailProps) => {
         {/* 세션 구성 */}
         <div className="flex h-full w-[93%] flex-col gap-y-5 md:w-[662px]">
           {/* 세션 구성 */}
-          {team.memberSessions && (
+          {team.teamSessions && (
             <SessionSetCard
               header="세션구성"
               className="h-fit bg-white shadow-md"
             >
               <div className="flex flex-wrap gap-x-2 gap-y-2 pt-[20px] md:pt-[40px]">
-                {team.memberSessions
-                  .sort((a, b) => {
+                {team.teamSessions.map((ts) =>
+                  ts.members.map((member) => {
+                    const sessionWithIndex = `${ts.session.name}${member.index}`
                     return (
-                      SessionOrder.indexOf(a.session) -
-                      SessionOrder.indexOf(b.session)
+                      <SessionBadge
+                        key={sessionWithIndex}
+                        session={sessionWithIndex}
+                        className="h-[22px] w-[56px] justify-center rounded bg-slate-200 px-[5px] py-[6px] text-xs hover:bg-slate-300 md:h-[34px] md:w-[74px] md:rounded-[20px] md:text-base"
+                      />
                     )
                   })
-                  .map((ms) =>
-                    ms.members.map((_, index) => {
-                      const sessionWithIndex = `${ms.session}${index + 1}`
-                      return (
-                        <SessionBadge
-                          key={sessionWithIndex}
-                          session={sessionWithIndex}
-                          className="h-[22px] w-[56px] justify-center rounded bg-slate-200 px-[5px] py-[6px] text-xs hover:bg-slate-300 md:h-[34px] md:w-[74px] md:rounded-[20px] md:text-base"
-                        />
-                      )
-                    })
-                  )}
+                )}
               </div>
             </SessionSetCard>
           )}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
@@ -288,7 +288,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
         isFreshmenFixed: firstPageForm.getValues("isFreshmenFixed") ?? false,
         isSelfMade: firstPageForm.getValues("isSelfMade") ?? false
       }
-      mutateTeamCreate(createData)
+      mutateTeamCreate([createData])
     } else {
       const updateData: UpdateTeam = {
         name: initialData.name,
@@ -303,7 +303,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
         isFreshmenFixed: firstPageForm.getValues("isFreshmenFixed") ?? false,
         isSelfMade: firstPageForm.getValues("isSelfMade") ?? false
       }
-      mutateTeamUpdate(initialData.id, updateData)
+      mutateTeamUpdate([initialData.id, updateData])
     }
 
     if (isError || !data) {

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/DeleteButton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/DeleteButton.tsx
@@ -27,7 +27,7 @@ const TeamCardDeleteButton = ({
   const deleteTeam = useDeleteTeam()
 
   const onDelete = async () => {
-    const res = await deleteTeam.mutateAsync(teamId)
+    const res = await deleteTeam.mutateAsync([teamId])
     if (res) {
       setIsOpen(false)
     }

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton.tsx
@@ -13,7 +13,7 @@ const DeleteButton = ({ children, className, teamId }: DeleteButtonProps) => {
   const { mutateAsync, error, isError } = useDeleteTeam()
 
   const onDelete = async () => {
-    await mutateAsync(teamId)
+    await mutateAsync([teamId])
     if (isError) {
       console.error("팀 삭제 오류:", error)
       alert("팀 삭제에 실패했습니다. 다시 시도해주세요.")

--- a/apps/web/app/(general)/(light)/performances/_components/PerformanceForm.tsx
+++ b/apps/web/app/(general)/(light)/performances/_components/PerformanceForm.tsx
@@ -34,7 +34,7 @@ const PerformanceForm = () => {
 
   async function onSubmit(formData: z.infer<typeof CreatePerformanceSchema>) {
     formData.posterImage = formData.posterImage || undefined
-    mutate(formData)
+    mutate([formData])
 
     if (isError || data === undefined) {
       toast({

--- a/apps/web/components/TeamDeleteButton.tsx
+++ b/apps/web/components/TeamDeleteButton.tsx
@@ -33,7 +33,7 @@ const TeamDeleteButton = ({
   const deleteTeam = useDeleteTeam()
 
   const onDelete = async () => {
-    const res = await deleteTeam.mutateAsync(teamId)
+    const res = await deleteTeam.mutateAsync([teamId])
     if (res) {
       setIsOpen(false)
       router.push(redirectUrl)

--- a/apps/web/hooks/useCustomQuery.ts
+++ b/apps/web/hooks/useCustomQuery.ts
@@ -98,7 +98,7 @@ export function createMutationHook<
   type TRawData = ApiSuccessType<TApiFn>
   type TData = TMappedData
   type TError = ApiErrorType<TApiFn>
-  type TVariables = Parameters<TApiFn>[0]
+  type TVariables = Parameters<TApiFn>
 
   return (
     options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationFn">
@@ -107,7 +107,7 @@ export function createMutationHook<
 
     return useMutation<TData, TError, TVariables>({
       mutationFn: async (variables: TVariables) => {
-        const rawData = (await apiFn.bind(apiClient)(variables)) as TRawData
+        const rawData = (await apiFn.bind(apiClient)(...variables)) as TRawData
         return mapper ? mapper(rawData) : (rawData as unknown as TData)
       },
       ...options

--- a/apps/web/lib/team/teamSession.ts
+++ b/apps/web/lib/team/teamSession.ts
@@ -1,13 +1,17 @@
-import { PerformanceTeamsList } from "@repo/shared-types"
+import { PerformanceTeamsList, TeamDetail } from "@repo/shared-types"
 
 // PerformanceTeamsList의 단일 팀 타입
 export type TeamFromList = PerformanceTeamsList[number]
 
-// 팀의 teamSessions 타입
+// 팀의 teamSessions 타입 (TeamFromList와 TeamDetail 모두 호환)
 export type TeamSessionFromList = TeamFromList["teamSessions"][number]
+export type TeamSessionFromDetail = TeamDetail["teamSessions"][number]
 
 // teamSession의 member 타입
 export type TeamSessionMember = TeamSessionFromList["members"][number]
+
+// 공통 타입 (두 타입이 동일한 구조를 가지므로 TeamSessionFromList 사용)
+export type TeamSession = TeamSessionFromList
 
 /**
  * 팀의 모든 세션이 정원을 충족했는지 확인

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -425,7 +425,7 @@ export default class ApiClient {
       | DuplicateApplicationError
       | PositionOccupiedError
       | InternalServerError
-    >(`/teams/${teamId}/apply`, "POST", teamApplicationData)
+    >(`/teams/${teamId}/apply`, "PATCH", teamApplicationData)
   }
 
   /**
@@ -447,7 +447,7 @@ export default class ApiClient {
       | NoApplicationFoundError
       | ForbiddenError
       | InternalServerError
-    >(`/teams/${teamId}/unapply`, "POST", teamApplicationData)
+    >(`/teams/${teamId}/unapply`, "PATCH", teamApplicationData)
   }
 
   /**


### PR DESCRIPTION
## 개요
팀 상세 페이지에서 세션구성, 마감된 세션, 세션 지원 섹션이 렌더링되지 않는 문제를 수정합니다.

## 변경 사항
- **ApplyButton**: 새 `teamSessions` 구조에 맞게 props 인터페이스 수정
  - `session` → `sessionName`
  - `memberSessionIndex` → `sessionIndex`
  - `selectedSessionsWithIndex` → `isSelected` (boolean)
  - `toggleSelectedSessionWithIndex` → `onToggle`
- **page.tsx**: 세션구성/마감된 세션/세션 지원 섹션 데이터 바인딩 구현
- **useTeamApplication**: `isSelected` 함수를 반환값에 추가
- **api-client**: `applyToTeam`, `unapplyFromTeam` 메서드를 `POST` → `PATCH`로 수정 (백엔드 컨트롤러와 일치)

## 관련 이슈
Closes #255