### PR TITLE
feat: 팀 목록/상세 페이지 스켈레톤 로딩 UI 추가

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailSkeleton.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailSkeleton.tsx
@@ -1,0 +1,152 @@
+import OleoPageHeader from "@/components/PageHeaders/OleoPageHeader"
+import { Skeleton } from "@/components/ui/skeleton"
+import ROUTES from "@/constants/routes"
+
+interface TeamDetailSkeletonProps {
+  performanceId: number
+}
+
+const BasicInfoSkeleton = () => (
+  <div className="relative h-fit w-full rounded-2xl bg-white px-10 py-14 shadow-md md:w-[466px] md:px-[40px] md:py-[60px]">
+    {/* 뱃지 */}
+    <Skeleton className="mb-[10px] h-[20px] w-[72px] md:mb-[16px] md:h-[32px] md:w-[130px]" />
+
+    {/* 팀장: 아바타 + 이름 + 시간 */}
+    <div className="mb-6 flex items-center gap-x-[8px] md:mb-[24px] md:gap-x-[10px]">
+      <Skeleton className="h-[24px] w-[24px] rounded-full md:h-[48px] md:w-[48px]" />
+      <Skeleton className="h-3 w-16 md:h-4 md:w-20" />
+      <Skeleton className="h-3 w-12 md:h-4 md:w-16" />
+    </div>
+
+    {/* 곡명 + 상태뱃지 */}
+    <div className="flex items-center justify-between gap-x-3">
+      <Skeleton className="h-7 w-40 md:h-8 md:w-52" />
+      <Skeleton className="h-5 w-20 rounded-full md:h-[32px] md:w-[130px]" />
+    </div>
+
+    {/* 아티스트 */}
+    <Skeleton className="mt-1 h-5 w-28 md:h-[34px] md:w-36" />
+
+    {/* 설명 */}
+    <div className="space-y-2 pt-[14px] md:pt-[28px]">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  </div>
+)
+
+const SessionSetCardSkeleton = ({
+  header,
+  children
+}: {
+  header: string
+  children: React.ReactNode
+}) => (
+  <div className="rounded-xl border-s-8 border-s-blue-900 bg-white px-[40px] py-[40px] shadow-md md:px-[68px] md:py-[56px]">
+    <h5 className="select-none text-base font-bold leading-[18px] text-slate-700 md:text-2xl md:leading-normal">
+      {header}
+    </h5>
+    {children}
+  </div>
+)
+
+const TeamDetailSkeleton = ({ performanceId }: TeamDetailSkeletonProps) => {
+  return (
+    <div className="container flex w-full flex-col items-center px-0 pt-16">
+      {/* 기울어진 배경 */}
+      <div
+        className="absolute left-0 top-0 z-0 h-[283px] w-full bg-slate-300 md:h-[600px]"
+        style={{ clipPath: "polygon(0 0%, 80% 0, 180% 65%, 0% 100%)" }}
+      />
+      <div
+        className="absolute left-0 top-0 h-[283px] w-full bg-primary md:h-[600px]"
+        style={{ clipPath: "polygon(0 0, 100% 0, 100% 60%, 0% 100%)" }}
+      />
+
+      {/* 페이지 헤더 */}
+      <OleoPageHeader
+        title="Join Your Team"
+        goBackHref={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
+        className="relative mb-10"
+      />
+
+      {/* YouTube 영역 */}
+      <div className="relative z-10 flex w-full items-center justify-center pb-[20px] md:pb-[49px]">
+        <Skeleton className="mx-10 aspect-video h-auto w-full rounded-lg md:h-[673px] md:w-[1152px]" />
+      </div>
+
+      <div className="flex w-full gap-[24px] max-md:flex-col max-md:items-center md:flex md:w-[1152px]">
+        {/* 왼쪽: BasicInfo + 포스터 */}
+        <div className="flex w-full flex-col gap-y-[24px]">
+          <BasicInfoSkeleton />
+          {/* 포스터 (데스크톱) */}
+          <Skeleton className="hidden h-[400px] w-full rounded-lg md:block" />
+        </div>
+
+        {/* 오른쪽: 세션 카드들 */}
+        <div className="flex h-full w-[93%] flex-col gap-y-5 md:w-[662px]">
+          {/* 세션구성 */}
+          <SessionSetCardSkeleton header="세션구성">
+            <div className="flex flex-wrap gap-x-2 gap-y-2 pt-[20px] md:pt-[40px]">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton
+                  key={i}
+                  className="h-[22px] w-[56px] rounded md:h-[34px] md:w-[74px] md:rounded-[20px]"
+                />
+              ))}
+            </div>
+          </SessionSetCardSkeleton>
+
+          {/* 마감된 세션 */}
+          <SessionSetCardSkeleton header="마감된 세션">
+            <div className="mt-4">
+              {/* 테이블 헤더 (데스크톱) */}
+              <div className="hidden items-center text-sm font-medium text-slate-500 md:flex">
+                <div className="flex h-[48px] w-[160px] items-center pl-4">
+                  Session
+                </div>
+                <div className="flex h-[48px] w-[466px] items-center pl-4">
+                  Member
+                </div>
+              </div>
+              <div className="hidden h-[1.5px] w-full bg-slate-200 md:block" />
+              {/* 멤버 행 */}
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-4 border-b border-slate-100 py-3"
+                >
+                  <Skeleton className="h-6 w-14 rounded-full" />
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+              ))}
+            </div>
+          </SessionSetCardSkeleton>
+
+          {/* 세션 지원 */}
+          <SessionSetCardSkeleton header="세션 지원">
+            {/* 안내 텍스트 */}
+            <div className="space-y-2 pt-[12px] md:pt-[16px]">
+              <Skeleton className="h-3 w-full md:w-[537px]" />
+              <Skeleton className="h-3 w-5/6 md:w-[480px]" />
+            </div>
+
+            {/* 세션 버튼 그리드 */}
+            <div className="mt-6 grid grid-cols-2 gap-3 md:flex md:flex-wrap">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton
+                  key={i}
+                  className="h-10 rounded-md md:h-10 md:w-[120px]"
+                />
+              ))}
+            </div>
+          </SessionSetCardSkeleton>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TeamDetailSkeleton

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -11,7 +11,7 @@ import BasicInfo from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_
 import DeleteEditButton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/DeleteEditButton"
 import MemberSessionCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard"
 import SessionSetCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard"
-import Loading from "@/app/_(errors)/Loading"
+import TeamDetailSkeleton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailSkeleton"
 import NotFoundPage from "@/app/_(errors)/NotFound"
 import OleoPageHeader from "@/components/PageHeaders/OleoPageHeader"
 import SessionBadge from "@/components/TeamBadges/SessionBadge"
@@ -45,7 +45,7 @@ const TeamDetail = () => {
   if (session.status === "unauthenticated") router.push(ROUTES.LOGIN)
 
   if (isLoading) {
-    return <Loading />
+    return <TeamDetailSkeleton performanceId={performanceId} />
   } else if (isError) {
     return <div>Error</div>
   } else if (!team) {

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListSkeleton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListSkeleton.tsx
@@ -1,0 +1,167 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+const TableRowSkeleton = () => (
+  <tr className="bg-white drop-shadow-[0_1px_2px_rgb(0,0,0,0.06)]">
+    {/* 곡명 */}
+    <td className="p-4">
+      <Skeleton className="mb-1.5 h-4 w-32" />
+      <Skeleton className="h-3 w-20" />
+    </td>
+    {/* 팀장 */}
+    <td className="p-4">
+      <div className="flex justify-center">
+        <Skeleton className="h-4 w-16" />
+      </div>
+    </td>
+    {/* 필요세션 */}
+    <td className="p-4">
+      <div className="flex gap-1">
+        <Skeleton className="h-6 w-12 rounded-full" />
+        <Skeleton className="h-6 w-12 rounded-full" />
+        <Skeleton className="h-6 w-12 rounded-full" />
+      </div>
+    </td>
+    {/* 모집상태 */}
+    <td className="p-4">
+      <div className="flex justify-center">
+        <Skeleton className="h-6 w-16 rounded-full" />
+      </div>
+    </td>
+    {/* 영상링크 */}
+    <td className="p-4">
+      <div className="flex justify-center">
+        <Skeleton className="h-5 w-5 rounded" />
+      </div>
+    </td>
+    {/* 액션 */}
+    <td className="p-4">
+      <div className="flex justify-center">
+        <Skeleton className="h-5 w-4 rounded" />
+      </div>
+    </td>
+  </tr>
+)
+
+const CardSkeleton = () => (
+  <div className="rounded-lg bg-white p-5 shadow-md">
+    {/* 곡명 & 상태 */}
+    <div className="flex items-start justify-between">
+      <Skeleton className="h-5 w-28" />
+      <Skeleton className="h-5 w-16 rounded-full" />
+    </div>
+
+    {/* 아티스트 */}
+    <Skeleton className="mt-2 h-4 w-20" />
+
+    {/* 팀장 */}
+    <div className="mt-3 flex items-center justify-between">
+      <Skeleton className="h-3 w-10" />
+      <div className="flex items-center gap-x-3">
+        <Skeleton className="h-5 w-5 rounded-full" />
+        <Skeleton className="h-3 w-14" />
+      </div>
+    </div>
+
+    {/* 필요세션 */}
+    <div className="mt-4 flex items-center justify-between">
+      <Skeleton className="h-3 w-14" />
+      <div className="flex gap-1">
+        <Skeleton className="h-6 w-10 rounded-lg" />
+        <Skeleton className="h-6 w-10 rounded-lg" />
+        <Skeleton className="h-6 w-10 rounded-lg" />
+      </div>
+    </div>
+  </div>
+)
+
+const TeamListSkeleton = () => {
+  return (
+    <div>
+      {/* 헤더 */}
+      <div className="flex flex-col justify-center space-y-1 pb-2 pt-10 text-center md:space-y-5 md:pb-[91px] md:pt-[135px]">
+        <Skeleton className="mx-auto h-8 w-40 md:h-12 md:w-60" />
+        <div className="flex items-center justify-center gap-2">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+
+      {/* 데스크톱: 테이블 */}
+      <div className="hidden md:block">
+        {/* 검색 + 버튼 */}
+        <div className="flex items-center justify-between py-[25px]">
+          <Skeleton className="h-10 w-[300px] rounded-md" />
+          <div className="flex gap-4">
+            <Skeleton className="h-10 w-[136px] rounded-[6px]" />
+            <Skeleton className="h-10 w-[136px] rounded-[6px]" />
+          </div>
+        </div>
+
+        {/* 테이블 */}
+        <table className="w-full">
+          <thead>
+            <tr className="bg-zinc-700">
+              <th className="p-3 text-left text-sm font-bold text-white">
+                곡명
+              </th>
+              <th className="p-3 text-center text-sm font-bold text-white">
+                팀장
+              </th>
+              <th className="p-3 text-left text-sm font-bold text-white">
+                필요 세션
+              </th>
+              <th className="p-3 text-center text-sm font-bold text-white">
+                모집상태
+              </th>
+              <th className="p-3 text-center text-sm font-bold text-white">
+                영상링크
+              </th>
+              <th className="p-3 text-sm font-bold text-white" />
+            </tr>
+          </thead>
+          <tbody className="[&_tr]:mb-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <TableRowSkeleton key={i} />
+            ))}
+          </tbody>
+        </table>
+
+        {/* 페이지네이션 */}
+        <div className="flex items-center justify-center space-x-2 pb-6 pt-14">
+          <Skeleton className="h-9 w-20 rounded-md" />
+          <Skeleton className="h-9 w-16 rounded-md" />
+        </div>
+      </div>
+
+      {/* 모바일: 카드 */}
+      <div className="mb-4 mt-6 md:hidden">
+        {/* 검색, 필터, 정렬 */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-center gap-x-3">
+            <Skeleton className="h-9 w-full rounded-md" />
+            <Skeleton className="h-9 w-9 shrink-0 rounded-md" />
+            <Skeleton className="h-9 w-9 shrink-0 rounded-md" />
+          </div>
+
+          {/* 공연선택 + 생성 버튼 */}
+          <div className="grid grid-cols-2 gap-x-4">
+            <Skeleton className="h-9 rounded-lg" />
+            <Skeleton className="h-9 rounded-lg" />
+          </div>
+        </div>
+
+        <div className="my-3 h-[1px] w-full bg-slate-200" />
+
+        {/* 카드 목록 */}
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TeamListSkeleton

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
@@ -8,6 +8,7 @@ import ROUTES from "@/constants/routes"
 import { usePerformances } from "@/hooks/api/usePerformance"
 import { useTeams } from "@/hooks/api/useTeam"
 import { useParams } from "next/navigation"
+import TeamListSkeleton from "./_components/TeamListSkeleton"
 import { columns } from "./_components/TeamListTable/columns"
 import { TeamListDataTable } from "./_components/TeamListTable/data-table"
 
@@ -20,7 +21,7 @@ const TeamList = () => {
     usePerformances()
 
   if (teamsStatus === "pending" || relatedPerformancesStatus === "pending") {
-    return <div>로딩중...</div>
+    return <TeamListSkeleton />
   }
 
   if (

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-slate-200", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary
<img width="1486" height="801" alt="image" src="https://github.com/user-attachments/assets/3fb6783c-cec0-4c1b-a7c4-e24836e98d89" />

- 팀 목록 페이지(`<div>로딩중...</div>`)와 팀 상세 페이지(`<Loading />`)의 텍스트 로딩 표시를 `animate-pulse` 기반 스켈레톤 UI로 교체
- shadcn/ui 스타일 `Skeleton` 프리미티브 컴포넌트 추가
- 데스크톱(테이블)/모바일(카드) 반응형 레이아웃 모두 대응

## Test plan
- [ ] `pnpm dev --filter=web`으로 개발 서버 실행
- [ ] 팀 목록 페이지 진입 시 스켈레톤 표시 확인 (데스크톱 테이블 + 모바일 카드)
- [ ] 팀 상세 페이지 진입 시 스켈레톤 표시 확인 (배경/헤더 실제 렌더 + 데이터 영역 스켈레톤)
- [ ] 데이터 로딩 완료 후 실제 콘텐츠로 자연스럽게 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)