### PR TITLE
feat: Admin CMS with inline editing and dashboard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "build": "nest build",
     "format": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "dev": "nest start --watch",
+    "dev": "docker compose up -d && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -11,11 +11,11 @@ import ROUTES from "@/constants/routes"
 import { cn } from "@/lib/utils"
 
 const NAV_ITEMS = [
-  { href: ROUTES.ADMIN.USERS, label: "Users", icon: Users },
-  { href: ROUTES.ADMIN.GENERATIONS, label: "Generations", icon: Hash },
-  { href: ROUTES.ADMIN.PERFORMANCES, label: "Performances", icon: Music },
-  { href: ROUTES.ADMIN.TEAMS, label: "Teams", icon: Mic },
-  { href: ROUTES.ADMIN.SESSIONS, label: "Sessions", icon: Guitar }
+  { href: ROUTES.ADMIN.USERS, label: "회원", icon: Users },
+  { href: ROUTES.ADMIN.GENERATIONS, label: "기수", icon: Hash },
+  { href: ROUTES.ADMIN.PERFORMANCES, label: "공연", icon: Music },
+  { href: ROUTES.ADMIN.TEAMS, label: "팀", icon: Mic },
+  { href: ROUTES.ADMIN.SESSIONS, label: "세션", icon: Guitar }
 ]
 
 function NavLinks({ onNavigate }: { onNavigate?: () => void }) {

--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import { Menu, Music, Users, Hash, Guitar, Mic } from "lucide-react"
+import {
+  LayoutDashboard,
+  Menu,
+  Music,
+  Users,
+  Hash,
+  Guitar,
+  Mic
+} from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useState } from "react"
@@ -10,7 +18,15 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import ROUTES from "@/constants/routes"
 import { cn } from "@/lib/utils"
 
+import { useUnsavedChanges } from "./UnsavedChangesContext"
+
 const NAV_ITEMS = [
+  {
+    href: ROUTES.ADMIN.INDEX,
+    label: "대시보드",
+    icon: LayoutDashboard,
+    exact: true
+  },
   { href: ROUTES.ADMIN.USERS, label: "회원", icon: Users },
   { href: ROUTES.ADMIN.GENERATIONS, label: "기수", icon: Hash },
   { href: ROUTES.ADMIN.PERFORMANCES, label: "공연", icon: Music },
@@ -20,19 +36,26 @@ const NAV_ITEMS = [
 
 function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname()
+  const { guardNavigation } = useUnsavedChanges()
 
   return (
     <nav className="flex flex-col gap-1">
-      {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-        const isActive =
-          pathname === href ||
-          (href !== ROUTES.ADMIN.INDEX && pathname.startsWith(href))
+      {NAV_ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        const isActive = exact
+          ? pathname === href
+          : pathname === href || pathname.startsWith(href)
 
         return (
           <Link
             key={href}
             href={href}
-            onClick={onNavigate}
+            onClick={(e) => {
+              if (guardNavigation(href)) {
+                e.preventDefault()
+                return
+              }
+              onNavigate?.()
+            }}
             className={cn(
               "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
               isActive
@@ -51,6 +74,7 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
 
 export function AdminSidebar() {
   const [open, setOpen] = useState(false)
+  const { guardNavigation } = useUnsavedChanges()
 
   return (
     <>
@@ -60,6 +84,9 @@ export function AdminSidebar() {
           <div className="border-b border-neutral-200 px-4 py-5">
             <Link
               href={ROUTES.ADMIN.INDEX}
+              onClick={(e) => {
+                if (guardNavigation(ROUTES.ADMIN.INDEX)) e.preventDefault()
+              }}
               className="text-lg font-bold tracking-tight"
             >
               AMANG Admin
@@ -71,6 +98,9 @@ export function AdminSidebar() {
           <div className="border-t border-neutral-200 px-3 py-4">
             <Link
               href={ROUTES.HOME}
+              onClick={(e) => {
+                if (guardNavigation(ROUTES.HOME)) e.preventDefault()
+              }}
               className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neutral-500 transition-colors hover:text-neutral-900"
             >
               사이트로 돌아가기

--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { Menu, Music, Users, Hash, Guitar, Mic } from "lucide-react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import ROUTES from "@/constants/routes"
+import { cn } from "@/lib/utils"
+
+const NAV_ITEMS = [
+  { href: ROUTES.ADMIN.USERS, label: "Users", icon: Users },
+  { href: ROUTES.ADMIN.GENERATIONS, label: "Generations", icon: Hash },
+  { href: ROUTES.ADMIN.PERFORMANCES, label: "Performances", icon: Music },
+  { href: ROUTES.ADMIN.TEAMS, label: "Teams", icon: Mic },
+  { href: ROUTES.ADMIN.SESSIONS, label: "Sessions", icon: Guitar }
+]
+
+function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname()
+
+  return (
+    <nav className="flex flex-col gap-1">
+      {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+        const isActive =
+          pathname === href ||
+          (href !== ROUTES.ADMIN.INDEX && pathname.startsWith(href))
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-neutral-900 text-white"
+                : "text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900"
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}
+
+export function AdminSidebar() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      {/* 데스크톱 사이드바 */}
+      <aside className="hidden w-60 flex-shrink-0 border-r border-neutral-200 bg-white md:block">
+        <div className="flex h-full flex-col">
+          <div className="border-b border-neutral-200 px-4 py-5">
+            <Link
+              href={ROUTES.ADMIN.INDEX}
+              className="text-lg font-bold tracking-tight"
+            >
+              AMANG Admin
+            </Link>
+          </div>
+          <div className="flex-1 px-3 py-4">
+            <NavLinks />
+          </div>
+          <div className="border-t border-neutral-200 px-3 py-4">
+            <Link
+              href={ROUTES.HOME}
+              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neutral-500 transition-colors hover:text-neutral-900"
+            >
+              사이트로 돌아가기
+            </Link>
+          </div>
+        </div>
+      </aside>
+
+      {/* 모바일 햄버거 */}
+      <div className="fixed left-4 top-4 z-50 md:hidden">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="icon">
+              <Menu className="h-4 w-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-60 p-0">
+            <div className="flex h-full flex-col">
+              <div className="border-b border-neutral-200 px-4 py-5">
+                <span className="text-lg font-bold tracking-tight">
+                  AMANG Admin
+                </span>
+              </div>
+              <div className="flex-1 px-3 py-4">
+                <NavLinks onNavigate={() => setOpen(false)} />
+              </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/(admin)/_components/UnsavedChangesContext.tsx
+++ b/apps/web/app/(admin)/_components/UnsavedChangesContext.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { createContext, useCallback, useContext, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+
+interface UnsavedChangesContextValue {
+  isDirty: boolean
+  setDirty: (dirty: boolean) => void
+  guardNavigation: (href: string) => boolean
+}
+
+const UnsavedChangesContext = createContext<UnsavedChangesContextValue>({
+  isDirty: false,
+  setDirty: () => {},
+  guardNavigation: () => false
+})
+
+export function useUnsavedChanges() {
+  return useContext(UnsavedChangesContext)
+}
+
+export function UnsavedChangesProvider({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  const router = useRouter()
+  const [dirty, setDirty] = useState(false)
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
+
+  const guardNavigation = useCallback(
+    (href: string): boolean => {
+      if (dirty) {
+        setPendingHref(href)
+        return true
+      }
+      return false
+    },
+    [dirty]
+  )
+
+  return (
+    <UnsavedChangesContext.Provider
+      value={{ isDirty: dirty, setDirty, guardNavigation }}
+    >
+      {children}
+
+      <Dialog
+        open={pendingHref !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingHref(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>저장하지 않고 나가시겠습니까?</DialogTitle>
+            <DialogDescription>
+              변경사항이 저장되지 않았습니다. 저장하지 않고 나가면 변경사항이
+              사라집니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingHref(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                const href = pendingHref
+                setDirty(false)
+                setPendingHref(null)
+                if (href) router.push(href)
+              }}
+            >
+              나가기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </UnsavedChangesContext.Provider>
+  )
+}

--- a/apps/web/app/(admin)/_components/UserSelectContent.tsx
+++ b/apps/web/app/(admin)/_components/UserSelectContent.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { SelectContent, SelectItem } from "@/components/ui/select"
+import { formatGenerationOrder } from "@/lib/utils"
+
+interface SelectableUser {
+  id: number
+  name: string
+  nickname: string
+  image: string | null
+  generation: { id: number; order: number }
+}
+
+interface UserSelectContentProps {
+  users: SelectableUser[] | undefined
+  allowNone?: boolean
+  noneLabel?: string
+}
+
+export function UserSelectContent({
+  users,
+  allowNone,
+  noneLabel = "없음"
+}: UserSelectContentProps) {
+  return (
+    <SelectContent>
+      {allowNone && <SelectItem value="none">{noneLabel}</SelectItem>}
+      {users?.map((user) => (
+        <SelectItem key={user.id} value={user.id.toString()}>
+          <div className="flex items-center gap-2">
+            <Avatar className="h-5 w-5">
+              <AvatarImage src={user.image ?? undefined} />
+              <AvatarFallback className="text-[10px]">
+                {user.name[0]}
+              </AvatarFallback>
+            </Avatar>
+            <span>{user.name}</span>
+            <span className="text-muted-foreground">{user.nickname}</span>
+            <span className="text-xs text-muted-foreground">
+              {formatGenerationOrder(user.generation.order)}기
+            </span>
+          </div>
+        </SelectItem>
+      ))}
+    </SelectContent>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/CopyRowLinkItem.tsx
+++ b/apps/web/app/(admin)/_components/data-table/CopyRowLinkItem.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { Check, Link2 } from "lucide-react"
+import { useState } from "react"
+
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+
+interface CopyRowLinkItemProps {
+  rowId: number
+}
+
+export function CopyRowLinkItem({ rowId }: CopyRowLinkItemProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    const url = new URL(window.location.href)
+    url.searchParams.set("rowId", String(rowId))
+    await navigator.clipboard.writeText(url.toString())
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <DropdownMenuItem onClick={handleCopy}>
+      {copied ? (
+        <Check className="mr-2 h-4 w-4 text-green-600" />
+      ) : (
+        <Link2 className="mr-2 h-4 w-4" />
+      )}
+      {copied ? "복사됨" : "링크 복사"}
+    </DropdownMenuItem>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DataTable.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTable.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable
+} from "@tanstack/react-table"
+import { useState } from "react"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { DataTablePagination } from "./DataTablePagination"
+import { DataTableToolbar } from "./DataTableToolbar"
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  isLoading?: boolean
+  searchColumn?: string
+  searchPlaceholder?: string
+  onCreateClick?: () => void
+  createLabel?: string
+  emptyMessage?: string
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  isLoading = false,
+  searchColumn,
+  searchPlaceholder,
+  onCreateClick,
+  createLabel,
+  emptyMessage = "데이터가 없습니다."
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    state: {
+      sorting,
+      columnFilters
+    }
+  })
+
+  return (
+    <div>
+      <DataTableToolbar
+        table={table}
+        searchColumn={searchColumn}
+        searchPlaceholder={searchPlaceholder}
+        onCreateClick={onCreateClick}
+        createLabel={createLabel}
+      />
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  {columns.map((_, j) => (
+                    <TableCell key={j}>
+                      <Skeleton className="h-5 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-neutral-500"
+                >
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {table.getFilteredRowModel().rows.length > 0 && (
+        <DataTablePagination table={table} />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DataTable.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTable.tsx
@@ -1,17 +1,48 @@
 "use client"
 
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  horizontalListSortingStrategy,
+  SortableContext
+} from "@dnd-kit/sortable"
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers"
+import {
   ColumnDef,
   ColumnFiltersState,
+  ColumnOrderState,
+  ColumnPinningState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  OnChangeFn,
+  RowSelectionState,
   SortingState,
-  useReactTable
+  useReactTable,
+  VisibilityState
 } from "@tanstack/react-table"
-import { useState } from "react"
+import { usePathname } from "next/navigation"
+import {
+  parseAsInteger,
+  parseAsString,
+  useQueryState,
+  useQueryStates
+} from "nuqs"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { cn } from "@/lib/utils"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import {
   Table,
@@ -24,7 +55,9 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 
 import { DataTablePagination } from "./DataTablePagination"
-import { DataTableToolbar } from "./DataTableToolbar"
+import { DataTableToolbar, type FilterConfig } from "./DataTableToolbar"
+import { DraggableHeader } from "./DraggableHeader"
+import "./types"
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -36,10 +69,56 @@ interface DataTableProps<TData, TValue> {
   createLabel?: string
   emptyMessage?: string
   initialSorting?: SortingState
+  onUpdateCell?: (
+    rowId: number,
+    columnId: string,
+    value: unknown
+  ) => Promise<void>
+  filters?: FilterConfig[]
+  initialColumnVisibility?: VisibilityState
+  onBulkDelete?: (rows: TData[]) => void
+  enableGlobalSearch?: boolean
 }
 
-export function DataTable<TData, TValue>({
-  columns,
+/**
+ * Thin shell that defers mount of DataTableInner until after hydration.
+ * nuqs hooks inside DataTableInner do async state sync during SSR hydration,
+ * triggering "Can't perform a React state update on a component that hasn't
+ * mounted yet". By rendering a skeleton on the server/first client render and
+ * only mounting the real table after useEffect fires, all nuqs hooks run in a
+ * pure client context where the URL is already available.
+ */
+export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  if (!hydrated) {
+    return (
+      <div className="rounded-md border">
+        <Table>
+          <TableBody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <TableRow key={i}>
+                {props.columns.map((_, j) => (
+                  <TableCell key={j}>
+                    <Skeleton className="h-5 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    )
+  }
+
+  return <DataTableInner {...props} />
+}
+
+function DataTableInner<TData, TValue>({
+  columns: userColumns,
   data,
   isLoading = false,
   searchColumn,
@@ -47,10 +126,223 @@ export function DataTable<TData, TValue>({
   onCreateClick,
   createLabel,
   emptyMessage = "데이터가 없습니다.",
-  initialSorting = []
+  initialSorting = [],
+  onUpdateCell,
+  filters = [],
+  initialColumnVisibility = {},
+  onBulkDelete,
+  enableGlobalSearch = false
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>(initialSorting)
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [editingCell, setEditingCell] = useState<string | null>(null)
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const [globalFilter, setGlobalFilter] = useState("")
+
+  // Inject select checkbox column when bulk delete is enabled
+  const hasBulkDelete = !!onBulkDelete
+  const columns = useMemo(() => {
+    if (!hasBulkDelete) return userColumns
+
+    const selectColumn: ColumnDef<TData, TValue> = {
+      id: "select",
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && "indeterminate")
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="전체 선택"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="행 선택"
+        />
+      ),
+      size: 32,
+      enableSorting: false,
+      enableHiding: false
+    }
+
+    return [selectColumn, ...userColumns]
+  }, [userColumns, hasBulkDelete])
+
+  // Column visibility — persisted in localStorage per page
+  const pathname = usePathname()
+  const visibilityStorageKey = `data-table-visibility:${pathname}`
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
+    initialColumnVisibility
+  )
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(visibilityStorageKey)
+      if (stored) setColumnVisibility(JSON.parse(stored))
+    } catch {
+      /* ignore */
+    }
+  }, [visibilityStorageKey])
+
+  const handleColumnVisibilityChange: OnChangeFn<VisibilityState> = useCallback(
+    (updaterOrValue) => {
+      setColumnVisibility((prev) => {
+        const next =
+          typeof updaterOrValue === "function"
+            ? updaterOrValue(prev)
+            : updaterOrValue
+        try {
+          localStorage.setItem(visibilityStorageKey, JSON.stringify(next))
+        } catch {
+          /* ignore */
+        }
+        return next
+      })
+    },
+    [visibilityStorageKey]
+  )
+
+  // URL-synced sorting state
+  const defaultSort = initialSorting[0]
+  const [sortId, setSortId] = useQueryState(
+    "sort",
+    parseAsString
+      .withDefault(defaultSort?.id ?? "")
+      .withOptions({ history: "replace" })
+  )
+  const [sortOrder, setSortOrder] = useQueryState(
+    "order",
+    parseAsString
+      .withDefault(defaultSort?.desc ? "desc" : "asc")
+      .withOptions({ history: "replace" })
+  )
+
+  const sorting: SortingState = useMemo(
+    () => (sortId ? [{ id: sortId, desc: sortOrder === "desc" }] : []),
+    [sortId, sortOrder]
+  )
+
+  const handleSortingChange: OnChangeFn<SortingState> = useCallback(
+    (updaterOrValue) => {
+      const next =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(sorting)
+          : updaterOrValue
+      const first = next[0]
+      if (first) {
+        setSortId(first.id)
+        setSortOrder(first.desc ? "desc" : "asc")
+      } else {
+        setSortId(null)
+        setSortOrder(null)
+      }
+    },
+    [sorting, setSortId, setSortOrder]
+  )
+
+  // URL-synced filter state via nuqs
+  const filterParsers = useMemo(
+    () => Object.fromEntries(filters.map((f) => [f.columnId, parseAsString])),
+    [filters]
+  )
+
+  const [urlFilters, setUrlFilters] = useQueryStates(filterParsers, {
+    history: "replace"
+  })
+
+  // Local search state (not in URL)
+  const [searchValue, setSearchValue] = useState("")
+
+  // Derive combined ColumnFiltersState for TanStack Table
+  const columnFilters: ColumnFiltersState = useMemo(() => {
+    const result: ColumnFiltersState = []
+
+    if (searchColumn && searchValue) {
+      result.push({ id: searchColumn, value: searchValue })
+    }
+
+    for (const [id, value] of Object.entries(urlFilters)) {
+      if (value != null) {
+        result.push({ id, value })
+      }
+    }
+
+    return result
+  }, [searchColumn, searchValue, urlFilters])
+
+  // Route filter changes to the right state store
+  const filterColumnIds = useMemo(
+    () => new Set(filters.map((f) => f.columnId)),
+    [filters]
+  )
+
+  const handleColumnFiltersChange: OnChangeFn<ColumnFiltersState> = useCallback(
+    (updaterOrValue) => {
+      const next =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(columnFilters)
+          : updaterOrValue
+
+      // Update search
+      if (searchColumn) {
+        const match = next.find((f) => f.id === searchColumn)
+        setSearchValue(match ? String(match.value) : "")
+      }
+
+      // Update URL filters
+      const urlUpdate: Record<string, string | null> = {}
+      for (const columnId of filterColumnIds) {
+        const match = next.find((f) => f.id === columnId)
+        urlUpdate[columnId] = match ? String(match.value) : null
+      }
+      setUrlFilters(urlUpdate)
+    },
+    [columnFilters, searchColumn, filterColumnIds, setUrlFilters]
+  )
+
+  // URL-synced highlighted row
+  const [highlightedRowId] = useQueryState(
+    "rowId",
+    parseAsInteger.withOptions({ history: "replace" })
+  )
+  const highlightRef = useRef<HTMLTableRowElement>(null)
+
+  // Column pinning: id left, actions right
+  const [columnPinning] = useState<ColumnPinningState>({
+    left: ["select", "id"],
+    right: ["actions"]
+  })
+
+  // Column order for drag reorder — lazy init from column defs
+  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
+    columns.map((c) => {
+      if ("id" in c && c.id) return c.id
+      if ("accessorKey" in c && typeof c.accessorKey === "string")
+        return c.accessorKey
+      return ""
+    })
+  )
+
+  // DnD sensors
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 5 }
+    }),
+    useSensor(KeyboardSensor)
+  )
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      setColumnOrder((prev) => {
+        const oldIndex = prev.indexOf(active.id as string)
+        const newIndex = prev.indexOf(over.id as string)
+        return arrayMove(prev, oldIndex, newIndex)
+      })
+    }
+  }, [])
 
   const table = useReactTable({
     data,
@@ -59,79 +351,183 @@ export function DataTable<TData, TValue>({
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: handleSortingChange,
+    onColumnFiltersChange: handleColumnFiltersChange,
+    onColumnVisibilityChange: handleColumnVisibilityChange,
+    onRowSelectionChange: setRowSelection,
+    onGlobalFilterChange: setGlobalFilter,
+    enableColumnResizing: true,
+    columnResizeMode: "onChange",
+    onColumnOrderChange: setColumnOrder,
     state: {
       sorting,
-      columnFilters
+      columnFilters,
+      columnVisibility,
+      columnOrder,
+      rowSelection,
+      globalFilter,
+      columnPinning
+    },
+    meta: {
+      updateCell: onUpdateCell,
+      editingCell,
+      setEditingCell
     }
   })
+
+  // Keep a ref to table so effects don't re-fire on every render
+  const tableRef = useRef(table)
+  tableRef.current = table
+
+  // Navigate to the page containing the highlighted row
+  useEffect(() => {
+    if (highlightedRowId == null) return
+    const t = tableRef.current
+    const allRows = t.getFilteredRowModel().rows
+    const rowIndex = allRows.findIndex(
+      (r) => (r.original as { id?: number }).id === highlightedRowId
+    )
+    if (rowIndex < 0) return
+
+    const pageSize = t.getState().pagination.pageSize
+    const targetPage = Math.floor(rowIndex / pageSize)
+    if (t.getState().pagination.pageIndex !== targetPage) {
+      t.setPageIndex(targetPage)
+    }
+  }, [highlightedRowId])
+
+  // Scroll highlighted row into view
+  useEffect(() => {
+    if (highlightRef.current) {
+      highlightRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center"
+      })
+    }
+  }, [highlightedRowId])
+
+  // Search handler for toolbar — routes to column filter or global filter
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      if (enableGlobalSearch) {
+        setGlobalFilter(value)
+      } else if (searchColumn) {
+        table.getColumn(searchColumn)?.setFilterValue(value || undefined)
+      }
+    },
+    [enableGlobalSearch, searchColumn, table]
+  )
+
+  const searchDisplayValue = enableGlobalSearch
+    ? globalFilter
+    : searchColumn
+      ? ((table.getColumn(searchColumn)?.getFilterValue() as string) ?? "")
+      : ""
 
   return (
     <div>
       <DataTableToolbar
         table={table}
-        searchColumn={searchColumn}
+        searchValue={searchDisplayValue}
+        onSearchChange={
+          searchColumn || enableGlobalSearch ? handleSearchChange : undefined
+        }
         searchPlaceholder={searchPlaceholder}
         onCreateClick={onCreateClick}
         createLabel={createLabel}
+        filters={filters}
+        onBulkDelete={
+          onBulkDelete
+            ? () => {
+                const selected = table
+                  .getFilteredSelectedRowModel()
+                  .rows.map((r) => r.original)
+                onBulkDelete(selected)
+                setRowSelection({})
+              }
+            : undefined
+        }
+        selectedCount={table.getFilteredSelectedRowModel().rows.length}
       />
 
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              Array.from({ length: 5 }).map((_, i) => (
-                <TableRow key={i}>
-                  {columns.map((_, j) => (
-                    <TableCell key={j}>
-                      <Skeleton className="h-5 w-full" />
-                    </TableCell>
-                  ))}
+      <DndContext
+        collisionDetection={closestCenter}
+        modifiers={[restrictToHorizontalAxis]}
+        sensors={sensors}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="overflow-x-auto rounded-md border">
+          <Table style={{ minWidth: table.getCenterTotalSize() }}>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  <SortableContext
+                    items={columnOrder}
+                    strategy={horizontalListSortingStrategy}
+                  >
+                    {headerGroup.headers.map((header) => (
+                      <DraggableHeader key={header.id} header={header} />
+                    ))}
+                  </SortableContext>
                 </TableRow>
-              ))
-            ) : table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
+              ))}
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {columns.map((_, j) => (
+                      <TableCell key={j}>
+                        <Skeleton className="h-5 w-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : table.getRowModel().rows?.length ? (
+                table.getRowModel().rows.map((row) => {
+                  const isHighlighted =
+                    highlightedRowId != null &&
+                    (row.original as { id?: number }).id === highlightedRowId
+
+                  return (
+                    <TableRow
+                      key={row.id}
+                      ref={isHighlighted ? highlightRef : undefined}
+                      data-state={row.getIsSelected() && "selected"}
+                      className={cn(
+                        isHighlighted &&
+                          "bg-primary/5 ring-1 ring-inset ring-primary/20"
                       )}
-                    </TableCell>
-                  ))}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell
+                          key={cell.id}
+                          className="relative"
+                          style={{ width: cell.column.getSize() }}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  )
+                })
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="h-24 text-center text-neutral-500"
+                  >
+                    {emptyMessage}
+                  </TableCell>
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center text-neutral-500"
-                >
-                  {emptyMessage}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </DndContext>
 
       {table.getFilteredRowModel().rows.length > 0 && (
         <DataTablePagination table={table} />

--- a/apps/web/app/(admin)/_components/data-table/DataTable.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTable.tsx
@@ -35,6 +35,7 @@ interface DataTableProps<TData, TValue> {
   onCreateClick?: () => void
   createLabel?: string
   emptyMessage?: string
+  initialSorting?: SortingState
 }
 
 export function DataTable<TData, TValue>({
@@ -45,9 +46,10 @@ export function DataTable<TData, TValue>({
   searchPlaceholder,
   onCreateClick,
   createLabel,
-  emptyMessage = "데이터가 없습니다."
+  emptyMessage = "데이터가 없습니다.",
+  initialSorting = []
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>(initialSorting)
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
   const table = useReactTable({

--- a/apps/web/app/(admin)/_components/data-table/DataTableColumnHeader.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableColumnHeader.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { Column } from "@tanstack/react-table"
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface DataTableColumnHeaderProps<TData, TValue> {
+  column: Column<TData, TValue>
+  title: string
+  className?: string
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  className
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  if (!column.getCanSort()) {
+    return <div className={cn(className)}>{title}</div>
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn("-ml-3 h-8 data-[state=open]:bg-accent", className)}
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+    >
+      {title}
+      {column.getIsSorted() === "desc" ? (
+        <ArrowDown className="ml-1 h-3 w-3" />
+      ) : column.getIsSorted() === "asc" ? (
+        <ArrowUp className="ml-1 h-3 w-3" />
+      ) : (
+        <ChevronsUpDown className="ml-1 h-3 w-3" />
+      )}
+    </Button>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DataTablePagination.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTablePagination.tsx
@@ -4,41 +4,79 @@ import { Table } from "@tanstack/react-table"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
 }
 
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
+
 export function DataTablePagination<TData>({
   table
 }: DataTablePaginationProps<TData>) {
+  const selectedCount = table.getFilteredSelectedRowModel().rows.length
+  const totalCount = table.getFilteredRowModel().rows.length
+
   return (
     <div className="flex items-center justify-between px-2 py-4">
       <div className="text-sm text-neutral-500">
-        총 {table.getFilteredRowModel().rows.length}개
+        {selectedCount > 0 ? (
+          <span>
+            {selectedCount}개 선택 / 총 {totalCount}개
+          </span>
+        ) : (
+          <span>총 {totalCount}개</span>
+        )}
       </div>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
-        >
-          <ChevronLeft className="h-4 w-4" />
-          이전
-        </Button>
-        <span className="text-sm text-neutral-600">
-          {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
-        >
-          다음
-          <ChevronRight className="h-4 w-4" />
-        </Button>
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-neutral-500">표시</span>
+          <Select
+            value={String(table.getState().pagination.pageSize)}
+            onValueChange={(v) => table.setPageSize(Number(v))}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <SelectItem key={size} value={String(size)}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            이전
+          </Button>
+          <span className="text-sm text-neutral-600">
+            {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            다음
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/app/(admin)/_components/data-table/DataTablePagination.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTablePagination.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Table } from "@tanstack/react-table"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+interface DataTablePaginationProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTablePagination<TData>({
+  table
+}: DataTablePaginationProps<TData>) {
+  return (
+    <div className="flex items-center justify-between px-2 py-4">
+      <div className="text-sm text-neutral-500">
+        총 {table.getFilteredRowModel().rows.length}개
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          <ChevronLeft className="h-4 w-4" />
+          이전
+        </Button>
+        <span className="text-sm text-neutral-600">
+          {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          다음
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
@@ -14,10 +14,16 @@ import {
   SelectValue
 } from "@/components/ui/select"
 
+export interface FilterOption {
+  label: string
+  value: string
+  render?: React.ReactNode
+}
+
 export interface FilterConfig {
   columnId: string
   label: string
-  options: { label: string; value: string }[]
+  options: FilterOption[]
 }
 
 interface DataTableToolbarProps<TData> {
@@ -115,8 +121,12 @@ export function DataTableToolbar<TData>({
             <SelectContent>
               <SelectItem value="__all__">전체 {filter.label}</SelectItem>
               {filter.options.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
+                <SelectItem
+                  key={opt.value}
+                  value={opt.value}
+                  textValue={opt.label}
+                >
+                  {opt.render ?? opt.label}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -128,11 +138,12 @@ export function DataTableToolbar<TData>({
         <Button
           variant="ghost"
           size="sm"
-          onClick={() =>
-            filters.forEach((f) =>
-              table.getColumn(f.columnId)?.setFilterValue(undefined)
+          onClick={() => {
+            const filterIds = new Set(filters.map((f) => f.columnId))
+            table.setColumnFilters((prev) =>
+              prev.filter((f) => !filterIds.has(f.id))
             )
-          }
+          }}
         >
           초기화
           <X className="ml-1 h-3 w-3" />

--- a/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
@@ -1,43 +1,160 @@
 "use client"
 
 import { Table } from "@tanstack/react-table"
-import { Plus, Search } from "lucide-react"
+import { Download, Plus, Search, Trash2, X } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { DataTableViewOptions } from "./DataTableViewOptions"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+export interface FilterConfig {
+  columnId: string
+  label: string
+  options: { label: string; value: string }[]
+}
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>
-  searchColumn?: string
+  searchValue?: string
+  onSearchChange?: (value: string) => void
   searchPlaceholder?: string
   onCreateClick?: () => void
   createLabel?: string
+  filters?: FilterConfig[]
+  onBulkDelete?: () => void
+  selectedCount?: number
+}
+
+function exportToCsv<TData>(table: Table<TData>) {
+  const visibleColumns = table
+    .getAllColumns()
+    .filter(
+      (col) => col.getIsVisible() && col.id !== "select" && col.id !== "actions"
+    )
+
+  const headers = visibleColumns.map(
+    (col) => col.columnDef.meta?.label ?? col.id
+  )
+
+  const rows = table.getFilteredRowModel().rows.map((row) =>
+    visibleColumns.map((col) => {
+      const value = row.getValue(col.id)
+      if (value == null) return ""
+      const str = String(value)
+      // Escape CSV values containing commas, quotes, or newlines
+      if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+        return `"${str.replace(/"/g, '""')}"`
+      }
+      return str
+    })
+  )
+
+  const csv = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n")
+  const blob = new Blob(["\uFEFF" + csv], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = `export-${new Date().toISOString().slice(0, 10)}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
 }
 
 export function DataTableToolbar<TData>({
   table,
-  searchColumn,
+  searchValue,
+  onSearchChange,
   searchPlaceholder = "검색...",
   onCreateClick,
-  createLabel = "생성"
+  createLabel = "생성",
+  filters = [],
+  onBulkDelete,
+  selectedCount = 0
 }: DataTableToolbarProps<TData>) {
+  const hasActiveFilters = filters.some(
+    (f) => table.getColumn(f.columnId)?.getFilterValue() != null
+  )
+
   return (
-    <div className="flex items-center justify-between gap-4 pb-4">
-      {searchColumn && (
+    <div className="flex flex-wrap items-center gap-4 pb-4">
+      {onSearchChange && (
         <div className="relative max-w-sm flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-400" />
           <Input
             placeholder={searchPlaceholder}
-            value={
-              (table.getColumn(searchColumn)?.getFilterValue() as string) ?? ""
-            }
-            onChange={(e) =>
-              table.getColumn(searchColumn)?.setFilterValue(e.target.value)
-            }
+            value={searchValue ?? ""}
+            onChange={(e) => onSearchChange(e.target.value)}
             className="pl-9"
           />
         </div>
       )}
+
+      {filters.map((filter) => {
+        const column = table.getColumn(filter.columnId)
+        if (!column) return null
+
+        const currentValue = column.getFilterValue() as string | undefined
+
+        return (
+          <Select
+            key={filter.columnId}
+            value={currentValue ?? "__all__"}
+            onValueChange={(v) =>
+              column.setFilterValue(v === "__all__" ? undefined : v)
+            }
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder={filter.label} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">전체 {filter.label}</SelectItem>
+              {filter.options.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )
+      })}
+
+      {hasActiveFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            filters.forEach((f) =>
+              table.getColumn(f.columnId)?.setFilterValue(undefined)
+            )
+          }
+        >
+          초기화
+          <X className="ml-1 h-3 w-3" />
+        </Button>
+      )}
+
+      {selectedCount > 0 && onBulkDelete && (
+        <Button variant="destructive" size="sm" onClick={onBulkDelete}>
+          <Trash2 className="mr-1 h-4 w-4" />
+          {selectedCount}개 삭제
+        </Button>
+      )}
+
+      <div className="flex-1" />
+
+      <Button variant="outline" size="sm" onClick={() => exportToCsv(table)}>
+        <Download className="mr-1 h-4 w-4" />
+        CSV
+      </Button>
+
+      <DataTableViewOptions table={table} />
+
       {onCreateClick && (
         <Button onClick={onCreateClick}>
           <Plus className="mr-1 h-4 w-4" />

--- a/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { Table } from "@tanstack/react-table"
+import { Plus, Search } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+interface DataTableToolbarProps<TData> {
+  table: Table<TData>
+  searchColumn?: string
+  searchPlaceholder?: string
+  onCreateClick?: () => void
+  createLabel?: string
+}
+
+export function DataTableToolbar<TData>({
+  table,
+  searchColumn,
+  searchPlaceholder = "검색...",
+  onCreateClick,
+  createLabel = "생성"
+}: DataTableToolbarProps<TData>) {
+  return (
+    <div className="flex items-center justify-between gap-4 pb-4">
+      {searchColumn && (
+        <div className="relative max-w-sm flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-400" />
+          <Input
+            placeholder={searchPlaceholder}
+            value={
+              (table.getColumn(searchColumn)?.getFilterValue() as string) ?? ""
+            }
+            onChange={(e) =>
+              table.getColumn(searchColumn)?.setFilterValue(e.target.value)
+            }
+            className="pl-9"
+          />
+        </div>
+      )}
+      {onCreateClick && (
+        <Button onClick={onCreateClick}>
+          <Plus className="mr-1 h-4 w-4" />
+          {createLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DataTableViewOptions.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableViewOptions.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Table } from "@tanstack/react-table"
+import { SlidersHorizontal } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+
+interface DataTableViewOptionsProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTableViewOptions<TData>({
+  table
+}: DataTableViewOptionsProps<TData>) {
+  const toggleableColumns = table
+    .getAllColumns()
+    .filter((column) => column.getCanHide())
+
+  if (toggleableColumns.length === 0) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <SlidersHorizontal className="mr-2 h-4 w-4" />
+          컬럼
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuLabel>컬럼 표시</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {toggleableColumns.map((column) => (
+          <DropdownMenuCheckboxItem
+            key={column.id}
+            checked={column.getIsVisible()}
+            onCheckedChange={(value) => column.toggleVisibility(!!value)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {column.columnDef.meta?.label ?? column.id}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DeleteConfirmDialog.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DeleteConfirmDialog.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+
+interface DeleteConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  title?: string
+  description?: string
+  isPending?: boolean
+}
+
+export function DeleteConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title = "삭제 확인",
+  description = "정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  isPending = false
+}: DeleteConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "삭제 중..." : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/DraggableHeader.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DraggableHeader.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useSortable } from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { Header, flexRender } from "@tanstack/react-table"
+import { GripVertical } from "lucide-react"
+import { CSSProperties } from "react"
+
+import { cn } from "@/lib/utils"
+import { TableHead } from "@/components/ui/table"
+
+interface DraggableHeaderProps<TData> {
+  header: Header<TData, unknown>
+}
+
+export function DraggableHeader<TData>({
+  header
+}: DraggableHeaderProps<TData>) {
+  const isPinned = header.column.getIsPinned()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({
+    id: header.column.id,
+    disabled: !!isPinned
+  })
+
+  const style: CSSProperties = {
+    width: header.getSize(),
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : 0,
+    position: "relative"
+  }
+
+  return (
+    <TableHead ref={setNodeRef} style={style} className="relative">
+      <div className="flex items-center gap-1">
+        {!isPinned && (
+          <GripVertical
+            className="h-3 w-3 shrink-0 cursor-grab text-neutral-400 active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+          />
+        )}
+        <div className="flex-1">
+          {header.isPlaceholder
+            ? null
+            : flexRender(header.column.columnDef.header, header.getContext())}
+        </div>
+      </div>
+      {header.column.getCanResize() && (
+        <div
+          onMouseDown={header.getResizeHandler()}
+          onTouchStart={header.getResizeHandler()}
+          className={cn(
+            "absolute right-0 top-0 h-full w-1 cursor-col-resize select-none touch-none",
+            "hover:bg-primary/50",
+            header.column.getIsResizing() && "bg-primary"
+          )}
+        />
+      )}
+    </TableHead>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/EditableCell.tsx
+++ b/apps/web/app/(admin)/_components/data-table/EditableCell.tsx
@@ -1,0 +1,387 @@
+"use client"
+
+import type { CellContext } from "@tanstack/react-table"
+import { Loader2, Pencil } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+
+import "./types"
+
+// --- Utility ---
+
+function toDatetimeLocal(date: Date | string): string {
+  const d = new Date(date)
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// --- Sub-editors ---
+
+interface EditorProps {
+  value: string
+  onChange: (v: string) => void
+  onSave: () => void
+  onCancel: () => void
+  isPending: boolean
+  inputRef: React.RefObject<HTMLInputElement | null>
+  type?: string
+  step?: number
+}
+
+function CellEditor({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  isPending,
+  inputRef,
+  type = "text",
+  step
+}: EditorProps) {
+  return (
+    <div className="absolute inset-0 z-10 flex items-center px-2">
+      <input
+        ref={inputRef}
+        type={type}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onSave}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            onSave()
+          }
+          if (e.key === "Escape") {
+            e.preventDefault()
+            onCancel()
+          }
+        }}
+        disabled={isPending}
+        className={cn(
+          "h-full w-full rounded-sm bg-background px-2 text-sm outline-none",
+          "ring-2 ring-ring",
+          isPending && "opacity-50"
+        )}
+      />
+      {isPending && (
+        <Loader2 className="absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2 animate-spin text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// --- Select cell editor ---
+
+function SelectCellEditor({
+  value,
+  options,
+  onSelect,
+  onCancel,
+  isPending
+}: {
+  value: string
+  options: { label: string; value: string }[]
+  onSelect: (value: string) => void
+  onCancel: () => void
+  isPending: boolean
+}) {
+  return (
+    <div className="absolute inset-0 z-10 flex items-center px-1">
+      <Select
+        defaultOpen
+        value={value}
+        onValueChange={onSelect}
+        onOpenChange={(open) => {
+          if (!open) onCancel()
+        }}
+        disabled={isPending}
+      >
+        <SelectTrigger className="h-7 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {isPending && (
+        <Loader2 className="absolute right-7 top-1/2 h-3 w-3 -translate-y-1/2 animate-spin text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// --- Boolean toggle cell ---
+
+function BooleanCellToggle({
+  checked,
+  rowId,
+  columnId,
+  updateCell
+}: {
+  checked: boolean
+  rowId: number
+  columnId: string
+  updateCell: (rowId: number, columnId: string, value: unknown) => Promise<void>
+}) {
+  const [isPending, setIsPending] = useState(false)
+
+  const handleToggle = async () => {
+    if (isPending) return
+    setIsPending(true)
+    try {
+      await updateCell(rowId, columnId, !checked)
+    } catch {
+      /* page-level handler shows toast */
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={handleToggle}
+        disabled={isPending}
+      />
+      {isPending && (
+        <Loader2 className="ml-1.5 h-3 w-3 animate-spin text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// --- Main EditableCell ---
+
+interface EditableCellProps<TData, TValue> {
+  cellContext: CellContext<TData, TValue>
+  displayValue: React.ReactNode
+}
+
+export function EditableCell<TData extends { id: number }, TValue>({
+  cellContext,
+  displayValue
+}: EditableCellProps<TData, TValue>) {
+  const { table, row, column } = cellContext
+  const meta = table.options.meta
+  const columnMeta = column.columnDef.meta
+
+  // Not editable — render display value only
+  if (!columnMeta?.editable || !meta?.updateCell) {
+    return <>{displayValue}</>
+  }
+
+  const editable = columnMeta.editable
+
+  // Boolean — direct toggle, no edit mode needed
+  if (editable.type === "boolean") {
+    return (
+      <BooleanCellToggle
+        checked={!!row.getValue(column.id)}
+        rowId={row.original.id}
+        columnId={column.id}
+        updateCell={meta.updateCell}
+      />
+    )
+  }
+
+  const cellId = `${row.original.id}-${column.id}`
+  const isEditing = meta.editingCell === cellId
+
+  return (
+    <EditableCellInner
+      key={cellId}
+      cellId={cellId}
+      isEditing={isEditing}
+      editable={editable}
+      rawValue={row.getValue(column.id)}
+      rowId={row.original.id}
+      columnId={column.id}
+      updateCell={meta.updateCell}
+      setEditingCell={meta.setEditingCell}
+      displayValue={displayValue}
+    />
+  )
+}
+
+// Inner component to use hooks unconditionally
+function EditableCellInner({
+  cellId,
+  isEditing,
+  editable,
+  rawValue,
+  rowId,
+  columnId,
+  updateCell,
+  setEditingCell,
+  displayValue
+}: {
+  cellId: string
+  isEditing: boolean
+  editable: NonNullable<
+    NonNullable<
+      import("@tanstack/react-table").ColumnMeta<unknown, unknown>
+    >["editable"]
+  >
+  rawValue: unknown
+  rowId: number
+  columnId: string
+  updateCell: (rowId: number, columnId: string, value: unknown) => Promise<void>
+  setEditingCell: (cellId: string | null) => void
+  displayValue: React.ReactNode
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isPending, setIsPending] = useState(false)
+  const [editValue, setEditValue] = useState("")
+  const savingRef = useRef(false)
+
+  // Initialize edit value when entering edit mode
+  useEffect(() => {
+    if (isEditing) {
+      let initial = ""
+      if (editable.type === "number" && editable.displayTransform) {
+        initial = editable.displayTransform(rawValue as number)
+      } else if (editable.type === "date" && rawValue) {
+        initial = toDatetimeLocal(rawValue as string | Date)
+      } else {
+        initial = rawValue != null ? String(rawValue) : ""
+      }
+      setEditValue(initial)
+      savingRef.current = false
+
+      // Focus after state update
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      })
+    }
+  }, [isEditing, rawValue, editable])
+
+  const handleSave = async () => {
+    if (savingRef.current || !isEditing) return
+    savingRef.current = true
+
+    // Compute save value
+    let saveValue: unknown = editValue
+    if (editable.type === "number") {
+      const num = parseFloat(editValue)
+      if (isNaN(num)) {
+        setEditingCell(null)
+        return
+      }
+      saveValue = editable.saveTransform ? editable.saveTransform(num) : num
+    } else if (editable.type === "date") {
+      saveValue = editValue || null
+    }
+
+    // Check if value actually changed
+    let originalForCompare: unknown = rawValue
+    if (editable.type === "number" && editable.displayTransform) {
+      originalForCompare = editable.displayTransform(rawValue as number)
+    } else if (editable.type === "date" && rawValue) {
+      originalForCompare = toDatetimeLocal(rawValue as string | Date)
+    } else {
+      originalForCompare = rawValue != null ? String(rawValue) : ""
+    }
+
+    if (String(editValue) === String(originalForCompare)) {
+      setEditingCell(null)
+      return
+    }
+
+    setIsPending(true)
+    try {
+      await updateCell(rowId, columnId, saveValue)
+      setEditingCell(null)
+    } catch {
+      // Page-level handler already showed toast; revert UI
+      setEditingCell(null)
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const handleSelectSave = async (newValue: string) => {
+    if (savingRef.current || !isEditing) return
+    savingRef.current = true
+
+    if (newValue === String(rawValue ?? "")) {
+      setEditingCell(null)
+      return
+    }
+
+    setIsPending(true)
+    try {
+      await updateCell(rowId, columnId, newValue)
+      setEditingCell(null)
+    } catch {
+      setEditingCell(null)
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const handleCancel = () => {
+    savingRef.current = true
+    setEditingCell(null)
+  }
+
+  if (!isEditing) {
+    return (
+      <div
+        className="group/cell -mx-2 -my-2 flex cursor-pointer items-center rounded px-2 py-2 hover:bg-muted/80"
+        onClick={() => setEditingCell(cellId)}
+      >
+        <span className="flex-1 truncate">
+          {displayValue || <span className="text-muted-foreground">-</span>}
+        </span>
+        <Pencil className="ml-1 h-3 w-3 shrink-0 text-muted-foreground/0 transition-colors group-hover/cell:text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (editable.type === "select") {
+    return (
+      <SelectCellEditor
+        value={String(rawValue ?? "")}
+        options={editable.options ?? []}
+        onSelect={handleSelectSave}
+        onCancel={handleCancel}
+        isPending={isPending}
+      />
+    )
+  }
+
+  return (
+    <CellEditor
+      value={editValue}
+      onChange={setEditValue}
+      onSave={handleSave}
+      onCancel={handleCancel}
+      isPending={isPending}
+      inputRef={inputRef}
+      type={
+        editable.type === "number"
+          ? "number"
+          : editable.type === "date"
+            ? "datetime-local"
+            : "text"
+      }
+      step={editable.type === "number" ? editable.step : undefined}
+    />
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/UserCell.tsx
+++ b/apps/web/app/(admin)/_components/data-table/UserCell.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import Link from "next/link"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { formatGenerationOrder } from "@/lib/utils"
+import ROUTES from "@/constants/routes"
+
+interface BasicUser {
+  id: number
+  name: string
+  image: string | null
+  generation?: { id: number; order: number } | null
+}
+
+interface UserCellProps {
+  user: BasicUser | null | undefined
+  fallback?: React.ReactNode
+}
+
+export function UserCell({ user, fallback = "-" }: UserCellProps) {
+  if (!user) return <>{fallback}</>
+
+  return (
+    <Link
+      href={`${ROUTES.ADMIN.USERS}?rowId=${user.id}`}
+      className="inline-flex items-center gap-1.5 text-blue-600 hover:underline"
+    >
+      <Avatar className="h-5 w-5">
+        <AvatarImage src={user.image ?? undefined} />
+        <AvatarFallback className="text-[10px]">{user.name[0]}</AvatarFallback>
+      </Avatar>
+      <span>{user.name}</span>
+      {user.generation && (
+        <span className="text-xs text-muted-foreground">
+          {formatGenerationOrder(user.generation.order)}기
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/apps/web/app/(admin)/_components/data-table/types.ts
+++ b/apps/web/app/(admin)/_components/data-table/types.ts
@@ -1,0 +1,26 @@
+import type { RowData } from "@tanstack/react-table"
+
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface TableMeta<TData extends RowData> {
+    updateCell?: (
+      rowId: number,
+      columnId: string,
+      value: unknown
+    ) => Promise<void>
+    editingCell: string | null
+    setEditingCell: (cellId: string | null) => void
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    label?: string
+    editable?: {
+      type: "text" | "number" | "date" | "select" | "boolean"
+      step?: number
+      displayTransform?: (v: number) => string
+      saveTransform?: (v: number) => number
+      options?: { label: string; value: string }[]
+    }
+  }
+}

--- a/apps/web/app/(admin)/_components/data-table/types.ts
+++ b/apps/web/app/(admin)/_components/data-table/types.ts
@@ -16,7 +16,7 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string
     editable?: {
-      type: "text" | "number" | "date" | "select" | "boolean"
+      type: "text" | "number" | "date" | "select" | "boolean" | "image" | "user"
       step?: number
       displayTransform?: (v: number) => string
       saveTransform?: (v: number) => number

--- a/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
@@ -21,13 +21,8 @@ import {
   FormMessage
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
+import { UserSelectContent } from "@/app/(admin)/_components/UserSelectContent"
+import { Select, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useUsers } from "@/hooks/api/useUser"
 import { formatGenerationOrder } from "@/lib/utils"
 import {
@@ -131,14 +126,7 @@ export function GenerationFormDialog({
                         <SelectValue placeholder="리더 선택 (선택사항)" />
                       </SelectTrigger>
                     </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">없음</SelectItem>
-                      {users?.map((user) => (
-                        <SelectItem key={user.id} value={user.id.toString()}>
-                          {user.name} ({user.nickname})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
+                    <UserSelectContent users={users} allowNone />
                   </Select>
                   <FormMessage />
                 </FormItem>

--- a/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { useUsers } from "@/hooks/api/useUser"
+import { formatGenerationOrder } from "@/lib/utils"
+import {
+  CreateGeneration,
+  CreateGenerationSchema,
+  GenerationWithBasicUsers
+} from "@repo/shared-types"
+
+interface GenerationFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateGeneration) => void
+  editingGeneration?: GenerationWithBasicUsers | null
+  isPending?: boolean
+}
+
+export function GenerationFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  editingGeneration,
+  isPending = false
+}: GenerationFormDialogProps) {
+  const { data: users } = useUsers()
+  const isEditing = !!editingGeneration
+
+  const form = useForm<CreateGeneration>({
+    resolver: zodResolver(CreateGenerationSchema),
+    defaultValues: {
+      order: 0,
+      leaderId: undefined
+    }
+  })
+
+  useEffect(() => {
+    if (open && editingGeneration) {
+      form.reset({
+        order: editingGeneration.order / 2,
+        leaderId: editingGeneration.leader?.id ?? undefined
+      })
+    } else if (open) {
+      form.reset({ order: 0, leaderId: undefined })
+    }
+  }, [open, editingGeneration, form])
+
+  const handleFormSubmit = (data: CreateGeneration) => {
+    onSubmit({ ...data, order: data.order * 2 })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing
+              ? `${formatGenerationOrder(editingGeneration.order)}기 편집`
+              : "기수 생성"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleFormSubmit)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="order"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>기수</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      step={0.5}
+                      {...field}
+                      onChange={(e) =>
+                        field.onChange(parseFloat(e.target.value))
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="leaderId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>리더</FormLabel>
+                  <Select
+                    value={field.value?.toString() ?? "none"}
+                    onValueChange={(v) =>
+                      field.onChange(v === "none" ? undefined : parseInt(v))
+                    }
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="리더 선택 (선택사항)" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="none">없음</SelectItem>
+                      {users?.map((user) => (
+                        <SelectItem key={user.id} value={user.id.toString()}>
+                          {user.name} ({user.nickname})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "저장 중..." : isEditing ? "수정" : "생성"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/generations/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/columns.tsx
@@ -24,13 +24,8 @@ interface ColumnActions {
   onDelete: (generation: GenerationWithBasicUsers) => void
 }
 
-interface ColumnOptions {
-  userOptions?: { label: string; value: string }[]
-}
-
 export function getColumns(
-  actions: ColumnActions,
-  options?: ColumnOptions
+  actions: ColumnActions
 ): ColumnDef<GenerationWithBasicUsers>[] {
   return [
     {
@@ -70,10 +65,7 @@ export function getColumns(
       ),
       meta: {
         label: "기장",
-        editable: {
-          type: "select",
-          options: options?.userOptions ?? []
-        }
+        editable: { type: "user" }
       },
       cell: (ctx) => (
         <EditableCell

--- a/apps/web/app/(admin)/admin/generations/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/columns.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { formatGenerationOrder } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { GenerationWithBasicUsers } from "@repo/shared-types"
+
+interface ColumnActions {
+  onEdit: (generation: GenerationWithBasicUsers) => void
+  onDelete: (generation: GenerationWithBasicUsers) => void
+}
+
+export function getColumns(
+  actions: ColumnActions
+): ColumnDef<GenerationWithBasicUsers>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60
+    },
+    {
+      accessorKey: "order",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="기수" />
+      ),
+      cell: ({ row }) => `${formatGenerationOrder(row.original.order)}기`
+    },
+    {
+      id: "leader",
+      header: "리더",
+      cell: ({ row }) => row.original.leader?.name ?? "-"
+    },
+    {
+      id: "memberCount",
+      header: "회원 수",
+      cell: ({ row }) => row.original.users.length
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/generations/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/columns.tsx
@@ -2,6 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table"
 import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
 import { formatGenerationOrder } from "@/lib/utils"
@@ -12,6 +13,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
+import ROUTES from "@/constants/routes"
 import { GenerationWithBasicUsers } from "@repo/shared-types"
 
 interface ColumnActions {
@@ -40,7 +42,18 @@ export function getColumns(
     {
       id: "leader",
       header: "리더",
-      cell: ({ row }) => row.original.leader?.name ?? "-"
+      cell: ({ row }) => {
+        const leader = row.original.leader
+        if (!leader) return "-"
+        return (
+          <Link
+            href={ROUTES.ADMIN.USERS}
+            className="text-blue-600 hover:underline"
+          >
+            {leader.name}
+          </Link>
+        )
+      }
     },
     {
       id: "memberCount",

--- a/apps/web/app/(admin)/admin/generations/page.tsx
+++ b/apps/web/app/(admin)/admin/generations/page.tsx
@@ -102,6 +102,7 @@ export default function GenerationsAdminPage() {
       <DataTable
         columns={columns}
         data={generations ?? []}
+        initialSorting={[{ id: "order", desc: true }]}
         isLoading={isLoading}
         onCreateClick={() => {
           setEditing(null)

--- a/apps/web/app/(admin)/admin/generations/page.tsx
+++ b/apps/web/app/(admin)/admin/generations/page.tsx
@@ -12,7 +12,6 @@ import {
   useGenerations,
   useUpdateGeneration
 } from "@/hooks/api/useGeneration"
-import { useUsers } from "@/hooks/api/useUser"
 import { formatGenerationOrder } from "@/lib/utils"
 import { GenerationWithBasicUsers } from "@repo/shared-types"
 
@@ -23,15 +22,6 @@ export default function GenerationsAdminPage() {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const { data: generations, isLoading } = useGenerations()
-  const { data: users } = useUsers()
-
-  const userOptions = useMemo(
-    () =>
-      (users ?? [])
-        .map((u) => ({ label: u.name, value: String(u.id) }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    [users]
-  )
 
   // 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false)
@@ -49,7 +39,7 @@ export default function GenerationsAdminPage() {
     async (rowId: number, columnId: string, value: unknown) => {
       const payload: Record<string, unknown> = {}
       if (columnId === "leader") {
-        payload.leaderId = Number(value)
+        payload.leaderId = value === "none" ? null : Number(value)
       } else {
         payload[columnId] = value
       }
@@ -71,20 +61,17 @@ export default function GenerationsAdminPage() {
 
   const columns = useMemo(
     () =>
-      getColumns(
-        {
-          onEdit: (gen) => {
-            setEditing(gen)
-            setFormOpen(true)
-          },
-          onDelete: (gen) => {
-            setDeleting(gen)
-            setDeleteOpen(true)
-          }
+      getColumns({
+        onEdit: (gen) => {
+          setEditing(gen)
+          setFormOpen(true)
         },
-        { userOptions }
-      ),
-    [userOptions]
+        onDelete: (gen) => {
+          setDeleting(gen)
+          setDeleteOpen(true)
+        }
+      }),
+    []
   )
 
   const handleSubmit = (data: { order: number; leaderId?: number }) => {

--- a/apps/web/app/(admin)/admin/generations/page.tsx
+++ b/apps/web/app/(admin)/admin/generations/page.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import {
+  useCreateGeneration,
+  useDeleteGeneration,
+  useGenerations,
+  useUpdateGeneration
+} from "@/hooks/api/useGeneration"
+import { formatGenerationOrder } from "@/lib/utils"
+import { GenerationWithBasicUsers } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+import { GenerationFormDialog } from "./_components/GenerationFormDialog"
+
+export default function GenerationsAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: generations, isLoading } = useGenerations()
+
+  // 다이얼로그 상태
+  const [formOpen, setFormOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editing, setEditing] = useState<GenerationWithBasicUsers | null>(null)
+  const [deleting, setDeleting] = useState<GenerationWithBasicUsers | null>(
+    null
+  )
+
+  const createMutation = useCreateGeneration()
+  const updateMutation = useUpdateGeneration()
+  const deleteMutation = useDeleteGeneration()
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onEdit: (gen) => {
+          setEditing(gen)
+          setFormOpen(true)
+        },
+        onDelete: (gen) => {
+          setDeleting(gen)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleSubmit = (data: { order: number; leaderId?: number }) => {
+    const mutation = editing
+      ? updateMutation.mutateAsync([editing.id, data])
+      : createMutation.mutateAsync([data])
+
+    mutation
+      .then(() => {
+        toast({
+          title: editing ? "기수가 수정되었습니다." : "기수가 생성되었습니다."
+        })
+        queryClient.invalidateQueries({ queryKey: ["generations"] })
+        setFormOpen(false)
+        setEditing(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "오류가 발생했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({
+          title: `${formatGenerationOrder(deleting.order)}기가 삭제되었습니다.`
+        })
+        queryClient.invalidateQueries({ queryKey: ["generations"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">기수 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={generations ?? []}
+        isLoading={isLoading}
+        onCreateClick={() => {
+          setEditing(null)
+          setFormOpen(true)
+        }}
+        createLabel="기수 생성"
+      />
+
+      <GenerationFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          setFormOpen(open)
+          if (!open) setEditing(null)
+        }}
+        onSubmit={handleSubmit}
+        editingGeneration={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${formatGenerationOrder(deleting.order)}기를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/page.tsx
+++ b/apps/web/app/(admin)/admin/page.tsx
@@ -1,7 +1,385 @@
-import { redirect } from "next/navigation"
+"use client"
 
+import { format } from "date-fns"
+import { Guitar, Hash, Mic, Music, Users } from "lucide-react"
+import Link from "next/link"
+import { useMemo } from "react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Skeleton } from "@/components/ui/skeleton"
 import ROUTES from "@/constants/routes"
+import { getSessionDisplayName } from "@/constants/session"
+import { useGenerations } from "@/hooks/api/useGeneration"
+import { usePerformances } from "@/hooks/api/usePerformance"
+import { useSessions } from "@/hooks/api/useSession"
+import { useAllTeams } from "@/hooks/api/useTeam"
+import { useUsers } from "@/hooks/api/useUser"
+import { formatGenerationOrder } from "@/lib/utils"
 
-export default function AdminIndexPage() {
-  redirect(ROUTES.ADMIN.USERS)
+// --- Summary Card ---
+
+function SummaryCard({
+  title,
+  count,
+  icon: Icon,
+  href,
+  isLoading
+}: {
+  title: string
+  count: number
+  icon: React.ElementType
+  href: string
+  isLoading: boolean
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-4 rounded-lg border bg-white p-5 transition-all hover:bg-neutral-50 hover:shadow-md hover:-translate-y-0.5"
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-100">
+        <Icon className="h-5 w-5 text-neutral-600" />
+      </div>
+      <div>
+        <p className="text-sm text-neutral-500">{title}</p>
+        {isLoading ? (
+          <Skeleton className="mt-1 h-7 w-12" />
+        ) : (
+          <p className="text-2xl font-bold">{count}</p>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+// --- Recent Activity Item ---
+
+function ActivityItem({
+  title,
+  subtitle,
+  date,
+  href
+}: {
+  title: string
+  subtitle: string
+  date: Date | string
+  href: string
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center justify-between rounded-md px-3 py-2.5 transition-colors hover:bg-neutral-50"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{title}</p>
+        <p className="truncate text-xs text-neutral-500">{subtitle}</p>
+      </div>
+      <span className="ml-4 shrink-0 text-xs text-neutral-400">
+        {format(new Date(date), "MM/dd HH:mm")}
+      </span>
+    </Link>
+  )
+}
+
+// --- Unfilled Team Item ---
+
+function UnfilledTeamItem({
+  team
+}: {
+  team: {
+    id: number
+    songName: string
+    performanceId: number
+    leader: {
+      id: number
+      name: string
+      image: string | null
+      generation: { id: number; order: number }
+    }
+    teamSessions: {
+      capacity: number
+      members: { userId: number }[]
+      session: { name: string }
+    }[]
+  }
+}) {
+  const totalCapacity = team.teamSessions.reduce((s, ts) => s + ts.capacity, 0)
+  const totalMembers = team.teamSessions.reduce(
+    (s, ts) => s + ts.members.length,
+    0
+  )
+  const unfilledSessions = team.teamSessions
+    .filter((ts) => ts.members.length < ts.capacity)
+    .map((ts) => getSessionDisplayName(ts.session.name))
+
+  return (
+    <Link
+      href={ROUTES.ADMIN.TEAM_DETAIL(team.id)}
+      className="flex items-center justify-between rounded-md px-3 py-2.5 transition-colors hover:bg-neutral-50"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{team.songName}</span>
+          <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-700">
+            {totalMembers}/{totalCapacity}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Avatar className="h-5 w-5">
+            <AvatarImage src={team.leader.image ?? undefined} />
+            <AvatarFallback className="text-[10px]">
+              {team.leader.name[0]}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-xs text-neutral-500">{team.leader.name}</span>
+          {unfilledSessions.length > 0 && (
+            <span className="text-xs text-neutral-400">
+              · 미충원: {unfilledSessions.join(", ")}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+// --- Main Dashboard ---
+
+export default function AdminDashboardPage() {
+  const { data: users, isLoading: usersLoading } = useUsers()
+  const { data: generations, isLoading: generationsLoading } = useGenerations()
+  const { data: performances, isLoading: performancesLoading } =
+    usePerformances()
+  const { data: teams, isLoading: teamsLoading } = useAllTeams()
+  const { data: sessions, isLoading: sessionsLoading } = useSessions()
+
+  // Recent performances (latest 5 by createdAt)
+  const recentPerformances = useMemo(
+    () =>
+      [...(performances ?? [])]
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+        .slice(0, 5),
+    [performances]
+  )
+
+  // Recent teams (latest 5 by createdAt)
+  const recentTeams = useMemo(
+    () =>
+      [...(teams ?? [])]
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+        .slice(0, 5),
+    [teams]
+  )
+
+  // Unfilled teams (teams with members < capacity)
+  const unfilledTeams = useMemo(
+    () =>
+      (teams ?? []).filter((team) => {
+        const totalCapacity = team.teamSessions.reduce(
+          (s, ts) => s + ts.capacity,
+          0
+        )
+        const totalMembers = team.teamSessions.reduce(
+          (s, ts) => s + ts.members.length,
+          0
+        )
+        return totalCapacity > 0 && totalMembers < totalCapacity
+      }),
+    [teams]
+  )
+
+  // Performance name lookup
+  const performanceMap = useMemo(
+    () => new Map(performances?.map((p) => [p.id, p.name]) ?? []),
+    [performances]
+  )
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">대시보드</h1>
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <SummaryCard
+          title="회원"
+          count={users?.length ?? 0}
+          icon={Users}
+          href={ROUTES.ADMIN.USERS}
+          isLoading={usersLoading}
+        />
+        <SummaryCard
+          title="기수"
+          count={generations?.length ?? 0}
+          icon={Hash}
+          href={ROUTES.ADMIN.GENERATIONS}
+          isLoading={generationsLoading}
+        />
+        <SummaryCard
+          title="공연"
+          count={performances?.length ?? 0}
+          icon={Music}
+          href={ROUTES.ADMIN.PERFORMANCES}
+          isLoading={performancesLoading}
+        />
+        <SummaryCard
+          title="팀"
+          count={teams?.length ?? 0}
+          icon={Mic}
+          href={ROUTES.ADMIN.TEAMS}
+          isLoading={teamsLoading}
+        />
+        <SummaryCard
+          title="세션"
+          count={sessions?.length ?? 0}
+          icon={Guitar}
+          href={ROUTES.ADMIN.SESSIONS}
+          isLoading={sessionsLoading}
+        />
+      </div>
+
+      {/* Content Grid */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Recent Performances */}
+        <div className="rounded-lg border bg-white transition-shadow hover:shadow-md">
+          <div className="flex items-center justify-between border-b px-4 py-3">
+            <h2 className="font-semibold">최근 공연</h2>
+            <Link
+              href={ROUTES.ADMIN.PERFORMANCES}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              전체 보기
+            </Link>
+          </div>
+          <div className="divide-y">
+            {performancesLoading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="px-3 py-2.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="mt-1 h-3 w-24" />
+                </div>
+              ))
+            ) : recentPerformances.length > 0 ? (
+              recentPerformances.map((p) => (
+                <ActivityItem
+                  key={p.id}
+                  title={p.name}
+                  subtitle={
+                    [
+                      p.location,
+                      p.startAt && format(new Date(p.startAt), "yyyy-MM-dd")
+                    ]
+                      .filter(Boolean)
+                      .join(" · ") || "정보 없음"
+                  }
+                  date={p.createdAt}
+                  href={`${ROUTES.ADMIN.PERFORMANCES}?rowId=${p.id}`}
+                />
+              ))
+            ) : (
+              <p className="px-3 py-6 text-center text-sm text-neutral-400">
+                등록된 공연이 없습니다.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Recent Teams */}
+        <div className="rounded-lg border bg-white transition-shadow hover:shadow-md">
+          <div className="flex items-center justify-between border-b px-4 py-3">
+            <h2 className="font-semibold">최근 팀</h2>
+            <Link
+              href={ROUTES.ADMIN.TEAMS}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              전체 보기
+            </Link>
+          </div>
+          <div className="divide-y">
+            {teamsLoading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="px-3 py-2.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="mt-1 h-3 w-24" />
+                </div>
+              ))
+            ) : recentTeams.length > 0 ? (
+              recentTeams.map((t) => (
+                <ActivityItem
+                  key={t.id}
+                  title={`${t.songName} - ${t.songArtist}`}
+                  subtitle={[performanceMap.get(t.performanceId), t.leader.name]
+                    .filter(Boolean)
+                    .join(" · ")}
+                  date={t.createdAt}
+                  href={ROUTES.ADMIN.TEAM_DETAIL(t.id)}
+                />
+              ))
+            ) : (
+              <p className="px-3 py-6 text-center text-sm text-neutral-400">
+                등록된 팀이 없습니다.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Unfilled Teams */}
+        {unfilledTeams.length > 0 && (
+          <div className="rounded-lg border bg-white transition-shadow hover:shadow-md lg:col-span-2">
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <h2 className="font-semibold">
+                미충원 팀{" "}
+                <span className="text-sm font-normal text-neutral-400">
+                  ({unfilledTeams.length})
+                </span>
+              </h2>
+            </div>
+            <div className="divide-y">
+              {unfilledTeams.map((team) => (
+                <UnfilledTeamItem key={team.id} team={team} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Generation Overview */}
+        {!generationsLoading && generations && generations.length > 0 && (
+          <div className="rounded-lg border bg-white transition-shadow hover:shadow-md lg:col-span-2">
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <h2 className="font-semibold">기수별 현황</h2>
+              <Link
+                href={ROUTES.ADMIN.GENERATIONS}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                전체 보기
+              </Link>
+            </div>
+            <div className="flex flex-wrap gap-3 p-4">
+              {[...generations]
+                .sort((a, b) => b.order - a.order)
+                .slice(0, 10)
+                .map((gen) => (
+                  <Link
+                    key={gen.id}
+                    href={`${ROUTES.ADMIN.USERS}?generation=${gen.order}`}
+                    className="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-all hover:bg-neutral-50 hover:shadow-sm hover:-translate-y-0.5"
+                  >
+                    <span className="font-medium">
+                      {formatGenerationOrder(gen.order)}기
+                    </span>
+                    <span className="text-neutral-400">
+                      {gen.users.length}명
+                    </span>
+                  </Link>
+                ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/apps/web/app/(admin)/admin/page.tsx
+++ b/apps/web/app/(admin)/admin/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation"
+
+import ROUTES from "@/constants/routes"
+
+export default function AdminIndexPage() {
+  redirect(ROUTES.ADMIN.USERS)
+}

--- a/apps/web/app/(admin)/admin/performances/_components/PerformanceFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/performances/_components/PerformanceFormDialog.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Performance } from "@repo/shared-types"
+
+// Admin용 간소화 스키마 (posterImage 파일 업로드 제외)
+const AdminPerformanceSchema = z.object({
+  name: z.string().min(1, "공연 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  startAt: z.string().nullable().optional(),
+  endAt: z.string().nullable().optional()
+})
+
+type AdminPerformanceForm = z.infer<typeof AdminPerformanceSchema>
+
+interface PerformanceFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: AdminPerformanceForm) => void
+  editingPerformance?: Performance | null
+  isPending?: boolean
+}
+
+function toDatetimeLocal(date: Date | string | null | undefined): string {
+  if (!date) return ""
+  const d = new Date(date)
+  if (isNaN(d.getTime())) return ""
+  return d.toISOString().slice(0, 16)
+}
+
+export function PerformanceFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  editingPerformance,
+  isPending = false
+}: PerformanceFormDialogProps) {
+  const isEditing = !!editingPerformance
+
+  const form = useForm<AdminPerformanceForm>({
+    resolver: zodResolver(AdminPerformanceSchema),
+    defaultValues: {
+      name: "",
+      description: null,
+      location: null,
+      startAt: null,
+      endAt: null
+    }
+  })
+
+  useEffect(() => {
+    if (open && editingPerformance) {
+      form.reset({
+        name: editingPerformance.name,
+        description: editingPerformance.description,
+        location: editingPerformance.location,
+        startAt: toDatetimeLocal(editingPerformance.startAt),
+        endAt: toDatetimeLocal(editingPerformance.endAt)
+      })
+    } else if (open) {
+      form.reset({
+        name: "",
+        description: null,
+        location: null,
+        startAt: null,
+        endAt: null
+      })
+    }
+  }, [open, editingPerformance, form])
+
+  const handleSubmit = (data: AdminPerformanceForm) => {
+    onSubmit({
+      ...data,
+      startAt: data.startAt || null,
+      endAt: data.endAt || null
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? `${editingPerformance.name} 편집` : "공연 생성"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>공연명</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>설명</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} value={field.value ?? ""} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>장소</FormLabel>
+                  <FormControl>
+                    <Input {...field} value={field.value ?? ""} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="startAt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>시작일시</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="datetime-local"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="endAt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>종료일시</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="datetime-local"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "저장 중..." : isEditing ? "수정" : "생성"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/performances/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/performances/_components/columns.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { format } from "date-fns"
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { Performance } from "@repo/shared-types"
+
+interface ColumnActions {
+  onEdit: (performance: Performance) => void
+  onDelete: (performance: Performance) => void
+}
+
+export function getColumns(actions: ColumnActions): ColumnDef<Performance>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="공연명" />
+      )
+    },
+    {
+      accessorKey: "location",
+      header: "장소",
+      cell: ({ row }) => row.original.location ?? "-"
+    },
+    {
+      accessorKey: "startAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="시작일" />
+      ),
+      cell: ({ row }) => {
+        const startAt = row.original.startAt
+        return startAt ? format(new Date(startAt), "yyyy-MM-dd HH:mm") : "-"
+      }
+    },
+    {
+      accessorKey: "endAt",
+      header: "종료일",
+      cell: ({ row }) => {
+        const endAt = row.original.endAt
+        return endAt ? format(new Date(endAt), "yyyy-MM-dd HH:mm") : "-"
+      }
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/performances/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/performances/_components/columns.tsx
@@ -4,7 +4,9 @@ import { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
 
+import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -26,35 +28,101 @@ export function getColumns(actions: ColumnActions): ColumnDef<Performance>[] {
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="ID" />
       ),
-      size: 60
+      size: 60,
+      enableHiding: false
     },
     {
       accessorKey: "name",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="공연명" />
+      ),
+      meta: { label: "공연명", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell cellContext={ctx} displayValue={ctx.row.original.name} />
       )
     },
     {
+      accessorKey: "description",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="설명" />
+      ),
+      meta: { label: "설명", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            <span className="max-w-[200px] truncate">
+              {ctx.row.original.description ?? "-"}
+            </span>
+          }
+        />
+      )
+    },
+    {
+      accessorKey: "posterImage",
+      header: "포스터",
+      meta: { label: "포스터" },
+      cell: ({ row }) => {
+        const url = row.original.posterImage
+        if (!url) return "-"
+        return (
+          <img
+            src={url}
+            alt="포스터"
+            className="h-10 w-8 rounded object-cover"
+          />
+        )
+      }
+    },
+    {
       accessorKey: "location",
-      header: "장소",
-      cell: ({ row }) => row.original.location ?? "-"
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="장소" />
+      ),
+      meta: { label: "장소", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.row.original.location ?? "-"}
+        />
+      ),
+      filterFn: (row, _columnId, filterValue) =>
+        row.original.location === filterValue
     },
     {
       accessorKey: "startAt",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="시작일" />
       ),
-      cell: ({ row }) => {
-        const startAt = row.original.startAt
-        return startAt ? format(new Date(startAt), "yyyy-MM-dd HH:mm") : "-"
+      meta: { label: "시작일", editable: { type: "date" } },
+      cell: (ctx) => {
+        const startAt = ctx.row.original.startAt
+        return (
+          <EditableCell
+            cellContext={ctx}
+            displayValue={
+              startAt ? format(new Date(startAt), "yyyy-MM-dd HH:mm") : "-"
+            }
+          />
+        )
       }
     },
     {
       accessorKey: "endAt",
-      header: "종료일",
-      cell: ({ row }) => {
-        const endAt = row.original.endAt
-        return endAt ? format(new Date(endAt), "yyyy-MM-dd HH:mm") : "-"
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="종료일" />
+      ),
+      meta: { label: "종료일", editable: { type: "date" } },
+      cell: (ctx) => {
+        const endAt = ctx.row.original.endAt
+        return (
+          <EditableCell
+            cellContext={ctx}
+            displayValue={
+              endAt ? format(new Date(endAt), "yyyy-MM-dd HH:mm") : "-"
+            }
+          />
+        )
       }
     },
     {
@@ -67,6 +135,7 @@ export function getColumns(actions: ColumnActions): ColumnDef<Performance>[] {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <CopyRowLinkItem rowId={row.original.id} />
             <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
               <Pencil className="mr-2 h-4 w-4" />
               편집
@@ -81,7 +150,8 @@ export function getColumns(actions: ColumnActions): ColumnDef<Performance>[] {
           </DropdownMenuContent>
         </DropdownMenu>
       ),
-      size: 50
+      size: 50,
+      enableHiding: false
     }
   ]
 }

--- a/apps/web/app/(admin)/admin/performances/page.tsx
+++ b/apps/web/app/(admin)/admin/performances/page.tsx
@@ -112,6 +112,7 @@ export default function PerformancesAdminPage() {
         columns={columns}
         data={performances ?? []}
         isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: true }]}
         searchColumn="name"
         searchPlaceholder="공연 검색..."
         onCreateClick={() => {

--- a/apps/web/app/(admin)/admin/performances/page.tsx
+++ b/apps/web/app/(admin)/admin/performances/page.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import {
+  useCreatePerformance,
+  useDeletePerformance,
+  usePerformances,
+  useUpdatePerformance
+} from "@/hooks/api/usePerformance"
+import { Performance } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+import { PerformanceFormDialog } from "./_components/PerformanceFormDialog"
+
+export default function PerformancesAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: performances, isLoading } = usePerformances()
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editing, setEditing] = useState<Performance | null>(null)
+  const [deleting, setDeleting] = useState<Performance | null>(null)
+
+  const createMutation = useCreatePerformance()
+  const updateMutation = useUpdatePerformance()
+  const deleteMutation = useDeletePerformance()
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onEdit: (perf) => {
+          setEditing(perf)
+          setFormOpen(true)
+        },
+        onDelete: (perf) => {
+          setDeleting(perf)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleSubmit = (data: {
+    name: string
+    description?: string | null
+    location?: string | null
+    startAt?: string | null
+    endAt?: string | null
+  }) => {
+    // datetime-local string을 Date로 변환
+    const payload = {
+      name: data.name,
+      description: data.description,
+      location: data.location,
+      startAt: data.startAt ? new Date(data.startAt) : null,
+      endAt: data.endAt ? new Date(data.endAt) : null
+    }
+
+    const mutation = editing
+      ? updateMutation.mutateAsync([editing.id, payload])
+      : createMutation.mutateAsync([payload])
+
+    mutation
+      .then(() => {
+        toast({
+          title: editing ? "공연이 수정되었습니다." : "공연이 생성되었습니다."
+        })
+        queryClient.invalidateQueries({ queryKey: ["performances"] })
+        setFormOpen(false)
+        setEditing(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "오류가 발생했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({ title: `${deleting.name} 공연이 삭제되었습니다.` })
+        queryClient.invalidateQueries({ queryKey: ["performances"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">공연 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={performances ?? []}
+        isLoading={isLoading}
+        searchColumn="name"
+        searchPlaceholder="공연 검색..."
+        onCreateClick={() => {
+          setEditing(null)
+          setFormOpen(true)
+        }}
+        createLabel="공연 생성"
+      />
+
+      <PerformanceFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          setFormOpen(open)
+          if (!open) setEditing(null)
+        }}
+        onSubmit={handleSubmit}
+        editingPerformance={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${deleting.name} 공연을 삭제하시겠습니까? 소속 팀도 모두 삭제됩니다.`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/performances/page.tsx
+++ b/apps/web/app/(admin)/admin/performances/page.tsx
@@ -12,6 +12,7 @@ import {
   usePerformances,
   useUpdatePerformance
 } from "@/hooks/api/usePerformance"
+import { useAllTeams } from "@/hooks/api/useTeam"
 import { Performance } from "@repo/shared-types"
 
 import { getColumns } from "./_components/columns"
@@ -21,6 +22,15 @@ export default function PerformancesAdminPage() {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const { data: performances, isLoading } = usePerformances()
+  const { data: teams } = useAllTeams()
+
+  const teamCountMap = useMemo(() => {
+    const map = new Map<number, number>()
+    for (const team of teams ?? []) {
+      map.set(team.performanceId, (map.get(team.performanceId) ?? 0) + 1)
+    }
+    return map
+  }, [teams])
 
   const [formOpen, setFormOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -64,17 +74,20 @@ export default function PerformancesAdminPage() {
 
   const columns = useMemo(
     () =>
-      getColumns({
-        onEdit: (perf) => {
-          setEditing(perf)
-          setFormOpen(true)
+      getColumns(
+        {
+          onEdit: (perf) => {
+            setEditing(perf)
+            setFormOpen(true)
+          },
+          onDelete: (perf) => {
+            setDeleting(perf)
+            setDeleteOpen(true)
+          }
         },
-        onDelete: (perf) => {
-          setDeleting(perf)
-          setDeleteOpen(true)
-        }
-      }),
-    []
+        teamCountMap
+      ),
+    [teamCountMap]
   )
 
   const handleSubmit = (data: {

--- a/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { SessionName } from "@repo/database"
+import { SESSION_NAMES } from "@/constants/session"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 
@@ -57,7 +57,7 @@ export function SessionFormDialog({
   const form = useForm<CreateSession>({
     resolver: zodResolver(CreateSessionSchema),
     defaultValues: {
-      name: SessionName.VOCAL,
+      name: SESSION_NAMES.VOCAL,
       leaderId: undefined
     }
   })
@@ -69,7 +69,7 @@ export function SessionFormDialog({
         leaderId: editingSession.leader?.id ?? undefined
       })
     } else if (open) {
-      form.reset({ name: SessionName.VOCAL, leaderId: undefined })
+      form.reset({ name: SESSION_NAMES.VOCAL, leaderId: undefined })
     }
   }, [open, editingSession, form])
 
@@ -103,7 +103,7 @@ export function SessionFormDialog({
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {Object.values(SessionName).map((name) => (
+                      {Object.values(SESSION_NAMES).map((name) => (
                         <SelectItem key={name} value={name}>
                           {getSessionDisplayName(name)}
                         </SelectItem>

--- a/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
@@ -21,6 +21,7 @@ import {
   FormLabel,
   FormMessage
 } from "@/components/ui/form"
+import { UserSelectContent } from "@/app/(admin)/_components/UserSelectContent"
 import {
   Select,
   SelectContent,
@@ -132,14 +133,7 @@ export function SessionFormDialog({
                         <SelectValue placeholder="리더 선택 (선택사항)" />
                       </SelectTrigger>
                     </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">없음</SelectItem>
-                      {users?.map((user) => (
-                        <SelectItem key={user.id} value={user.id.toString()}>
-                          {user.name} ({user.nickname})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
+                    <UserSelectContent users={users} allowNone />
                   </Select>
                   <FormMessage />
                 </FormItem>

--- a/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { SessionName } from "@repo/database"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { getSessionDisplayName } from "@/constants/session"
+import { useUsers } from "@/hooks/api/useUser"
+import {
+  CreateSession,
+  CreateSessionSchema,
+  SessionWithBasicUsers
+} from "@repo/shared-types"
+
+interface SessionFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateSession) => void
+  editingSession?: SessionWithBasicUsers | null
+  isPending?: boolean
+}
+
+export function SessionFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  editingSession,
+  isPending = false
+}: SessionFormDialogProps) {
+  const { data: users } = useUsers()
+  const isEditing = !!editingSession
+
+  const form = useForm<CreateSession>({
+    resolver: zodResolver(CreateSessionSchema),
+    defaultValues: {
+      name: SessionName.VOCAL,
+      leaderId: undefined
+    }
+  })
+
+  useEffect(() => {
+    if (open && editingSession) {
+      form.reset({
+        name: editingSession.name,
+        leaderId: editingSession.leader?.id ?? undefined
+      })
+    } else if (open) {
+      form.reset({ name: SessionName.VOCAL, leaderId: undefined })
+    }
+  }, [open, editingSession, form])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing
+              ? `${getSessionDisplayName(editingSession.name)} 편집`
+              : "세션 생성"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>세션명</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={isEditing}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.values(SessionName).map((name) => (
+                        <SelectItem key={name} value={name}>
+                          {getSessionDisplayName(name)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="leaderId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>리더</FormLabel>
+                  <Select
+                    value={field.value?.toString() ?? "none"}
+                    onValueChange={(v) =>
+                      field.onChange(v === "none" ? undefined : parseInt(v))
+                    }
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="리더 선택 (선택사항)" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="none">없음</SelectItem>
+                      {users?.map((user) => (
+                        <SelectItem key={user.id} value={user.id.toString()}>
+                          {user.name} ({user.nickname})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "저장 중..." : isEditing ? "수정" : "생성"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
@@ -27,17 +27,12 @@ interface ColumnActions {
   onDelete: (session: SessionWithBasicUsers) => void
 }
 
-interface ColumnOptions {
-  userOptions?: { label: string; value: string }[]
-}
-
 const sessionNameOptions = Object.entries(SESSION_DISPLAY_NAME).map(
   ([value, label]) => ({ label, value })
 )
 
 export function getColumns(
-  actions: ColumnActions,
-  options?: ColumnOptions
+  actions: ColumnActions
 ): ColumnDef<SessionWithBasicUsers>[] {
   return [
     {
@@ -66,14 +61,22 @@ export function getColumns(
     },
     {
       accessorKey: "icon",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="아이콘" />
-      ),
-      meta: { label: "아이콘", editable: { type: "text" } },
+      header: "아이콘",
+      meta: { label: "아이콘", editable: { type: "image" } },
       cell: (ctx) => (
         <EditableCell
           cellContext={ctx}
-          displayValue={ctx.row.original.icon ?? "-"}
+          displayValue={
+            ctx.row.original.icon ? (
+              <img
+                src={ctx.row.original.icon}
+                alt="아이콘"
+                className="h-8 w-8 rounded object-contain"
+              />
+            ) : (
+              "-"
+            )
+          }
         />
       )
     },
@@ -85,10 +88,7 @@ export function getColumns(
       ),
       meta: {
         label: "세션장",
-        editable: {
-          type: "select",
-          options: options?.userOptions ?? []
-        }
+        editable: { type: "user" }
       },
       cell: (ctx) => (
         <EditableCell

--- a/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
@@ -2,6 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table"
 import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
 import { Button } from "@/components/ui/button"
@@ -12,6 +13,7 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import { getSessionDisplayName } from "@/constants/session"
+import ROUTES from "@/constants/routes"
 import { SessionWithBasicUsers } from "@repo/shared-types"
 
 interface ColumnActions {
@@ -40,7 +42,18 @@ export function getColumns(
     {
       id: "leader",
       header: "리더",
-      cell: ({ row }) => row.original.leader?.name ?? "-"
+      cell: ({ row }) => {
+        const leader = row.original.leader
+        if (!leader) return "-"
+        return (
+          <Link
+            href={ROUTES.ADMIN.USERS}
+            className="text-blue-600 hover:underline"
+          >
+            {leader.name}
+          </Link>
+        )
+      }
     },
     {
       id: "memberCount",

--- a/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/columns.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { getSessionDisplayName } from "@/constants/session"
+import { SessionWithBasicUsers } from "@repo/shared-types"
+
+interface ColumnActions {
+  onEdit: (session: SessionWithBasicUsers) => void
+  onDelete: (session: SessionWithBasicUsers) => void
+}
+
+export function getColumns(
+  actions: ColumnActions
+): ColumnDef<SessionWithBasicUsers>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="세션명" />
+      ),
+      cell: ({ row }) => getSessionDisplayName(row.original.name)
+    },
+    {
+      id: "leader",
+      header: "리더",
+      cell: ({ row }) => row.original.leader?.name ?? "-"
+    },
+    {
+      id: "memberCount",
+      header: "회원 수",
+      cell: ({ row }) => row.original.users.length
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/sessions/page.tsx
+++ b/apps/web/app/(admin)/admin/sessions/page.tsx
@@ -100,6 +100,7 @@ export default function SessionsAdminPage() {
         columns={columns}
         data={sessions ?? []}
         isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: false }]}
         searchColumn="name"
         searchPlaceholder="세션 검색..."
         onCreateClick={() => {

--- a/apps/web/app/(admin)/admin/sessions/page.tsx
+++ b/apps/web/app/(admin)/admin/sessions/page.tsx
@@ -13,7 +13,6 @@ import {
   useSessions,
   useUpdateSession
 } from "@/hooks/api/useSession"
-import { useUsers } from "@/hooks/api/useUser"
 import { CreateSession, SessionWithBasicUsers } from "@repo/shared-types"
 
 import { getColumns } from "./_components/columns"
@@ -23,15 +22,6 @@ export default function SessionsAdminPage() {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const { data: sessions, isLoading } = useSessions()
-  const { data: users } = useUsers()
-
-  const userOptions = useMemo(
-    () =>
-      (users ?? [])
-        .map((u) => ({ label: u.name, value: String(u.id) }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    [users]
-  )
 
   const [formOpen, setFormOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -46,7 +36,7 @@ export default function SessionsAdminPage() {
     async (rowId: number, columnId: string, value: unknown) => {
       const payload: Record<string, unknown> = {}
       if (columnId === "leader") {
-        payload.leaderId = Number(value)
+        payload.leaderId = value === "none" ? null : Number(value)
       } else {
         payload[columnId] = value
       }
@@ -68,20 +58,17 @@ export default function SessionsAdminPage() {
 
   const columns = useMemo(
     () =>
-      getColumns(
-        {
-          onEdit: (session) => {
-            setEditing(session)
-            setFormOpen(true)
-          },
-          onDelete: (session) => {
-            setDeleting(session)
-            setDeleteOpen(true)
-          }
+      getColumns({
+        onEdit: (session) => {
+          setEditing(session)
+          setFormOpen(true)
         },
-        { userOptions }
-      ),
-    [userOptions]
+        onDelete: (session) => {
+          setDeleting(session)
+          setDeleteOpen(true)
+        }
+      }),
+    []
   )
 
   const handleSubmit = (data: CreateSession) => {

--- a/apps/web/app/(admin)/admin/sessions/page.tsx
+++ b/apps/web/app/(admin)/admin/sessions/page.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import { getSessionDisplayName } from "@/constants/session"
+import {
+  useCreateSession,
+  useDeleteSession,
+  useSessions,
+  useUpdateSession
+} from "@/hooks/api/useSession"
+import { CreateSession, SessionWithBasicUsers } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+import { SessionFormDialog } from "./_components/SessionFormDialog"
+
+export default function SessionsAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: sessions, isLoading } = useSessions()
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editing, setEditing] = useState<SessionWithBasicUsers | null>(null)
+  const [deleting, setDeleting] = useState<SessionWithBasicUsers | null>(null)
+
+  const createMutation = useCreateSession()
+  const updateMutation = useUpdateSession()
+  const deleteMutation = useDeleteSession()
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onEdit: (session) => {
+          setEditing(session)
+          setFormOpen(true)
+        },
+        onDelete: (session) => {
+          setDeleting(session)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleSubmit = (data: CreateSession) => {
+    const mutation = editing
+      ? updateMutation.mutateAsync([editing.id, data])
+      : createMutation.mutateAsync([data])
+
+    mutation
+      .then(() => {
+        toast({
+          title: editing ? "세션이 수정되었습니다." : "세션이 생성되었습니다."
+        })
+        queryClient.invalidateQueries({ queryKey: ["sessions"] })
+        setFormOpen(false)
+        setEditing(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "오류가 발생했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({
+          title: `${getSessionDisplayName(deleting.name)} 세션이 삭제되었습니다.`
+        })
+        queryClient.invalidateQueries({ queryKey: ["sessions"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">세션 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={sessions ?? []}
+        isLoading={isLoading}
+        searchColumn="name"
+        searchPlaceholder="세션 검색..."
+        onCreateClick={() => {
+          setEditing(null)
+          setFormOpen(true)
+        }}
+        createLabel="세션 생성"
+      />
+
+      <SessionFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          setFormOpen(open)
+          if (!open) setEditing(null)
+        }}
+        onSubmit={handleSubmit}
+        editingSession={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${getSessionDisplayName(deleting.name)} 세션을 삭제하시겠습니까?`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/MemberSelectDialog.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/MemberSelectDialog.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
 import {
   Dialog,
   DialogContent,
@@ -10,6 +11,7 @@ import {
   DialogTitle
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { getSessionDisplayName } from "@/constants/session"
 import { useUsers } from "@/hooks/api/useUser"
 import { formatGenerationOrder } from "@/lib/utils"
 
@@ -41,7 +43,7 @@ export function MemberSelectDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>멤버 선택</DialogTitle>
         </DialogHeader>
@@ -52,31 +54,54 @@ export function MemberSelectDialog({
           onChange={(e) => setSearch(e.target.value)}
         />
 
-        <div className="max-h-64 overflow-y-auto">
+        <div className="max-h-80 overflow-y-auto">
           {filteredUsers.length === 0 ? (
-            <p className="py-4 text-center text-sm text-neutral-500">
+            <p className="py-8 text-center text-sm text-neutral-500">
               검색 결과가 없습니다.
             </p>
           ) : (
-            <div className="space-y-1">
+            <div className="divide-y">
               {filteredUsers.map((user) => (
-                <Button
+                <button
                   key={user.id}
-                  variant="ghost"
-                  className="w-full justify-start"
+                  type="button"
+                  className="flex w-full items-center gap-3 px-2 py-2.5 text-left transition-colors hover:bg-muted/60"
                   onClick={() => {
                     onSelect(user.id)
                     setSearch("")
                   }}
                 >
-                  <span className="font-medium">{user.name}</span>
-                  <span className="ml-2 text-neutral-500">
-                    ({user.nickname})
-                  </span>
-                  <span className="ml-auto text-xs text-neutral-400">
-                    {formatGenerationOrder(user.generation.order)}기
-                  </span>
-                </Button>
+                  <Avatar className="h-8 w-8 shrink-0">
+                    <AvatarImage src={user.image ?? undefined} />
+                    <AvatarFallback className="text-xs">
+                      {user.name[0]}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="text-sm font-medium">{user.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {user.nickname}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatGenerationOrder(user.generation.order)}기
+                      </span>
+                    </div>
+                    {user.sessions.length > 0 && (
+                      <div className="mt-0.5 flex gap-1">
+                        {user.sessions.map((s) => (
+                          <Badge
+                            key={s.id}
+                            variant="outline"
+                            className="px-1.5 py-0 text-[10px]"
+                          >
+                            {getSessionDisplayName(s.name)}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </button>
               ))}
             </div>
           )}

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/MemberSelectDialog.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/MemberSelectDialog.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { useUsers } from "@/hooks/api/useUser"
+import { formatGenerationOrder } from "@/lib/utils"
+
+interface MemberSelectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (userId: number) => void
+  excludeUserIds: Set<number>
+}
+
+export function MemberSelectDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  excludeUserIds
+}: MemberSelectDialogProps) {
+  const { data: users } = useUsers()
+  const [search, setSearch] = useState("")
+
+  const filteredUsers =
+    users
+      ?.filter((u) => !excludeUserIds.has(u.id))
+      .filter(
+        (u) =>
+          !search ||
+          u.name.toLowerCase().includes(search.toLowerCase()) ||
+          u.nickname.toLowerCase().includes(search.toLowerCase())
+      ) ?? []
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>멤버 선택</DialogTitle>
+        </DialogHeader>
+
+        <Input
+          placeholder="이름 또는 닉네임 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        <div className="max-h-64 overflow-y-auto">
+          {filteredUsers.length === 0 ? (
+            <p className="py-4 text-center text-sm text-neutral-500">
+              검색 결과가 없습니다.
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {filteredUsers.map((user) => (
+                <Button
+                  key={user.id}
+                  variant="ghost"
+                  className="w-full justify-start"
+                  onClick={() => {
+                    onSelect(user.id)
+                    setSearch("")
+                  }}
+                >
+                  <span className="font-medium">{user.name}</span>
+                  <span className="ml-2 text-neutral-500">
+                    ({user.nickname})
+                  </span>
+                  <span className="ml-auto text-xs text-neutral-400">
+                    {formatGenerationOrder(user.generation.order)}기
+                  </span>
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { SessionName } from "@repo/database"
 import { Minus, Plus, X } from "lucide-react"
 import { useState } from "react"
 

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import { getSessionDisplayName } from "@/constants/session"
+import { getSessionDisplayName, SESSION_NAMES } from "@/constants/session"
 import { useSessions } from "@/hooks/api/useSession"
 import { useUsers } from "@/hooks/api/useUser"
 import { TeamDetail } from "@repo/shared-types"
@@ -156,102 +156,121 @@ export function TeamSessionsEditor({
           세션이 없습니다. 세션을 추가해주세요.
         </p>
       ) : (
-        <div className="space-y-4">
-          {memberSessions.map((ms, sessionIndex) => (
-            <div key={ms.sessionId} className="rounded-md border p-4">
-              <div className="mb-3 flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <span className="font-medium">
-                    {getSessionName(ms.sessionId)}
-                  </span>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="h-6 w-6"
-                      onClick={() =>
-                        updateCapacity(sessionIndex, ms.capacity - 1)
-                      }
-                    >
-                      <Minus className="h-3 w-3" />
-                    </Button>
-                    <Input
-                      type="number"
-                      value={ms.capacity}
-                      onChange={(e) =>
-                        updateCapacity(
-                          sessionIndex,
-                          parseInt(e.target.value) || 1
-                        )
-                      }
-                      className="h-6 w-12 text-center"
-                      min={1}
-                    />
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="h-6 w-6"
-                      onClick={() =>
-                        updateCapacity(sessionIndex, ms.capacity + 1)
-                      }
-                    >
-                      <Plus className="h-3 w-3" />
-                    </Button>
-                  </div>
-                  <Badge variant="secondary">
-                    {ms.members.length}/{ms.capacity}
-                  </Badge>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 text-red-500"
-                  onClick={() => removeSession(sessionIndex)}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-
-              {/* 멤버 목록 */}
-              <div className="flex flex-wrap gap-2">
-                {ms.members
-                  .sort((a, b) => a.index - b.index)
-                  .map((member) => (
-                    <Badge
-                      key={member.userId}
-                      variant="outline"
-                      className="flex items-center gap-1 py-1"
-                    >
-                      <span className="text-neutral-400">{member.index}.</span>
-                      {getUserName(member.userId)}
-                      <button
+        <div className="grid gap-4 lg:grid-cols-2">
+          {[...memberSessions.entries()]
+            .sort(([, a], [, b]) => {
+              const order = Object.values(SESSION_NAMES)
+              const aName =
+                teamDetail.teamSessions.find(
+                  (ts) => ts.sessionId === a.sessionId
+                )?.session.name ??
+                sessions?.find((s) => s.id === a.sessionId)?.name
+              const bName =
+                teamDetail.teamSessions.find(
+                  (ts) => ts.sessionId === b.sessionId
+                )?.session.name ??
+                sessions?.find((s) => s.id === b.sessionId)?.name
+              const aIdx = order.indexOf(aName as (typeof order)[number])
+              const bIdx = order.indexOf(bName as (typeof order)[number])
+              return (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx)
+            })
+            .map(([sessionIndex, ms]) => (
+              <div key={ms.sessionId} className="rounded-md border p-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="font-medium">
+                      {getSessionName(ms.sessionId)}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-6 w-6"
                         onClick={() =>
-                          removeMember(sessionIndex, member.userId)
+                          updateCapacity(sessionIndex, ms.capacity - 1)
                         }
-                        className="ml-1 rounded-full hover:bg-neutral-100"
                       >
-                        <X className="h-3 w-3" />
-                      </button>
+                        <Minus className="h-3 w-3" />
+                      </Button>
+                      <Input
+                        type="number"
+                        value={ms.capacity}
+                        onChange={(e) =>
+                          updateCapacity(
+                            sessionIndex,
+                            parseInt(e.target.value) || 1
+                          )
+                        }
+                        className="h-6 w-12 text-center"
+                        min={1}
+                      />
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-6 w-6"
+                        onClick={() =>
+                          updateCapacity(sessionIndex, ms.capacity + 1)
+                        }
+                      >
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                    </div>
+                    <Badge variant="outline">
+                      {ms.members.length}/{ms.capacity}
                     </Badge>
-                  ))}
-
-                {ms.members.length < ms.capacity && (
+                  </div>
                   <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7"
-                    onClick={() => {
-                      setEditingSessionIndex(sessionIndex)
-                      setMemberDialogOpen(true)
-                    }}
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-red-500"
+                    onClick={() => removeSession(sessionIndex)}
                   >
-                    <Plus className="mr-1 h-3 w-3" />
-                    멤버 추가
+                    <X className="h-4 w-4" />
                   </Button>
-                )}
+                </div>
+
+                {/* 멤버 목록 */}
+                <div className="flex flex-wrap gap-2">
+                  {ms.members
+                    .sort((a, b) => a.index - b.index)
+                    .map((member) => (
+                      <Badge
+                        key={member.userId}
+                        variant="outline"
+                        className="flex items-center gap-1 py-1"
+                      >
+                        <span className="text-neutral-400">
+                          {member.index}.
+                        </span>
+                        {getUserName(member.userId)}
+                        <button
+                          onClick={() =>
+                            removeMember(sessionIndex, member.userId)
+                          }
+                          className="ml-1 rounded-full hover:bg-neutral-100"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    ))}
+
+                  {ms.members.length < ms.capacity && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7"
+                      onClick={() => {
+                        setEditingSessionIndex(sessionIndex)
+                        setMemberDialogOpen(true)
+                      }}
+                    >
+                      <Plus className="mr-1 h-3 w-3" />
+                      멤버 추가
+                    </Button>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
         </div>
       )}
 

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import { SessionName } from "@repo/database"
+import { Minus, Plus, X } from "lucide-react"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { getSessionDisplayName } from "@/constants/session"
+import { useSessions } from "@/hooks/api/useSession"
+import { useUsers } from "@/hooks/api/useUser"
+import { TeamDetail } from "@repo/shared-types"
+
+import { MemberSelectDialog } from "./MemberSelectDialog"
+
+type MemberSessionState = {
+  sessionId: number
+  capacity: number
+  members: { userId: number; index: number }[]
+}
+
+interface TeamSessionsEditorProps {
+  memberSessions: MemberSessionState[]
+  onChange: (sessions: MemberSessionState[]) => void
+  teamDetail: TeamDetail
+}
+
+export function TeamSessionsEditor({
+  memberSessions,
+  onChange,
+  teamDetail
+}: TeamSessionsEditorProps) {
+  const { data: sessions } = useSessions()
+  const { data: users } = useUsers()
+  const [memberDialogOpen, setMemberDialogOpen] = useState(false)
+  const [editingSessionIndex, setEditingSessionIndex] = useState<number | null>(
+    null
+  )
+
+  // 현재 사용되지 않은 세션 목록
+  const usedSessionIds = new Set(memberSessions.map((ms) => ms.sessionId))
+  const availableSessions =
+    sessions?.filter((s) => !usedSessionIds.has(s.id)) ?? []
+
+  const addSession = (sessionId: number) => {
+    onChange([...memberSessions, { sessionId, capacity: 1, members: [] }])
+  }
+
+  const removeSession = (index: number) => {
+    onChange(memberSessions.filter((_, i) => i !== index))
+  }
+
+  const updateCapacity = (index: number, capacity: number) => {
+    if (capacity < 1) return
+    const current = memberSessions[index]!
+    const updated = [...memberSessions]
+    updated[index] = {
+      sessionId: current.sessionId,
+      capacity,
+      // capacity보다 큰 index의 멤버 제거
+      members: current.members.filter((m) => m.index <= capacity)
+    }
+    onChange(updated)
+  }
+
+  const removeMember = (sessionIndex: number, userId: number) => {
+    const current = memberSessions[sessionIndex]!
+    const updated = [...memberSessions]
+    updated[sessionIndex] = {
+      sessionId: current.sessionId,
+      capacity: current.capacity,
+      members: current.members.filter((m) => m.userId !== userId)
+    }
+    onChange(updated)
+  }
+
+  const addMember = (sessionIndex: number, userId: number) => {
+    const current = memberSessions[sessionIndex]!
+    // 다음 빈 index 찾기
+    const usedIndices = new Set(current.members.map((m) => m.index))
+    let nextIndex = 1
+    while (usedIndices.has(nextIndex) && nextIndex <= current.capacity) {
+      nextIndex++
+    }
+    if (nextIndex > current.capacity) return
+
+    const updated = [...memberSessions]
+    updated[sessionIndex] = {
+      sessionId: current.sessionId,
+      capacity: current.capacity,
+      members: [...current.members, { userId, index: nextIndex }]
+    }
+    onChange(updated)
+    setMemberDialogOpen(false)
+  }
+
+  const getSessionName = (sessionId: number): string => {
+    // teamDetail에서 먼저 찾기
+    const ts = teamDetail.teamSessions.find((ts) => ts.sessionId === sessionId)
+    if (ts) return getSessionDisplayName(ts.session.name)
+
+    // sessions 데이터에서 찾기
+    const session = sessions?.find((s) => s.id === sessionId)
+    return session ? getSessionDisplayName(session.name) : `세션 ${sessionId}`
+  }
+
+  const getUserName = (userId: number): string => {
+    // teamDetail에서 먼저 찾기
+    for (const ts of teamDetail.teamSessions) {
+      const member = ts.members.find((m) => m.userId === userId)
+      if (member) return `${member.user.name} (${member.user.nickname})`
+    }
+
+    // users 데이터에서 찾기
+    const user = users?.find((u) => u.id === userId)
+    return user ? `${user.name} (${user.nickname})` : `유저 ${userId}`
+  }
+
+  // 현재 팀에 이미 배정된 유저 ID 모음 (멤버 중복 배정 방지용)
+  const assignedUserIds = new Set(
+    memberSessions.flatMap((ms) => ms.members.map((m) => m.userId))
+  )
+
+  return (
+    <div className="rounded-lg border bg-white p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">세션 구성</h2>
+        {availableSessions.length > 0 && (
+          <Select onValueChange={(v) => addSession(parseInt(v))}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="세션 추가" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableSessions.map((s) => (
+                <SelectItem key={s.id} value={s.id.toString()}>
+                  {getSessionDisplayName(s.name)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      {memberSessions.length === 0 ? (
+        <p className="py-8 text-center text-neutral-500">
+          세션이 없습니다. 세션을 추가해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {memberSessions.map((ms, sessionIndex) => (
+            <div key={ms.sessionId} className="rounded-md border p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="font-medium">
+                    {getSessionName(ms.sessionId)}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="h-6 w-6"
+                      onClick={() =>
+                        updateCapacity(sessionIndex, ms.capacity - 1)
+                      }
+                    >
+                      <Minus className="h-3 w-3" />
+                    </Button>
+                    <Input
+                      type="number"
+                      value={ms.capacity}
+                      onChange={(e) =>
+                        updateCapacity(
+                          sessionIndex,
+                          parseInt(e.target.value) || 1
+                        )
+                      }
+                      className="h-6 w-12 text-center"
+                      min={1}
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="h-6 w-6"
+                      onClick={() =>
+                        updateCapacity(sessionIndex, ms.capacity + 1)
+                      }
+                    >
+                      <Plus className="h-3 w-3" />
+                    </Button>
+                  </div>
+                  <Badge variant="secondary">
+                    {ms.members.length}/{ms.capacity}
+                  </Badge>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-red-500"
+                  onClick={() => removeSession(sessionIndex)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {/* 멤버 목록 */}
+              <div className="flex flex-wrap gap-2">
+                {ms.members
+                  .sort((a, b) => a.index - b.index)
+                  .map((member) => (
+                    <Badge
+                      key={member.userId}
+                      variant="outline"
+                      className="flex items-center gap-1 py-1"
+                    >
+                      <span className="text-neutral-400">{member.index}.</span>
+                      {getUserName(member.userId)}
+                      <button
+                        onClick={() =>
+                          removeMember(sessionIndex, member.userId)
+                        }
+                        className="ml-1 rounded-full hover:bg-neutral-100"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+
+                {ms.members.length < ms.capacity && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7"
+                    onClick={() => {
+                      setEditingSessionIndex(sessionIndex)
+                      setMemberDialogOpen(true)
+                    }}
+                  >
+                    <Plus className="mr-1 h-3 w-3" />
+                    멤버 추가
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <MemberSelectDialog
+        open={memberDialogOpen}
+        onOpenChange={setMemberDialogOpen}
+        onSelect={(userId) => {
+          if (editingSessionIndex !== null) {
+            addMember(editingSessionIndex, userId)
+          }
+        }}
+        excludeUserIds={assignedUserIds}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/_components/TeamSessionsEditor.tsx
@@ -123,9 +123,12 @@ export function TeamSessionsEditor({
     return user ? `${user.name} (${user.nickname})` : `유저 ${userId}`
   }
 
-  // 현재 팀에 이미 배정된 유저 ID 모음 (멤버 중복 배정 방지용)
-  const assignedUserIds = new Set(
-    memberSessions.flatMap((ms) => ms.members.map((m) => m.userId))
+  // 현재 편집 중인 세션에 이미 배정된 유저만 제외 (다른 세션과 중복 허용)
+  const currentSessionUserIds = new Set(
+    editingSessionIndex !== null
+      ? (memberSessions[editingSessionIndex]?.members.map((m) => m.userId) ??
+          [])
+      : []
   )
 
   return (
@@ -260,7 +263,7 @@ export function TeamSessionsEditor({
             addMember(editingSessionIndex, userId)
           }
         }}
-        excludeUserIds={assignedUserIds}
+        excludeUserIds={currentSessionUserIds}
       />
     </div>
   )

--- a/apps/web/app/(admin)/admin/teams/[teamId]/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/page.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { ArrowLeft, Save } from "lucide-react"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import { useToast } from "@/components/hooks/use-toast"
+import ROUTES from "@/constants/routes"
+import { useTeam, useUpdateTeam } from "@/hooks/api/useTeam"
+import { useUsers } from "@/hooks/api/useUser"
+import { TeamDetail, UpdateTeam } from "@repo/shared-types"
+
+import { TeamSessionsEditor } from "./_components/TeamSessionsEditor"
+
+type MemberSessionState = {
+  sessionId: number
+  capacity: number
+  members: { userId: number; index: number }[]
+}
+
+export default function TeamDetailAdminPage() {
+  const { teamId } = useParams<{ teamId: string }>()
+  const id = parseInt(teamId)
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+
+  const { data: team, isLoading } = useTeam(id)
+  const { data: users } = useUsers()
+  const updateMutation = useUpdateTeam()
+
+  // 폼 상태
+  const [name, setName] = useState("")
+  const [songName, setSongName] = useState("")
+  const [songArtist, setSongArtist] = useState("")
+  const [leaderId, setLeaderId] = useState<number>(0)
+  const [isFreshmenFixed, setIsFreshmenFixed] = useState(false)
+  const [isSelfMade, setIsSelfMade] = useState(false)
+  const [songYoutubeVideoUrl, setSongYoutubeVideoUrl] = useState("")
+  const [memberSessions, setMemberSessions] = useState<MemberSessionState[]>([])
+
+  // 팀 데이터 로드 시 폼에 반영
+  useEffect(() => {
+    if (team) {
+      setName(team.name)
+      setSongName(team.songName)
+      setSongArtist(team.songArtist)
+      setLeaderId(team.leaderId)
+      setIsFreshmenFixed(team.isFreshmenFixed)
+      setIsSelfMade(team.isSelfMade)
+      setSongYoutubeVideoUrl(team.songYoutubeVideoUrl ?? "")
+      setMemberSessions(
+        team.teamSessions.map((ts) => ({
+          sessionId: ts.sessionId,
+          capacity: ts.capacity,
+          members: ts.members.map((m) => ({
+            userId: m.userId,
+            index: m.index
+          }))
+        }))
+      )
+    }
+  }, [team])
+
+  const handleSave = useCallback(() => {
+    const payload: UpdateTeam = {
+      name,
+      songName,
+      songArtist,
+      leaderId,
+      isFreshmenFixed,
+      isSelfMade,
+      songYoutubeVideoUrl: songYoutubeVideoUrl || undefined,
+      memberSessions
+    }
+
+    updateMutation
+      .mutateAsync([id, payload])
+      .then(() => {
+        toast({ title: "팀이 수정되었습니다." })
+        queryClient.invalidateQueries({ queryKey: ["team", id] })
+        queryClient.invalidateQueries({ queryKey: ["teams"] })
+      })
+      .catch((error) => {
+        toast({
+          title: "수정에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }, [
+    id,
+    name,
+    songName,
+    songArtist,
+    leaderId,
+    isFreshmenFixed,
+    isSelfMade,
+    songYoutubeVideoUrl,
+    memberSessions,
+    updateMutation,
+    queryClient,
+    toast
+  ])
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (!team) {
+    return <div className="text-neutral-500">팀을 찾을 수 없습니다.</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link href={ROUTES.ADMIN.TEAMS}>
+            <Button variant="ghost" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-2xl font-bold">팀 편집</h1>
+        </div>
+        <Button onClick={handleSave} disabled={updateMutation.isPending}>
+          <Save className="mr-1 h-4 w-4" />
+          {updateMutation.isPending ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+
+      {/* 기본 정보 */}
+      <div className="rounded-lg border bg-white p-6">
+        <h2 className="mb-4 text-lg font-semibold">팀 정보</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label>팀명</Label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+
+          <div className="space-y-2">
+            <Label>리더</Label>
+            <Select
+              value={leaderId.toString()}
+              onValueChange={(v) => setLeaderId(parseInt(v))}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {users?.map((user) => (
+                  <SelectItem key={user.id} value={user.id.toString()}>
+                    {user.name} ({user.nickname})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>곡명</Label>
+            <Input
+              value={songName}
+              onChange={(e) => setSongName(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>아티스트</Label>
+            <Input
+              value={songArtist}
+              onChange={(e) => setSongArtist(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>YouTube URL</Label>
+            <Input
+              value={songYoutubeVideoUrl}
+              onChange={(e) => setSongYoutubeVideoUrl(e.target.value)}
+              placeholder="https://youtube.com/..."
+            />
+          </div>
+
+          <div className="flex items-center gap-6 pt-6">
+            <div className="flex items-center gap-2">
+              <Switch
+                checked={isFreshmenFixed}
+                onCheckedChange={setIsFreshmenFixed}
+              />
+              <Label>신입생 고정</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch checked={isSelfMade} onCheckedChange={setIsSelfMade} />
+              <Label>자작곡</Label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 세션/멤버 편집 */}
+      <TeamSessionsEditor
+        memberSessions={memberSessions}
+        onChange={setMemberSessions}
+        teamDetail={team}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/teams/[teamId]/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/[teamId]/page.tsx
@@ -1,21 +1,16 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import { ArrowLeft, Save } from "lucide-react"
+import { ArrowLeft, ExternalLink, Save } from "lucide-react"
 import Link from "next/link"
 import { useParams } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 
+import { UserSelectContent } from "@/app/(admin)/_components/UserSelectContent"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
+import { Select, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { useToast } from "@/components/hooks/use-toast"
@@ -141,10 +136,20 @@ export default function TeamDetailAdminPage() {
           </Link>
           <h1 className="text-2xl font-bold">팀 편집</h1>
         </div>
-        <Button onClick={handleSave} disabled={updateMutation.isPending}>
-          <Save className="mr-1 h-4 w-4" />
-          {updateMutation.isPending ? "저장 중..." : "저장"}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link
+              href={ROUTES.PERFORMANCE.TEAM.DETAIL(team.performanceId, team.id)}
+            >
+              <ExternalLink className="mr-1 h-4 w-4" />
+              바로가기
+            </Link>
+          </Button>
+          <Button onClick={handleSave} disabled={updateMutation.isPending}>
+            <Save className="mr-1 h-4 w-4" />
+            {updateMutation.isPending ? "저장 중..." : "저장"}
+          </Button>
+        </div>
       </div>
 
       {/* 기본 정보 */}
@@ -157,7 +162,7 @@ export default function TeamDetailAdminPage() {
           </div>
 
           <div className="space-y-2">
-            <Label>리더</Label>
+            <Label>팀장</Label>
             <Select
               value={leaderId.toString()}
               onValueChange={(v) => setLeaderId(parseInt(v))}
@@ -165,13 +170,7 @@ export default function TeamDetailAdminPage() {
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent>
-                {users?.map((user) => (
-                  <SelectItem key={user.id} value={user.id.toString()}>
-                    {user.name} ({user.nickname})
-                  </SelectItem>
-                ))}
-              </SelectContent>
+              <UserSelectContent users={users} />
             </Select>
           </div>
 

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -4,7 +4,10 @@ import { ColumnDef } from "@tanstack/react-table"
 import { Eye, EllipsisVertical, Trash2 } from "lucide-react"
 import Link from "next/link"
 
+import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
+import { UserCell } from "@/app/(admin)/_components/data-table/UserCell"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -22,50 +25,120 @@ interface ColumnActions {
   onDelete: (team: TeamItem) => void
 }
 
-export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
+export function getColumns(
+  actions: ColumnActions,
+  performanceMap?: Map<number, string>
+): ColumnDef<TeamItem>[] {
   return [
     {
       accessorKey: "id",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="ID" />
       ),
-      size: 60
+      cell: ({ row }) => (
+        <Link
+          href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}
+          className="text-blue-600 hover:underline"
+        >
+          {row.original.id}
+        </Link>
+      ),
+      size: 60,
+      enableHiding: false
+    },
+    {
+      id: "performanceId",
+      accessorFn: (row) =>
+        performanceMap?.get(row.performanceId) ?? String(row.performanceId),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="공연" />
+      ),
+      meta: { label: "공연" },
+      cell: ({ row }) => (
+        <Link
+          href={`${ROUTES.ADMIN.PERFORMANCES}?rowId=${row.original.performanceId}`}
+          className="text-blue-600 hover:underline"
+        >
+          {performanceMap?.get(row.original.performanceId) ??
+            row.original.performanceId}
+        </Link>
+      ),
+      filterFn: (row, _columnId, filterValue) =>
+        String(row.original.performanceId) === filterValue
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="팀명" />
+      ),
+      meta: { label: "팀명", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.getValue() as string}
+        />
+      )
     },
     {
       accessorKey: "songName",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="곡명" />
       ),
-      cell: ({ row }) => (
-        <Link
-          href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}
-          className="text-blue-600 hover:underline"
-        >
-          {row.original.songName}
-        </Link>
-      )
+      cell: (cellContext) => (
+        <EditableCell
+          cellContext={cellContext}
+          displayValue={cellContext.getValue() as string}
+        />
+      ),
+      meta: {
+        label: "곡명",
+        editable: { type: "text" }
+      }
     },
     {
       accessorKey: "songArtist",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="아티스트" />
-      )
+      ),
+      cell: (cellContext) => (
+        <EditableCell
+          cellContext={cellContext}
+          displayValue={cellContext.getValue() as string}
+        />
+      ),
+      meta: {
+        label: "아티스트",
+        editable: { type: "text" }
+      },
+      filterFn: (row, _columnId, filterValue) =>
+        row.original.songArtist === filterValue
     },
     {
       id: "leader",
-      header: "리더",
-      cell: ({ row }) => (
-        <Link
-          href={ROUTES.ADMIN.USERS}
-          className="text-blue-600 hover:underline"
-        >
-          {row.original.leader.name}
-        </Link>
-      )
+      accessorFn: (row) => row.leader.name,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="리더" />
+      ),
+      meta: { label: "리더" },
+      cell: ({ row }) => <UserCell user={row.original.leader} />,
+      filterFn: (row, _columnId, filterValue) =>
+        String(row.original.leader.id) === filterValue
     },
     {
       id: "fillRate",
-      header: "충원율",
+      accessorFn: (row) => {
+        const total = row.teamSessions.reduce((s, ts) => s + ts.capacity, 0)
+        if (total === 0) return 0
+        const filled = row.teamSessions.reduce(
+          (s, ts) => s + ts.members.length,
+          0
+        )
+        return filled / total
+      },
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="충원율" />
+      ),
+      meta: { label: "충원율" },
       cell: ({ row }) => {
         const sessions = row.original.teamSessions
         const totalCapacity = sessions.reduce((sum, s) => sum + s.capacity, 0)
@@ -76,11 +149,37 @@ export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
         const isFull = totalMembers >= totalCapacity
 
         return (
-          <Badge variant={isFull ? "default" : "secondary"}>
+          <Badge variant={isFull ? "default" : "outline"}>
             {totalMembers}/{totalCapacity}
           </Badge>
         )
       }
+    },
+    {
+      accessorKey: "isFreshmenFixed",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="신입생 고정" />
+      ),
+      meta: { label: "신입생 고정", editable: { type: "boolean" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.row.original.isFreshmenFixed ? "O" : "-"}
+        />
+      )
+    },
+    {
+      accessorKey: "isSelfMade",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="자작곡" />
+      ),
+      meta: { label: "자작곡", editable: { type: "boolean" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.row.original.isSelfMade ? "O" : "-"}
+        />
+      )
     },
     {
       id: "actions",
@@ -92,6 +191,7 @@ export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <CopyRowLinkItem rowId={row.original.id} />
             <DropdownMenuItem asChild>
               <Link href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}>
                 <Eye className="mr-2 h-4 w-4" />
@@ -108,7 +208,8 @@ export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
           </DropdownMenuContent>
         </DropdownMenu>
       ),
-      size: 50
+      size: 50,
+      enableHiding: false
     }
   ]
 }

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { Eye, EllipsisVertical, Trash2 } from "lucide-react"
+import { Eye, EllipsisVertical, ExternalLink, Trash2 } from "lucide-react"
 import Link from "next/link"
 
 import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
@@ -114,13 +114,39 @@ export function getColumns(
         row.original.songArtist === filterValue
     },
     {
+      accessorKey: "posterImage",
+      header: "포스터",
+      meta: { label: "포스터", editable: { type: "image" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            ctx.row.original.posterImage ? (
+              <img
+                src={ctx.row.original.posterImage}
+                alt="포스터"
+                className="h-10 w-8 rounded object-cover"
+              />
+            ) : (
+              "-"
+            )
+          }
+        />
+      )
+    },
+    {
       id: "leader",
       accessorFn: (row) => row.leader.name,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="리더" />
+        <DataTableColumnHeader column={column} title="팀장" />
       ),
-      meta: { label: "리더" },
-      cell: ({ row }) => <UserCell user={row.original.leader} />,
+      meta: { label: "팀장", editable: { type: "user" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={<UserCell user={ctx.row.original.leader} />}
+        />
+      ),
       filterFn: (row, _columnId, filterValue) =>
         String(row.original.leader.id) === filterValue
     },
@@ -192,6 +218,17 @@ export function getColumns(
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <CopyRowLinkItem rowId={row.original.id} />
+            <DropdownMenuItem asChild>
+              <Link
+                href={ROUTES.PERFORMANCE.TEAM.DETAIL(
+                  row.original.performanceId,
+                  row.original.id
+                )}
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                바로가기
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}>
                 <Eye className="mr-2 h-4 w-4" />

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -35,6 +35,14 @@ export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
       accessorKey: "songName",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="곡명" />
+      ),
+      cell: ({ row }) => (
+        <Link
+          href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}
+          className="text-blue-600 hover:underline"
+        >
+          {row.original.songName}
+        </Link>
       )
     },
     {
@@ -46,7 +54,14 @@ export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
     {
       id: "leader",
       header: "리더",
-      cell: ({ row }) => row.original.leader.name
+      cell: ({ row }) => (
+        <Link
+          href={ROUTES.ADMIN.USERS}
+          className="text-blue-600 hover:underline"
+        >
+          {row.original.leader.name}
+        </Link>
+      )
     },
     {
       id: "fillRate",

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { Eye, EllipsisVertical, Trash2 } from "lucide-react"
+import Link from "next/link"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import ROUTES from "@/constants/routes"
+import { TeamList } from "@repo/shared-types"
+
+type TeamItem = TeamList[number]
+
+interface ColumnActions {
+  onDelete: (team: TeamItem) => void
+}
+
+export function getColumns(actions: ColumnActions): ColumnDef<TeamItem>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60
+    },
+    {
+      accessorKey: "songName",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="곡명" />
+      )
+    },
+    {
+      accessorKey: "songArtist",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="아티스트" />
+      )
+    },
+    {
+      id: "leader",
+      header: "리더",
+      cell: ({ row }) => row.original.leader.name
+    },
+    {
+      id: "fillRate",
+      header: "충원율",
+      cell: ({ row }) => {
+        const sessions = row.original.teamSessions
+        const totalCapacity = sessions.reduce((sum, s) => sum + s.capacity, 0)
+        const totalMembers = sessions.reduce(
+          (sum, s) => sum + s.members.length,
+          0
+        )
+        const isFull = totalMembers >= totalCapacity
+
+        return (
+          <Badge variant={isFull ? "default" : "secondary"}>
+            {totalMembers}/{totalCapacity}
+          </Badge>
+        )
+      }
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <Link href={ROUTES.ADMIN.TEAM_DETAIL(row.original.id)}>
+                <Eye className="mr-2 h-4 w-4" />
+                상세/편집
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import { useAllTeams, useDeleteTeam } from "@/hooks/api/useTeam"
+import { TeamList } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+
+type TeamItem = TeamList[number]
+
+export default function TeamsAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: teams, isLoading } = useAllTeams()
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleting, setDeleting] = useState<TeamItem | null>(null)
+
+  const deleteMutation = useDeleteTeam()
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onDelete: (team) => {
+          setDeleting(team)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({ title: `${deleting.songName} 팀이 삭제되었습니다.` })
+        queryClient.invalidateQueries({ queryKey: ["teams"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">팀 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={teams ?? []}
+        isLoading={isLoading}
+        searchColumn="songName"
+        searchPlaceholder="곡명으로 검색..."
+        emptyMessage="등록된 팀이 없습니다."
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting ? `"${deleting.songName}" 팀을 삭제하시겠습니까?` : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -62,6 +62,7 @@ export default function TeamsAdminPage() {
         columns={columns}
         data={teams ?? []}
         isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: true }]}
         searchColumn="songName"
         searchPlaceholder="곡명으로 검색..."
         emptyMessage="등록된 팀이 없습니다."

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -6,7 +6,8 @@ import { useMemo, useState } from "react"
 import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
 import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
 import { useToast } from "@/components/hooks/use-toast"
-import { useAllTeams, useDeleteTeam } from "@/hooks/api/useTeam"
+import { usePerformances } from "@/hooks/api/usePerformance"
+import { useAllTeams, useDeleteTeam, useUpdateTeam } from "@/hooks/api/useTeam"
 import { TeamList } from "@repo/shared-types"
 
 import { getColumns } from "./_components/columns"
@@ -17,22 +18,104 @@ export default function TeamsAdminPage() {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const { data: teams, isLoading } = useAllTeams()
+  const { data: performances } = usePerformances()
 
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleting, setDeleting] = useState<TeamItem | null>(null)
 
   const deleteMutation = useDeleteTeam()
+  const updateMutation = useUpdateTeam()
+
+  const performanceMap = useMemo(
+    () => new Map(performances?.map((p) => [p.id, p.name]) ?? []),
+    [performances]
+  )
+
+  const performanceFilters = useMemo(
+    () =>
+      performances?.map((p) => ({
+        label: p.name,
+        value: String(p.id)
+      })) ?? [],
+    [performances]
+  )
+
+  const leaderFilters = useMemo(
+    () =>
+      [
+        ...new Map(
+          (teams ?? []).map((t) => [t.leader.id, t.leader.name])
+        ).entries()
+      ]
+        .map(([id, name]) => ({ label: name, value: String(id) }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [teams]
+  )
+
+  const artistFilters = useMemo(
+    () =>
+      [...new Set((teams ?? []).map((t) => t.songArtist))]
+        .sort()
+        .map((v) => ({ label: v, value: v })),
+    [teams]
+  )
 
   const columns = useMemo(
     () =>
-      getColumns({
-        onDelete: (team) => {
-          setDeleting(team)
-          setDeleteOpen(true)
-        }
-      }),
-    []
+      getColumns(
+        {
+          onDelete: (team) => {
+            setDeleting(team)
+            setDeleteOpen(true)
+          }
+        },
+        performanceMap
+      ),
+    [performanceMap]
   )
+
+  const handleCellUpdate = async (
+    rowId: number,
+    columnId: string,
+    value: unknown
+  ) => {
+    const team = teams?.find((t) => t.id === rowId)
+    if (!team) return
+
+    const payload = {
+      name: team.name,
+      description: team.description,
+      leaderId: team.leaderId,
+      songName: team.songName,
+      songArtist: team.songArtist,
+      isFreshmenFixed: team.isFreshmenFixed,
+      isSelfMade: team.isSelfMade,
+      posterImage: team.posterImage,
+      songYoutubeVideoUrl: team.songYoutubeVideoUrl,
+      memberSessions: team.teamSessions.map((ts) => ({
+        sessionId: ts.sessionId,
+        capacity: ts.capacity,
+        members: ts.members.map((m) => ({
+          userId: m.userId,
+          index: m.index
+        }))
+      })),
+      [columnId]: value
+    }
+
+    try {
+      await updateMutation.mutateAsync([rowId, payload])
+      toast({ title: "수정되었습니다." })
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
+    } catch (error) {
+      toast({
+        title: "수정에 실패했습니다.",
+        description: (error as Error).message,
+        variant: "destructive"
+      })
+      throw error
+    }
+  }
 
   const handleDelete = () => {
     if (!deleting) return
@@ -66,6 +149,44 @@ export default function TeamsAdminPage() {
         searchColumn="songName"
         searchPlaceholder="곡명으로 검색..."
         emptyMessage="등록된 팀이 없습니다."
+        onUpdateCell={handleCellUpdate}
+        initialColumnVisibility={{
+          name: false,
+          isFreshmenFixed: false,
+          isSelfMade: false
+        }}
+        filters={[
+          {
+            columnId: "performanceId",
+            label: "공연",
+            options: performanceFilters
+          },
+          {
+            columnId: "leader",
+            label: "리더",
+            options: leaderFilters
+          },
+          {
+            columnId: "songArtist",
+            label: "아티스트",
+            options: artistFilters
+          }
+        ]}
+        onBulkDelete={async (rows) => {
+          const results = await Promise.allSettled(
+            rows.map((r) => deleteMutation.mutateAsync([(r as TeamItem).id]))
+          )
+          const failed = results.filter((r) => r.status === "rejected").length
+          if (failed > 0) {
+            toast({
+              title: `${rows.length - failed}개 삭제, ${failed}개 실패`,
+              variant: "destructive"
+            })
+          } else {
+            toast({ title: `${rows.length}개 팀이 삭제되었습니다.` })
+          }
+          queryClient.invalidateQueries({ queryKey: ["teams"] })
+        }}
       />
 
       <DeleteConfirmDialog

--- a/apps/web/app/(admin)/admin/users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/columns.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+import { EllipsisVertical, ExternalLink, Pencil, Trash2 } from "lucide-react"
 import Link from "next/link"
 
 import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
@@ -133,7 +133,12 @@ export function getColumns(): ColumnDef<PublicUser>[] {
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <CopyRowLinkItem rowId={row.original.id} />
-            {/* TODO: 백엔드에 PATCH /users/:id, DELETE /users/:id 엔드포인트 추가 후 활성화 */}
+            <DropdownMenuItem asChild>
+              <Link href={ROUTES.MEMBER.DETAIL(row.original.id)}>
+                <ExternalLink className="mr-2 h-4 w-4" />
+                바로가기
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuItem disabled>
               <Pencil className="mr-2 h-4 w-4" />
               편집 (API 미구현)

--- a/apps/web/app/(admin)/admin/users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/columns.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { formatGenerationOrder } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+
+// publicUser 타입: { id, name, image, nickname, bio, generation: { order } }
+interface PublicUser {
+  id: number
+  name: string
+  image: string | null
+  nickname: string
+  bio: string | null
+  generation: { order: number }
+}
+
+export function getColumns(): ColumnDef<PublicUser>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60
+    },
+    {
+      id: "avatar",
+      header: "",
+      cell: ({ row }) => (
+        <Avatar className="h-8 w-8">
+          <AvatarImage src={row.original.image ?? undefined} />
+          <AvatarFallback>{row.original.name[0]}</AvatarFallback>
+        </Avatar>
+      ),
+      size: 40
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="이름" />
+      )
+    },
+    {
+      accessorKey: "nickname",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="닉네임" />
+      )
+    },
+    {
+      id: "generation",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="기수" />
+      ),
+      accessorFn: (row) => row.generation.order,
+      cell: ({ row }) =>
+        `${formatGenerationOrder(row.original.generation.order)}기`
+    },
+    {
+      id: "actions",
+      cell: () => (
+        // TODO: 백엔드에 PATCH /users/:id, DELETE /users/:id 엔드포인트 추가 후 활성화
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8" disabled>
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem disabled>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집 (API 미구현)
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled className="text-red-600">
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제 (API 미구현)
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/columns.tsx
@@ -2,9 +2,11 @@
 
 import { ColumnDef } from "@tanstack/react-table"
 import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
 import { formatGenerationOrder } from "@/lib/utils"
+import ROUTES from "@/constants/routes"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import {
@@ -62,8 +64,14 @@ export function getColumns(): ColumnDef<PublicUser>[] {
         <DataTableColumnHeader column={column} title="기수" />
       ),
       accessorFn: (row) => row.generation.order,
-      cell: ({ row }) =>
-        `${formatGenerationOrder(row.original.generation.order)}기`
+      cell: ({ row }) => (
+        <Link
+          href={ROUTES.ADMIN.GENERATIONS}
+          className="text-blue-600 hover:underline"
+        >
+          {formatGenerationOrder(row.original.generation.order)}기
+        </Link>
+      )
     },
     {
       id: "actions",

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -26,6 +26,7 @@ export default function UsersAdminPage() {
         columns={columns}
         data={users ?? []}
         isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: false }]}
         searchColumn="name"
         searchPlaceholder="이름으로 검색..."
         emptyMessage="등록된 회원이 없습니다."

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { useUsers } from "@/hooks/api/useUser"
+
+import { getColumns } from "./_components/columns"
+
+// TODO: 백엔드에 다음 API 추가 필요:
+// - GET /users/admin (email, isAdmin, sessions 포함한 admin용 응답)
+// - PATCH /users/:id (AdminGuard)
+// - DELETE /users/:id (AdminGuard)
+// 위 API 추가 후 UserFormDialog, 편집/삭제 기능 구현
+
+export default function UsersAdminPage() {
+  const { data: users, isLoading } = useUsers()
+
+  const columns = useMemo(() => getColumns(), [])
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">회원 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={users ?? []}
+        isLoading={isLoading}
+        searchColumn="name"
+        searchPlaceholder="이름으로 검색..."
+        emptyMessage="등록된 회원이 없습니다."
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -3,7 +3,11 @@
 import { useMemo } from "react"
 
 import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { useGenerations } from "@/hooks/api/useGeneration"
+import { useSessions } from "@/hooks/api/useSession"
 import { useUsers } from "@/hooks/api/useUser"
+import { formatGenerationOrder } from "@/lib/utils"
+import { getSessionDisplayName } from "@/constants/session"
 
 import { getColumns } from "./_components/columns"
 
@@ -15,6 +19,28 @@ import { getColumns } from "./_components/columns"
 
 export default function UsersAdminPage() {
   const { data: users, isLoading } = useUsers()
+  const { data: generations } = useGenerations()
+  const { data: sessions } = useSessions()
+
+  const generationFilters = useMemo(
+    () =>
+      generations
+        ?.sort((a, b) => b.order - a.order)
+        .map((g) => ({
+          label: `${formatGenerationOrder(g.order)}기`,
+          value: String(g.order)
+        })) ?? [],
+    [generations]
+  )
+
+  const sessionFilters = useMemo(
+    () =>
+      sessions?.map((s) => ({
+        label: getSessionDisplayName(s.name),
+        value: s.name
+      })) ?? [],
+    [sessions]
+  )
 
   const columns = useMemo(() => getColumns(), [])
 
@@ -27,9 +53,22 @@ export default function UsersAdminPage() {
         data={users ?? []}
         isLoading={isLoading}
         initialSorting={[{ id: "id", desc: false }]}
-        searchColumn="name"
+        initialColumnVisibility={{ bio: false }}
+        enableGlobalSearch
         searchPlaceholder="이름으로 검색..."
         emptyMessage="등록된 회원이 없습니다."
+        filters={[
+          {
+            columnId: "generation",
+            label: "기수",
+            options: generationFilters
+          },
+          {
+            columnId: "sessions",
+            label: "세션",
+            options: sessionFilters
+          }
+        ]}
       />
     </div>
   )

--- a/apps/web/app/(admin)/layout.tsx
+++ b/apps/web/app/(admin)/layout.tsx
@@ -4,6 +4,7 @@ import { auth } from "@/auth"
 import ROUTES from "@/constants/routes"
 
 import { AdminSidebar } from "./_components/AdminSidebar"
+import { UnsavedChangesProvider } from "./_components/UnsavedChangesContext"
 
 export default async function AdminLayout({
   children
@@ -17,9 +18,13 @@ export default async function AdminLayout({
   }
 
   return (
-    <div className="flex h-screen">
-      <AdminSidebar />
-      <main className="flex-1 overflow-auto bg-neutral-50 p-6">{children}</main>
-    </div>
+    <UnsavedChangesProvider>
+      <div className="flex h-screen">
+        <AdminSidebar />
+        <main className="flex-1 overflow-auto bg-neutral-50 p-6">
+          {children}
+        </main>
+      </div>
+    </UnsavedChangesProvider>
   )
 }

--- a/apps/web/app/(admin)/layout.tsx
+++ b/apps/web/app/(admin)/layout.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation"
+
+import { auth } from "@/auth"
+import ROUTES from "@/constants/routes"
+
+import { AdminSidebar } from "./_components/AdminSidebar"
+
+export default async function AdminLayout({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  const session = await auth()
+
+  if (!session?.user?.isAdmin) {
+    redirect(ROUTES.LOGIN)
+  }
+
+  return (
+    <div className="flex h-screen">
+      <AdminSidebar />
+      <main className="flex-1 overflow-auto bg-neutral-50 p-6">{children}</main>
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton.tsx
@@ -8,10 +8,10 @@ import { useEffect, useState } from "react"
 import { getSessionDisplayName } from "@/constants/session"
 import SESSIONIMAGE from "@/constants/sessionimage"
 import { cn } from "@/lib/utils"
-import { type SessionName } from "@repo/database"
+import type { SessionNameValue } from "@/constants/session"
 
 interface ApplyButtonProps {
-  sessionName: SessionName
+  sessionName: SessionNameValue
   sessionIndex: number
   isSelected: boolean
   onToggle: () => void

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -6,7 +6,7 @@ import { useToast } from "@/components/hooks/use-toast"
 import { useUnapplyFromTeam } from "@/hooks/api/useTeam"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { getSessionDisplayName } from "@/constants/session"
-import { SessionName } from "@repo/database"
+import type { SessionNameValue } from "@/constants/session"
 import { TeamDetail } from "@repo/shared-types"
 
 type TeamMember = TeamDetail["teamSessions"][number]["members"][number]["user"]
@@ -14,7 +14,7 @@ type TeamMember = TeamDetail["teamSessions"][number]["members"][number]["user"]
 interface MemberSessionCardProps {
   teamId: number
   sessionId: number
-  sessionName: SessionName
+  sessionName: SessionNameValue
   sessionIndex: number
   user: TeamMember
   // eslint-disable-next-line no-unused-vars

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
@@ -15,7 +15,7 @@ import { CreateTeam, TeamDetail, UpdateTeam } from "@repo/shared-types"
 
 import { useSessions } from "@/hooks/api/useSession"
 import { useCreateTeam, useUpdateTeam } from "@/hooks/api/useTeam"
-import { SessionName } from "@repo/database"
+import { SESSION_NAMES } from "@/constants/session"
 import { useQueryClient } from "@tanstack/react-query"
 import FirstPage from "./FirstPage"
 import basicInfoSchema from "./FirstPage/schema"
@@ -79,85 +79,85 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
       [key: string]: z.infer<ReturnType<typeof memberSessionRequiredField>>
     } = {
       보컬1: {
-        session: SessionName.VOCAL,
+        session: SESSION_NAMES.VOCAL,
         required: false,
         member: null,
         index: 1
       },
       보컬2: {
-        session: SessionName.VOCAL,
+        session: SESSION_NAMES.VOCAL,
         required: false,
         member: null,
         index: 2
       },
       보컬3: {
-        session: SessionName.VOCAL,
+        session: SESSION_NAMES.VOCAL,
         required: false,
         member: null,
         index: 3
       },
       기타1: {
-        session: SessionName.GUITAR,
+        session: SESSION_NAMES.GUITAR,
         required: false,
         member: null,
         index: 1
       },
       기타2: {
-        session: SessionName.GUITAR,
+        session: SESSION_NAMES.GUITAR,
         required: false,
         member: null,
         index: 2
       },
       기타3: {
-        session: SessionName.GUITAR,
+        session: SESSION_NAMES.GUITAR,
         required: false,
         member: null,
         index: 3
       },
       베이스1: {
-        session: SessionName.BASS,
+        session: SESSION_NAMES.BASS,
         required: false,
         member: null,
         index: 1
       },
       베이스2: {
-        session: SessionName.BASS,
+        session: SESSION_NAMES.BASS,
         required: false,
         member: null,
         index: 2
       },
       드럼1: {
-        session: SessionName.DRUM,
+        session: SESSION_NAMES.DRUM,
         required: false,
         member: null,
         index: 1
       },
       신디1: {
-        session: SessionName.SYNTH,
+        session: SESSION_NAMES.SYNTH,
         required: false,
         member: null,
         index: 1
       },
       신디2: {
-        session: SessionName.SYNTH,
+        session: SESSION_NAMES.SYNTH,
         required: false,
         member: null,
         index: 2
       },
       신디3: {
-        session: SessionName.SYNTH,
+        session: SESSION_NAMES.SYNTH,
         required: false,
         member: null,
         index: 3
       },
       현악기1: {
-        session: SessionName.STRINGS,
+        session: SESSION_NAMES.STRINGS,
         required: false,
         member: null,
         index: 1
       },
       관악기1: {
-        session: SessionName.WINDS,
+        session: SESSION_NAMES.WINDS,
         required: false,
         member: null,
         index: 1

--- a/apps/web/components/Header/_component/Profile.tsx
+++ b/apps/web/components/Header/_component/Profile.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { LoaderCircle, LogOut, User, Users } from "lucide-react"
+import { LoaderCircle, LogOut, Settings, User, Users } from "lucide-react"
 import { signOut, useSession } from "next-auth/react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -92,6 +92,18 @@ const Profile = () => {
         <MenuItem icon={<Users size={iconSize} />} href={ROUTES.PROFILE.TEAMS}>
           참여 중인 팀
         </MenuItem>
+
+        {session.user?.isAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <MenuItem
+              icon={<Settings size={iconSize} />}
+              href={ROUTES.ADMIN.INDEX}
+            >
+              관리자
+            </MenuItem>
+          </>
+        )}
 
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/apps/web/components/Header/_component/Sidebar/index.tsx
+++ b/apps/web/components/Header/_component/Sidebar/index.tsx
@@ -11,11 +11,26 @@ import { SheetTitle } from "@/components/ui/sheet"
 
 const Sidebar = () => {
   const [isOpen, setIsOpen] = React.useState(false)
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <button type="button">
+        <Menu className="h-6 w-6 text-white" />
+      </button>
+    )
+  }
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <SheetTrigger>
-        <Menu className="h-6 w-6 text-white" />
+      <SheetTrigger asChild>
+        <button type="button">
+          <Menu className="h-6 w-6 text-white" />
+        </button>
       </SheetTrigger>
       <SheetContent>
         <SheetTitle className="hidden">메뉴</SheetTitle>

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -5,7 +5,13 @@ const ROUTES = {
   LOGIN: "/login",
   SIGNUP: "/signup",
   ADMIN: {
-    INDEX: "/admin"
+    INDEX: "/admin",
+    USERS: "/admin/users",
+    GENERATIONS: "/admin/generations",
+    PERFORMANCES: "/admin/performances",
+    TEAMS: "/admin/teams",
+    TEAM_DETAIL: (teamId: number) => `/admin/teams/${teamId}`,
+    SESSIONS: "/admin/sessions"
   },
   NOTICE: {
     CREATE: "/notices/create",

--- a/apps/web/constants/session.ts
+++ b/apps/web/constants/session.ts
@@ -1,21 +1,37 @@
-import { SessionName } from "@repo/database"
+/**
+ * SessionName 값 (Prisma SessionName enum과 동일)
+ * 클라이언트 번들에서 @repo/database 를 직접 import하면
+ * PrismaClient 네이티브 바이너리가 포함되므로 여기서 별도 정의
+ */
+export const SESSION_NAMES = {
+  VOCAL: "VOCAL",
+  GUITAR: "GUITAR",
+  BASS: "BASS",
+  SYNTH: "SYNTH",
+  DRUM: "DRUM",
+  STRINGS: "STRINGS",
+  WINDS: "WINDS"
+} as const
+
+export type SessionNameValue =
+  (typeof SESSION_NAMES)[keyof typeof SESSION_NAMES]
 
 /**
- * SessionName enum → 한글 표시명 매핑
+ * SessionName → 한글 표시명 매핑
  */
-export const SESSION_DISPLAY_NAME: Record<SessionName, string> = {
-  [SessionName.VOCAL]: "보컬",
-  [SessionName.GUITAR]: "기타",
-  [SessionName.BASS]: "베이스",
-  [SessionName.SYNTH]: "신디",
-  [SessionName.DRUM]: "드럼",
-  [SessionName.STRINGS]: "현악기",
-  [SessionName.WINDS]: "관악기"
+export const SESSION_DISPLAY_NAME: Record<SessionNameValue, string> = {
+  [SESSION_NAMES.VOCAL]: "보컬",
+  [SESSION_NAMES.GUITAR]: "기타",
+  [SESSION_NAMES.BASS]: "베이스",
+  [SESSION_NAMES.SYNTH]: "신디",
+  [SESSION_NAMES.DRUM]: "드럼",
+  [SESSION_NAMES.STRINGS]: "현악기",
+  [SESSION_NAMES.WINDS]: "관악기"
 }
 
 /**
- * SessionName enum을 한글 표시명으로 변환
+ * SessionName을 한글 표시명으로 변환
  */
-export function getSessionDisplayName(sessionName: SessionName): string {
-  return SESSION_DISPLAY_NAME[sessionName] ?? sessionName
+export function getSessionDisplayName(sessionName: string): string {
+  return SESSION_DISPLAY_NAME[sessionName as SessionNameValue] ?? sessionName
 }

--- a/apps/web/hooks/api/useTeam.ts
+++ b/apps/web/hooks/api/useTeam.ts
@@ -1,6 +1,11 @@
 import { createMutationHook, createQueryHook } from "@/hooks/useCustomQuery"
 import ApiClient from "@repo/api-client"
 
+export const useAllTeams = createQueryHook(ApiClient.prototype.getTeams, () => [
+  "teams",
+  "all"
+])
+
 export const useCreateTeam = createMutationHook(ApiClient.prototype.createTeam)
 
 export const useTeams = createQueryHook(

--- a/apps/web/lib/providers/index.tsx
+++ b/apps/web/lib/providers/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { SessionProvider, signOut, useSession } from "next-auth/react"
+import { NuqsAdapter } from "nuqs/adapters/next/app"
 import { useEffect } from "react"
 import { ApiClientProvider } from "./api-client-provider"
 import ReactQueryProvider from "./react-query-provider"
@@ -19,12 +20,14 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider>
-      <SessionGuard>
-        <ApiClientProvider>
-          <ReactQueryProvider>{children}</ReactQueryProvider>
-        </ApiClientProvider>
-      </SessionGuard>
-    </SessionProvider>
+    <NuqsAdapter>
+      <SessionProvider>
+        <SessionGuard>
+          <ApiClientProvider>
+            <ReactQueryProvider>{children}</ReactQueryProvider>
+          </ApiClientProvider>
+        </SessionGuard>
+      </SessionProvider>
+    </NuqsAdapter>
   )
 }

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: false,
   images: {
     remotePatterns: [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,10 @@
     "build-storybook": "storybook build -o storybook-static"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@faker-js/faker": "^8.4.1",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",
@@ -51,6 +55,7 @@
     "lucide-react": "^0.424.0",
     "next": "^16.1.6",
     "next-auth": "5.0.0-beta.30",
+    "nuqs": "^2.8.8",
     "path-to-regexp": "^8.3.0",
     "react": "^19.2.4",
     "react-day-picker": "^8.10.1",

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -3,15 +3,18 @@ import { Prisma } from "@repo/database"
 export const basicUserSelector = {
   id: true,
   name: true,
-  image: true
+  image: true,
+  generation: {
+    select: { id: true, order: true }
+  }
 } satisfies Prisma.UserSelect
 
 export const publicUserSelector = {
   ...basicUserSelector,
   nickname: true,
   bio: true,
-  generation: {
-    select: { order: true }
+  sessions: {
+    select: { id: true, name: true }
   }
 } satisfies Prisma.UserSelect
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,18 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@faker-js/faker':
         specifier: ^8.4.1
         version: 8.4.1
@@ -280,6 +292,9 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.30
         version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      nuqs:
+        specifier: ^2.8.8
+        version: 2.8.8(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       path-to-regexp:
         specifier: ^8.3.0
         version: 8.3.0
@@ -947,6 +962,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -2829,6 +2872,9 @@ packages:
   '@smithy/uuid@1.1.0':
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6029,6 +6075,27 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  nuqs@2.8.8:
+    resolution: {integrity: sha512-LF5sw9nWpHyPWzMMu9oho3r9C5DvkpmBIg4LQN78sexIzGaeRx8DWr0uy3YiFx5i2QGZN1Qqcb+OAtEVRa2bnA==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
+
   nypm@0.6.4:
     resolution: {integrity: sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==}
     engines: {node: '>=18'}
@@ -8560,6 +8627,38 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
@@ -10464,6 +10563,8 @@ snapshots:
   '@smithy/uuid@1.1.0':
     dependencies:
       tslib: 2.8.1
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -14207,6 +14308,13 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  nuqs@2.8.8(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.4
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   nypm@0.6.4:
     dependencies:


### PR DESCRIPTION
## Summary
- 어드민 CMS 구축: 회원, 기수, 공연, 팀, 세션 엔티티별 DataTable + CRUD
- Supabase 스타일 인라인 셀 편집 (text, number, date, select, boolean, image, user)
- 대시보드 페이지: 요약 카드, 최근 공연/팀, 미충원 팀, 기수별 현황
- 팀 상세 편집 페이지: 세션/멤버 편집, 저장하지 않고 나가기 방지 (UnsavedChangesContext)
- DnD 컬럼 순서 변경, FK 링크, 필터, 일괄 삭제, 정렬

Closes #305

## Test plan
- [ ] 각 엔티티 테이블 CRUD 확인 (생성, 인라인 편집, 삭제)
- [ ] 인라인 편집: 클릭→수정→blur/Enter 저장, Escape 취소
- [ ] 팀 상세 페이지에서 변경 후 네비게이션 시 확인 다이얼로그 표시
- [ ] 대시보드 요약 카드 수치 및 링크 확인
- [ ] 필터 적용/초기화 동작 확인
- [ ] 모바일 반응형 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)