### PR TITLE
chore: ArgoCD Image Updater 도입을 위한 imagePullPolicy 변경

### DIFF
--- a/infra/k8s/api/base/deployment.yaml
+++ b/infra/k8s/api/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: api
           image: ghcr.io/skku-amang/amang-api:latest
-          imagePullPolicy: Always # TODO: use Argocd Image Updater
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8000

--- a/infra/k8s/web/base/deployment.yaml
+++ b/infra/k8s/web/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: web
           image: ghcr.io/skku-amang/amang-web:latest
-          imagePullPolicy: Always # TODO: use Argocd Image Updater
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## Summary
- web/api Deployment의 `imagePullPolicy`를 `Always`에서 `IfNotPresent`로 변경
- ArgoCD Image Updater가 이미지 태그를 관리하면 Always 불필요

## 관련 작업
- homelab 레포에서 ArgoCD Image Updater 설치 및 Application annotation 추가 필요
- 관련 이슈: #274

## Test plan
- [ ] homelab 레포에서 Image Updater 설정 완료 후 머지
- [ ] 이미지 푸시 시 자동 배포 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)