### PR TITLE
fix: 팀 생성/수정/삭제 후 캐시 무효화 로직 개선

### DIFF
--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/DeleteButton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/DeleteButton.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { useDeleteTeam } from "@/hooks/api/useTeam"
 import { cn } from "@/lib/utils"
+import { useQueryClient } from "@tanstack/react-query"
 
 interface TeamCardDeleteButtonProps {
   teamId: number
@@ -25,10 +26,13 @@ const TeamCardDeleteButton = ({
 }: TeamCardDeleteButtonProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const deleteTeam = useDeleteTeam()
+  const queryClient = useQueryClient()
 
   const onDelete = async () => {
     const res = await deleteTeam.mutateAsync([teamId])
     if (res) {
+      // 팀 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
       setIsOpen(false)
     }
   }

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useDeleteTeam } from "@/hooks/api/useTeam"
+import { useQueryClient } from "@tanstack/react-query"
 import React from "react"
 
 interface DeleteButtonProps {
@@ -10,15 +11,18 @@ interface DeleteButtonProps {
 }
 
 const DeleteButton = ({ children, className, teamId }: DeleteButtonProps) => {
-  const { mutateAsync, error, isError } = useDeleteTeam()
+  const { mutateAsync } = useDeleteTeam()
+  const queryClient = useQueryClient()
 
   const onDelete = async () => {
-    await mutateAsync([teamId])
-    if (isError) {
-      console.error("팀 삭제 오류:", error)
-      alert("팀 삭제에 실패했습니다. 다시 시도해주세요.")
-    } else {
+    try {
+      await mutateAsync([teamId])
+      // 팀 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
       alert("팀이 삭제되었습니다.")
+    } catch (err) {
+      console.error("팀 삭제 오류:", err)
+      alert("팀 삭제에 실패했습니다. 다시 시도해주세요.")
     }
   }
 

--- a/apps/web/components/TeamDeleteButton.tsx
+++ b/apps/web/components/TeamDeleteButton.tsx
@@ -12,6 +12,7 @@ import {
   DialogTrigger
 } from "@/components/ui/dialog"
 import { useDeleteTeam } from "@/hooks/api/useTeam"
+import { useQueryClient } from "@tanstack/react-query"
 
 interface TeamDeleteButtonProps {
   className?: string
@@ -31,10 +32,13 @@ const TeamDeleteButton = ({
 
   const [isOpen, setIsOpen] = useState(false)
   const deleteTeam = useDeleteTeam()
+  const queryClient = useQueryClient()
 
   const onDelete = async () => {
     const res = await deleteTeam.mutateAsync([teamId])
     if (res) {
+      // 팀 목록 캐시 무효화 (모든 performance의 팀 목록)
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
       setIsOpen(false)
       router.push(redirectUrl)
       toast({


### PR DESCRIPTION
## 변경 사항

팀 생성/수정/삭제 후 팀 목록이 갱신되지 않는 문제를 해결했습니다.

### 문제 원인
- `staleTime: 60초` 설정으로 인해 쿼리가 Fresh 상태로 유지
- `invalidateQueries`의 기본 `refetchType: 'active'`는 Fresh 상태의 쿼리를 refetch하지 않음

### 해결 방법
- `invalidateQueries`에 `refetchType: 'all'` 옵션 추가
- Fresh 상태여도 강제로 refetch되도록 수정
- 팀 삭제 시에도 캐시 무효화 로직 추가

### 변경 파일
- `apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx`
- `apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/DeleteButton.tsx`
- `apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton.tsx`
- `apps/web/components/TeamDeleteButton.tsx`

### 테스트
- [x] 팀 생성 후 목록 갱신 확인
- [x] 팀 수정 후 목록 갱신 확인
- [x] 팀 삭제 후 목록 갱신 확인

closes #260 