### PR TITLE
fix: 빌드 시 NEXT_PUBLIC_API_URL 환경변수 전달하도록 수정

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,8 +18,11 @@ jobs:
         app:
           - name: web
             dockerfile: apps/web/Dockerfile
+            build-args: |
+              NEXT_PUBLIC_API_URL=https://amang-api.json-server.win
           - name: api
             dockerfile: apps/api/Dockerfile
+            build-args: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,5 +50,6 @@ jobs:
           tags: |
             ghcr.io/skku-amang/amang-${{ matrix.app.name }}:${{ github.sha }}
             ghcr.io/skku-amang/amang-${{ matrix.app.name }}:latest
+          build-args: ${{ matrix.app.build-args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -14,6 +14,9 @@ RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
 COPY --from=builder /app/out/json/ .
 RUN pnpm install --frozen-lockfile
 

--- a/apps/web/env.d.ts
+++ b/apps/web/env.d.ts
@@ -2,7 +2,6 @@ declare namespace NodeJS {
   interface ProcessEnv {
     NODE_ENV: "development" | "production" | "test"
     AUTH_SECRET: string
-    NEXT_PUBLIC_DEVELOPMENT_URL?: string // 개발환경에서의 백엔드 서버 주소
-    NEXT_PUBLIC_DEPLOY_URL?: string // 배포환경에서의 백엔드 서버 주소
+    NEXT_PUBLIC_API_URL?: string // 백엔드 서버 주소
   }
 }

--- a/infra/k8s/web/overlays/production/configmap.yaml
+++ b/infra/k8s/web/overlays/production/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: web-config
 data:
   NODE_ENV: production
-  NEXT_PUBLIC_DEPLOY_URL: https://amang-api.json-server.win

--- a/infra/k8s/web/overlays/staging/configmap.yaml
+++ b/infra/k8s/web/overlays/staging/configmap.yaml
@@ -4,4 +4,3 @@ metadata:
   name: web-config
 data:
   NODE_ENV: development
-  NEXT_PUBLIC_DEVELOPMENT_URL: https://amang-api-staging.json-server.win


### PR DESCRIPTION
## Summary
- NEXT_PUBLIC_* 환경변수가 빌드 타임에 번들링되므로 Docker 빌드 시 ARG로 전달하도록 수정
- 런타임 configmap에서 불필요한 NEXT_PUBLIC_* 환경변수 제거
- CORS 에러 해결 (프론트엔드가 localhost:8000 대신 실제 API 서버로 요청)

## Test plan
- [ ] main 브랜치에 머지 후 GitHub Actions 빌드 성공 확인
- [ ] 배포된 프론트엔드에서 API 요청 시 CORS 에러 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)