### PR TITLE
fix: Vercel 프리뷰 도메인 CORS 허용 추가

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -15,7 +15,8 @@ async function bootstrap() {
     origin: [
       "http://localhost:3000",
       "https://amang.json-server.win",
-      "https://amang-staging.json-server.win"
+      "https://amang-staging.json-server.win",
+      /\.vercel\.app$/
     ],
     credentials: true
   })


### PR DESCRIPTION
## Summary
- Vercel 프리뷰 배포(`*.vercel.app`)에서 API 요청 시 CORS 에러 발생하는 문제 수정
- NestJS CORS origin에 `/\.vercel\.app$/` 정규식 패턴 추가

## Test plan
- [ ] Vercel 프리뷰 배포에서 API 요청이 CORS 에러 없이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)