### PR TITLE
test: add API integration test infrastructure

### DIFF
--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,0 +1,7 @@
+NODE_ENV=test
+ACCESS_TOKEN_SECRET=test_access_secret
+REFRESH_TOKEN_SECRET=test_refresh_secret
+ACCESS_TOKEN_EXPIRES_IN=1h
+REFRESH_TOKEN_EXPIRES_IN=7d
+DATABASE_URL=postgresql://postgres:postgres@localhost:5433/amang_test_db
+SEED_DEFAULT_PASSWORD=Test1234!

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:integration": "jest --config ./test/jest-integration.json --runInBand",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/common/configure-app.ts
+++ b/apps/api/src/common/configure-app.ts
@@ -1,0 +1,20 @@
+import { INestApplication } from "@nestjs/common"
+import { HttpAdapterHost } from "@nestjs/core"
+import cookieParser from "cookie-parser"
+import { ZodValidationPipe } from "nestjs-zod"
+import { AllErrorFilter } from "./filters/all-error.filter"
+import { ApiErrorFilter } from "./filters/api-error.filter"
+import { ZodValidationErrorFilter } from "./filters/zod-validation-error"
+import { ApiResultInterceptor } from "./interceptors/api-result.interceptor"
+
+export function configureApp(app: INestApplication): void {
+  const httpAdapterHost = app.get(HttpAdapterHost)
+  app.use(cookieParser())
+  app.useGlobalPipes(new ZodValidationPipe())
+  app.useGlobalFilters(
+    new AllErrorFilter(httpAdapterHost),
+    new ZodValidationErrorFilter(httpAdapterHost),
+    new ApiErrorFilter(httpAdapterHost)
+  )
+  app.useGlobalInterceptors(new ApiResultInterceptor())
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,16 +1,10 @@
 import { ConfigService } from "@nestjs/config"
-import { HttpAdapterHost, NestFactory } from "@nestjs/core"
-import cookieParser from "cookie-parser"
-import { ZodValidationPipe } from "nestjs-zod"
+import { NestFactory } from "@nestjs/core"
 import { AppModule } from "./app.module"
-import { AllErrorFilter } from "./common/filters/all-error.filter"
-import { ApiErrorFilter } from "./common/filters/api-error.filter"
-import { ZodValidationErrorFilter } from "./common/filters/zod-validation-error"
-import { ApiResultInterceptor } from "./common/interceptors/api-result.interceptor"
+import { configureApp } from "./common/configure-app"
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
-  const httpAdapterHost = app.get(HttpAdapterHost)
   app.enableCors({
     origin: [
       "http://localhost:3000",
@@ -20,14 +14,7 @@ async function bootstrap() {
     ],
     credentials: true
   })
-  app.use(cookieParser())
-  app.useGlobalPipes(new ZodValidationPipe())
-  app.useGlobalFilters(
-    new AllErrorFilter(httpAdapterHost),
-    new ZodValidationErrorFilter(httpAdapterHost),
-    new ApiErrorFilter(httpAdapterHost)
-  )
-  app.useGlobalInterceptors(new ApiResultInterceptor())
+  configureApp(app)
   const configService = app.get(ConfigService)
   await app.listen(configService.get<number>("PORT") ?? 8000)
 }

--- a/apps/api/test/integration/auth/auth.integration.spec.ts
+++ b/apps/api/test/integration/auth/auth.integration.spec.ts
@@ -1,0 +1,151 @@
+import { INestApplication } from "@nestjs/common"
+import request from "supertest"
+import { createTestApp, closeTestApp } from "../helpers/test-app.helper"
+import { loginAsAdmin, loginAsUser } from "../helpers/auth.helper"
+
+describe("Auth Integration", () => {
+  let app: INestApplication
+
+  beforeAll(async () => {
+    app = await createTestApp()
+  })
+
+  afterAll(async () => {
+    await closeTestApp()
+  })
+
+  describe("POST /auth/login", () => {
+    it("should login as admin with valid credentials", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "admin1@g.skku.edu",
+          password: process.env.SEED_DEFAULT_PASSWORD
+        })
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.accessToken).toBeDefined()
+      expect(res.body.data.refreshToken).toBeDefined()
+      expect(res.body.data.expiresIn).toBeDefined()
+      expect(res.body.data.user).toBeDefined()
+      expect(res.body.data.user.email).toBe("admin1@g.skku.edu")
+      expect(res.body.data.user.isAdmin).toBe(true)
+      // password should never be exposed
+      expect(res.body.data.user.password).toBeUndefined()
+      expect(res.body.data.user.hashedRefreshToken).toBeUndefined()
+    })
+
+    it("should login as regular user", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "user1@g.skku.edu",
+          password: process.env.SEED_DEFAULT_PASSWORD
+        })
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.user.isAdmin).toBe(false)
+    })
+
+    it("should reject wrong password", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "admin1@g.skku.edu",
+          password: "WrongPassword1"
+        })
+        .expect(401)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/authentication-error")
+    })
+
+    it("should reject non-existent email", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "nobody@g.skku.edu",
+          password: "SomePassword1"
+        })
+        .expect(401)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/authentication-error")
+    })
+
+    it("should reject invalid email format", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "not-an-email",
+          password: "SomePassword1"
+        })
+        .expect(400)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/validation-error")
+    })
+
+    it("should reject empty password", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send({
+          email: "admin1@g.skku.edu",
+          password: ""
+        })
+        .expect(400)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/validation-error")
+    })
+  })
+
+  describe("POST /auth/logout", () => {
+    it("should logout with valid token", async () => {
+      const tokens = await loginAsUser(app, 1)
+
+      const res = await request(app.getHttpServer())
+        .post("/auth/logout")
+        .set("Authorization", `Bearer ${tokens.accessToken}`)
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.message).toBeDefined()
+    })
+
+    it("should reject logout without token", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/logout")
+        .expect(401)
+
+      expect(res.body.isSuccess).toBe(false)
+    })
+  })
+
+  describe("POST /auth/refresh", () => {
+    it("should refresh tokens with valid refresh token", async () => {
+      const tokens = await loginAsUser(app, 2)
+
+      const res = await request(app.getHttpServer())
+        .post("/auth/refresh")
+        .send({ refreshToken: tokens.refreshToken })
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.accessToken).toBeDefined()
+      expect(res.body.data.refreshToken).toBeDefined()
+      expect(res.body.data.expiresIn).toBeDefined()
+    })
+
+    it("should reject invalid refresh token", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/auth/refresh")
+        .send({ refreshToken: "invalid.refresh.token" })
+        .expect(401)
+
+      expect(res.body.isSuccess).toBe(false)
+    })
+  })
+})

--- a/apps/api/test/integration/helpers/auth.helper.ts
+++ b/apps/api/test/integration/helpers/auth.helper.ts
@@ -1,0 +1,44 @@
+import { INestApplication } from "@nestjs/common"
+import request from "supertest"
+
+export interface TestTokens {
+  accessToken: string
+  refreshToken: string
+  userId: number
+}
+
+export async function loginAsAdmin(
+  app: INestApplication,
+  adminIndex: number = 1
+): Promise<TestTokens> {
+  const res = await request(app.getHttpServer())
+    .post("/auth/login")
+    .send({
+      email: `admin${adminIndex}@g.skku.edu`,
+      password: process.env.SEED_DEFAULT_PASSWORD
+    })
+    .expect(200)
+
+  const { accessToken, refreshToken, user } = res.body.data
+  return { accessToken, refreshToken, userId: user.id }
+}
+
+export async function loginAsUser(
+  app: INestApplication,
+  userIndex: number = 1
+): Promise<TestTokens> {
+  const res = await request(app.getHttpServer())
+    .post("/auth/login")
+    .send({
+      email: `user${userIndex}@g.skku.edu`,
+      password: process.env.SEED_DEFAULT_PASSWORD
+    })
+    .expect(200)
+
+  const { accessToken, refreshToken, user } = res.body.data
+  return { accessToken, refreshToken, userId: user.id }
+}
+
+export function withAuth(req: request.Test, tokens: TestTokens): request.Test {
+  return req.set("Authorization", `Bearer ${tokens.accessToken}`)
+}

--- a/apps/api/test/integration/helpers/test-app.helper.ts
+++ b/apps/api/test/integration/helpers/test-app.helper.ts
@@ -1,0 +1,24 @@
+import { INestApplication } from "@nestjs/common"
+import { Test, TestingModule } from "@nestjs/testing"
+import { AppModule } from "../../../src/app.module"
+import { configureApp } from "../../../src/common/configure-app"
+
+let app: INestApplication | null = null
+
+export async function createTestApp(): Promise<INestApplication> {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [AppModule]
+  }).compile()
+
+  app = moduleFixture.createNestApplication()
+  configureApp(app)
+  await app.init()
+  return app
+}
+
+export async function closeTestApp(): Promise<void> {
+  if (app) {
+    await app.close()
+    app = null
+  }
+}

--- a/apps/api/test/integration/performance/performance.integration.spec.ts
+++ b/apps/api/test/integration/performance/performance.integration.spec.ts
@@ -22,13 +22,13 @@ describe("Performance Integration", () => {
 
   afterAll(async () => {
     // clean up any performances we created
-    if (createdIds.length > 0) {
-      for (const id of createdIds) {
+    for (const id of createdIds) {
+      try {
         await withAuth(
           request(app.getHttpServer()).delete(`/performances/${id}`),
           adminTokens
-        ).catch(() => {})
-      }
+        )
+      } catch {}
     }
     await closeTestApp()
   })

--- a/apps/api/test/integration/performance/performance.integration.spec.ts
+++ b/apps/api/test/integration/performance/performance.integration.spec.ts
@@ -1,0 +1,184 @@
+import { INestApplication } from "@nestjs/common"
+import request from "supertest"
+import { createTestApp, closeTestApp } from "../helpers/test-app.helper"
+import {
+  loginAsAdmin,
+  loginAsUser,
+  withAuth,
+  TestTokens
+} from "../helpers/auth.helper"
+
+describe("Performance Integration", () => {
+  let app: INestApplication
+  let adminTokens: TestTokens
+  let userTokens: TestTokens
+  const createdIds: number[] = []
+
+  beforeAll(async () => {
+    app = await createTestApp()
+    adminTokens = await loginAsAdmin(app)
+    userTokens = await loginAsUser(app)
+  })
+
+  afterAll(async () => {
+    // clean up any performances we created
+    if (createdIds.length > 0) {
+      for (const id of createdIds) {
+        await withAuth(
+          request(app.getHttpServer()).delete(`/performances/${id}`),
+          adminTokens
+        ).catch(() => {})
+      }
+    }
+    await closeTestApp()
+  })
+
+  describe("GET /performances (public)", () => {
+    it("should return list without auth", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/performances")
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(Array.isArray(res.body.data)).toBe(true)
+    })
+  })
+
+  describe("POST /performances (admin only)", () => {
+    it("should create performance as admin", async () => {
+      const res = await withAuth(
+        request(app.getHttpServer()).post("/performances"),
+        adminTokens
+      )
+        .send({ name: "통합 테스트 공연" })
+        .expect(201)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.name).toBe("통합 테스트 공연")
+      expect(res.body.data.id).toBeDefined()
+      createdIds.push(res.body.data.id)
+    })
+
+    it("should create performance with full fields", async () => {
+      const res = await withAuth(
+        request(app.getHttpServer()).post("/performances"),
+        adminTokens
+      )
+        .send({
+          name: "정기 공연",
+          description: "2025년 정기 공연입니다",
+          location: "성균관대 새천년홀",
+          startAt: "2025-12-01T18:00:00Z",
+          endAt: "2025-12-01T21:00:00Z"
+        })
+        .expect(201)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.location).toBe("성균관대 새천년홀")
+      createdIds.push(res.body.data.id)
+    })
+
+    it("should reject creation by non-admin", async () => {
+      const res = await withAuth(
+        request(app.getHttpServer()).post("/performances"),
+        userTokens
+      )
+        .send({ name: "Should Fail" })
+        .expect(403)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/forbidden")
+    })
+
+    it("should reject creation without auth", async () => {
+      await request(app.getHttpServer())
+        .post("/performances")
+        .send({ name: "No Auth" })
+        .expect(401)
+    })
+
+    it("should reject empty name", async () => {
+      const res = await withAuth(
+        request(app.getHttpServer()).post("/performances"),
+        adminTokens
+      )
+        .send({ name: "" })
+        .expect(400)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/validation-error")
+    })
+  })
+
+  describe("GET /performances/:id (public)", () => {
+    it("should return performance detail", async () => {
+      const id = createdIds[0]
+      const res = await request(app.getHttpServer())
+        .get(`/performances/${id}`)
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.id).toBe(id)
+      expect(res.body.data.name).toBe("통합 테스트 공연")
+    })
+
+    it("should return 404 for non-existent id", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/performances/999999")
+        .expect(404)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/not-found")
+    })
+  })
+
+  describe("PATCH /performances/:id (admin only)", () => {
+    it("should update performance as admin", async () => {
+      const id = createdIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/performances/${id}`),
+        adminTokens
+      )
+        .send({ name: "수정된 공연 이름" })
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.name).toBe("수정된 공연 이름")
+    })
+
+    it("should reject update by non-admin", async () => {
+      const id = createdIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/performances/${id}`),
+        userTokens
+      )
+        .send({ name: "Should Fail" })
+        .expect(403)
+
+      expect(res.body.isSuccess).toBe(false)
+    })
+  })
+
+  describe("DELETE /performances/:id (admin only)", () => {
+    it("should reject deletion by non-admin", async () => {
+      const id = createdIds[0]
+      await withAuth(
+        request(app.getHttpServer()).delete(`/performances/${id}`),
+        userTokens
+      ).expect(403)
+    })
+
+    it("should delete performance as admin", async () => {
+      const id = createdIds.pop()!
+      const res = await withAuth(
+        request(app.getHttpServer()).delete(`/performances/${id}`),
+        adminTokens
+      ).expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+
+      // verify it's gone
+      await request(app.getHttpServer()).get(`/performances/${id}`).expect(404)
+    })
+  })
+})

--- a/apps/api/test/integration/setup/load-env.ts
+++ b/apps/api/test/integration/setup/load-env.ts
@@ -1,0 +1,15 @@
+import * as fs from "fs"
+import * as path from "path"
+
+const envPath = path.resolve(__dirname, "../../../.env.test")
+const envContent = fs.readFileSync(envPath, "utf8")
+
+for (const line of envContent.split("\n")) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith("#")) continue
+  const eqIndex = trimmed.indexOf("=")
+  if (eqIndex === -1) continue
+  const key = trimmed.slice(0, eqIndex)
+  const value = trimmed.slice(eqIndex + 1)
+  process.env[key] = value
+}

--- a/apps/api/test/integration/setup/load-env.ts
+++ b/apps/api/test/integration/setup/load-env.ts
@@ -4,7 +4,7 @@ import * as path from "path"
 const envPath = path.resolve(__dirname, "../../../.env.test")
 const envContent = fs.readFileSync(envPath, "utf8")
 
-for (const line of envContent.split("\n")) {
+for (const line of envContent.split(/\r?\n/)) {
   const trimmed = line.trim()
   if (!trimmed || trimmed.startsWith("#")) continue
   const eqIndex = trimmed.indexOf("=")

--- a/apps/api/test/integration/team/team.integration.spec.ts
+++ b/apps/api/test/integration/team/team.integration.spec.ts
@@ -1,0 +1,298 @@
+import { INestApplication } from "@nestjs/common"
+import request from "supertest"
+import { createTestApp, closeTestApp } from "../helpers/test-app.helper"
+import {
+  loginAsAdmin,
+  loginAsUser,
+  withAuth,
+  TestTokens
+} from "../helpers/auth.helper"
+
+describe("Team Integration", () => {
+  let app: INestApplication
+  let adminTokens: TestTokens
+  let user1Tokens: TestTokens
+  let user2Tokens: TestTokens
+  let performanceId: number
+  let sessionId: number
+  const createdTeamIds: number[] = []
+
+  beforeAll(async () => {
+    app = await createTestApp()
+    adminTokens = await loginAsAdmin(app)
+    user1Tokens = await loginAsUser(app, 1)
+    user2Tokens = await loginAsUser(app, 2)
+
+    // create a performance for team tests
+    const perfRes = await withAuth(
+      request(app.getHttpServer()).post("/performances"),
+      adminTokens
+    )
+      .send({ name: "팀 테스트용 공연" })
+      .expect(201)
+    performanceId = perfRes.body.data.id
+
+    // get a session ID from seeded data
+    const sessionRes = await request(app.getHttpServer())
+      .get("/sessions")
+      .expect(200)
+    sessionId = sessionRes.body.data[0].id
+  })
+
+  afterAll(async () => {
+    // clean up teams
+    for (const id of createdTeamIds) {
+      await withAuth(
+        request(app.getHttpServer()).delete(`/teams/${id}`),
+        adminTokens
+      ).catch(() => {})
+    }
+    // clean up performance
+    await withAuth(
+      request(app.getHttpServer()).delete(`/performances/${performanceId}`),
+      adminTokens
+    ).catch(() => {})
+
+    await closeTestApp()
+  })
+
+  describe("GET /teams (public)", () => {
+    it("should return list without auth", async () => {
+      const res = await request(app.getHttpServer()).get("/teams").expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(Array.isArray(res.body.data)).toBe(true)
+    })
+  })
+
+  describe("POST /teams (authenticated)", () => {
+    it("should create team with sessions", async () => {
+      const res = await withAuth(
+        request(app.getHttpServer()).post("/teams"),
+        adminTokens
+      )
+        .send({
+          name: "통합 테스트 밴드",
+          songName: "Test Song",
+          songArtist: "Test Artist",
+          leaderId: adminTokens.userId,
+          performanceId,
+          memberSessions: [
+            {
+              sessionId,
+              capacity: 2,
+              members: []
+            }
+          ]
+        })
+        .expect(201)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.name).toBe("통합 테스트 밴드")
+      expect(res.body.data.teamSessions).toBeDefined()
+      expect(res.body.data.teamSessions.length).toBe(1)
+      createdTeamIds.push(res.body.data.id)
+    })
+
+    it("should reject creation without auth", async () => {
+      await request(app.getHttpServer())
+        .post("/teams")
+        .send({
+          name: "No Auth",
+          songName: "Song",
+          songArtist: "Artist",
+          leaderId: 1,
+          performanceId,
+          memberSessions: []
+        })
+        .expect(401)
+    })
+  })
+
+  describe("GET /teams/:id (public)", () => {
+    it("should return team detail", async () => {
+      const id = createdTeamIds[0]
+      const res = await request(app.getHttpServer())
+        .get(`/teams/${id}`)
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.id).toBe(id)
+      expect(res.body.data.teamSessions).toBeDefined()
+      expect(res.body.data.leader).toBeDefined()
+    })
+
+    it("should return 404 for non-existent team", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/teams/999999")
+        .expect(404)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/not-found")
+    })
+  })
+
+  describe("PUT /teams/:id (owner or admin)", () => {
+    it("should update team as owner", async () => {
+      const id = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).put(`/teams/${id}`),
+        adminTokens
+      )
+        .send({
+          name: "수정된 밴드",
+          songName: "Updated Song",
+          songArtist: "Updated Artist",
+          leaderId: adminTokens.userId,
+          memberSessions: [
+            {
+              sessionId,
+              capacity: 3,
+              members: []
+            }
+          ]
+        })
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      expect(res.body.data.name).toBe("수정된 밴드")
+    })
+
+    it("should reject update by non-owner non-admin", async () => {
+      const id = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).put(`/teams/${id}`),
+        user1Tokens
+      )
+        .send({
+          name: "Should Fail",
+          songName: "Song",
+          songArtist: "Artist",
+          leaderId: user1Tokens.userId,
+          memberSessions: []
+        })
+        .expect(403)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/forbidden")
+    })
+  })
+
+  describe("PATCH /teams/:id/apply (authenticated)", () => {
+    it("should apply to a team session", async () => {
+      const teamId = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/apply`),
+        user1Tokens
+      )
+        .send([{ sessionId, index: 1 }])
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      // verify member was added
+      const teamSession = res.body.data.teamSessions.find(
+        (ts: any) => ts.session.id === sessionId
+      )
+      expect(teamSession.members.length).toBe(1)
+      expect(teamSession.members[0].user.id).toBe(user1Tokens.userId)
+    })
+
+    it("should reject duplicate application", async () => {
+      const teamId = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/apply`),
+        user1Tokens
+      )
+        .send([{ sessionId, index: 2 }])
+        .expect(409)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/team/duplicate-application")
+    })
+
+    it("should reject occupied position", async () => {
+      const teamId = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/apply`),
+        user2Tokens
+      )
+        .send([{ sessionId, index: 1 }])
+        .expect(409)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/team/position-occupied")
+    })
+
+    it("should allow second user in different position", async () => {
+      const teamId = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/apply`),
+        user2Tokens
+      )
+        .send([{ sessionId, index: 2 }])
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      const teamSession = res.body.data.teamSessions.find(
+        (ts: any) => ts.session.id === sessionId
+      )
+      expect(teamSession.members.length).toBe(2)
+    })
+  })
+
+  describe("PATCH /teams/:id/unapply (authenticated)", () => {
+    it("should reject unapply for another user's position", async () => {
+      const teamId = createdTeamIds[0]
+      // user2 tries to unapply from index 1 (user1's position)
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/unapply`),
+        user2Tokens
+      )
+        .send([{ sessionId, index: 1 }])
+        .expect(403)
+
+      expect(res.body.isSuccess).toBe(false)
+      expect(res.body.error.type).toBe("/errors/forbidden")
+    })
+
+    it("should unapply from team session", async () => {
+      const teamId = createdTeamIds[0]
+      const res = await withAuth(
+        request(app.getHttpServer()).patch(`/teams/${teamId}/unapply`),
+        user1Tokens
+      )
+        .send([{ sessionId, index: 1 }])
+        .expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+      const teamSession = res.body.data.teamSessions.find(
+        (ts: any) => ts.session.id === sessionId
+      )
+      // user1 removed, only user2 remains
+      expect(teamSession.members.length).toBe(1)
+    })
+  })
+
+  describe("DELETE /teams/:id (owner or admin)", () => {
+    it("should reject deletion by non-owner", async () => {
+      const id = createdTeamIds[0]
+      await withAuth(
+        request(app.getHttpServer()).delete(`/teams/${id}`),
+        user1Tokens
+      ).expect(403)
+    })
+
+    it("should delete team as admin", async () => {
+      const id = createdTeamIds.pop()!
+      const res = await withAuth(
+        request(app.getHttpServer()).delete(`/teams/${id}`),
+        adminTokens
+      ).expect(200)
+
+      expect(res.body.isSuccess).toBe(true)
+
+      // verify it's gone
+      await request(app.getHttpServer()).get(`/teams/${id}`).expect(404)
+    })
+  })
+})

--- a/apps/api/test/integration/team/team.integration.spec.ts
+++ b/apps/api/test/integration/team/team.integration.spec.ts
@@ -42,16 +42,20 @@ describe("Team Integration", () => {
   afterAll(async () => {
     // clean up teams
     for (const id of createdTeamIds) {
-      await withAuth(
-        request(app.getHttpServer()).delete(`/teams/${id}`),
-        adminTokens
-      ).catch(() => {})
+      try {
+        await withAuth(
+          request(app.getHttpServer()).delete(`/teams/${id}`),
+          adminTokens
+        )
+      } catch {}
     }
     // clean up performance
-    await withAuth(
-      request(app.getHttpServer()).delete(`/performances/${performanceId}`),
-      adminTokens
-    ).catch(() => {})
+    try {
+      await withAuth(
+        request(app.getHttpServer()).delete(`/performances/${performanceId}`),
+        adminTokens
+      )
+    } catch {}
 
     await closeTestApp()
   })

--- a/apps/api/test/jest-integration.json
+++ b/apps/api/test/jest-integration.json
@@ -1,0 +1,11 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".integration.spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "setupFiles": ["./integration/setup/load-env.ts"],
+  "testTimeout": 30000
+}

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,10 @@
       "persistent": true,
       "env": ["NODE_ENV"]
     },
+    "test:integration": {
+      "dependsOn": ["^build"],
+      "env": ["NODE_ENV", "DATABASE_URL", "SEED_DEFAULT_PASSWORD"]
+    },
     "check-types": {
       "dependsOn": ["^check-types", "^build"]
     },


### PR DESCRIPTION
## Summary
- `configureApp()` 추출: `main.ts`의 global pipes/filters/interceptors를 테스트 앱과 공유
- 통합 테스트 인프라 구축: Jest config, env 로딩, 테스트 헬퍼(앱 생성, 인증)
- Auth / Performance / Team 3개 도메인 37개 통합 테스트 작성

## 구조
```
apps/api/
├── src/common/configure-app.ts       # global config 추출
├── .env.test                          # 테스트 환경변수 (git 추적)
└── test/
    ├── jest-integration.json          # 통합 테스트 Jest 설정
    └── integration/
        ├── setup/load-env.ts          # .env.test 로딩
        ├── helpers/
        │   ├── test-app.helper.ts     # NestJS 테스트 앱 생성
        │   └── auth.helper.ts         # 인증 헬퍼
        ├── auth/                      # 10 tests
        ├── performance/               # 10 tests
        └── team/                      # 17 tests
```

## 실행 방법
```bash
# 테스트 DB 준비 (최초 1회)
docker exec amang-postgres psql -U postgres -c "CREATE DATABASE amang_test_db;"
cd packages/database
DATABASE_URL=postgresql://postgres:postgres@localhost:5433/amang_test_db npx prisma migrate deploy
DATABASE_URL=postgresql://postgres:postgres@localhost:5433/amang_test_db SEED_TYPE=test SEED_DEFAULT_PASSWORD=Test1234! npx ts-node prisma/seed.ts

# 통합 테스트 실행
cd apps/api && pnpm test:integration
```

## TODO
- [ ] Session 도메인 통합 테스트
- [ ] Generation 도메인 통합 테스트
- [ ] Equipment 도메인 통합 테스트
- [ ] Rental 도메인 통합 테스트
- [ ] CI 파이프라인에 통합 테스트 추가

## Test plan
- [x] `pnpm test:integration` — 37 tests passing
- [x] `main.ts` 리팩터링 후 기존 API 동작 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)