### PR TITLE
feat: redesign auth pages and sidebar menu

### DIFF
--- a/apps/web/app/(general)/(light)/signup/_components/SignupForm.tsx
+++ b/apps/web/app/(general)/(light)/signup/_components/SignupForm.tsx
@@ -272,7 +272,7 @@ const SignupForm = () => {
                   세션
                 </SimpleLabel>
                 <FormDescription>
-                  연주 가능한 세션을 선택해주세요.
+                  자신의 세션을 선택해주세요(중복체크가능)
                 </FormDescription>
               </div>
               {sessionsStatus !== "success" ? (
@@ -316,7 +316,21 @@ const SignupForm = () => {
             </FormItem>
           )}
         />
-        <Button type="submit">회원가입</Button>
+        <div className="flex justify-center gap-4 pt-8">
+          <Button
+            type="button"
+            className="h-11 w-36 rounded-full bg-slate-200 font-semibold text-slate-600 hover:bg-slate-300"
+            onClick={() => router.back()}
+          >
+            취소하기
+          </Button>
+          <Button
+            type="submit"
+            className="h-11 w-36 rounded-full bg-[#023664] font-semibold text-white hover:bg-[#012a50]"
+          >
+            회원가입
+          </Button>
+        </div>
       </form>
     </Form>
   )

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -59,8 +59,8 @@ const Login = () => {
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="flex h-[653px] flex-col items-center justify-center overflow-hidden rounded-2xl bg-white lg:relative lg:w-[60rem] lg:shadow-2xl xl:w-[70rem]">
+    <div className="flex h-full w-full items-center justify-center px-6 lg:px-0">
+      <div className="flex w-full max-w-md flex-col items-center justify-center overflow-hidden rounded-2xl bg-white lg:relative lg:h-[653px] lg:max-w-none lg:w-[60rem] lg:shadow-2xl xl:w-[70rem]">
         <Image
           width="680"
           height="753"
@@ -93,17 +93,17 @@ const Login = () => {
             Log in and join the rhythm
           </div>
         </div>
-        <div className="flex flex-col items-center justify-center lg:absolute lg:right-20 lg:top-[8.5rem] xl:right-32">
-          <h3 className="mb-2 text-2xl font-bold text-slate-900">로그인</h3>
-          <h5 className="mb-8 text-sm font-medium text-slate-500">
+        <div className="flex w-full flex-col items-center justify-center py-8 lg:absolute lg:right-20 lg:top-[8.5rem] lg:w-auto lg:py-0 xl:right-32">
+          <h3 className="mb-2 text-2xl font-medium text-slate-900">로그인</h3>
+          <h5 className="mb-8 text-sm font-normal text-slate-400">
             계속하려면 로그인해주세요
           </h5>
           {/* 일반 로그인 */}
           <form
-            className="flex flex-col items-center"
+            className="flex w-full flex-col items-center"
             onSubmit={handleSubmit(onValid)}
           >
-            <div className="grid w-full max-w-sm items-center gap-1.5">
+            <div className="grid w-full items-center gap-1.5 lg:max-w-sm">
               <Label htmlFor="email" className="font-semibold">
                 아이디
               </Label>
@@ -115,7 +115,7 @@ const Login = () => {
               />
             </div>
             <div className="mb-6 text-destructive">{errors.email?.message}</div>
-            <div className="grid w-full max-w-sm items-center gap-1.5">
+            <div className="grid w-full items-center gap-1.5 lg:max-w-sm">
               <Label htmlFor="password" className="font-semibold">
                 비밀번호
               </Label>
@@ -130,10 +130,10 @@ const Login = () => {
             <div className="text-destructive">{errors.password?.message}</div>
             <Button
               type="submit"
-              className="mt-8 h-12 w-full rounded-lg bg-[#4A8AF4] text-base font-semibold text-white hover:bg-[#3b7ae5] lg:w-80"
+              className="mt-8 h-[52px] w-full rounded-lg bg-[#4A8AF4] text-base font-semibold text-white hover:bg-[#3b7ae5] lg:w-[300px]"
               disabled={isSubmitting}
             >
-              {isSubmitting ? "Login on Progress..." : "로그인"}
+              {isSubmitting ? "로그인 중..." : "로그인"}
             </Button>
             <div className="flex justify-center pt-4">
               <div className="pr-2 text-sm font-medium text-slate-900">

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -94,8 +94,8 @@ const Login = () => {
           </div>
         </div>
         <div className="flex flex-col items-center justify-center lg:absolute lg:right-20 lg:top-[8.5rem] xl:right-32">
-          <h3 className="mb-2 text-2xl font-black text-slate-900">로그인</h3>
-          <h5 className="mb-8 text-sm font-black text-slate-500">
+          <h3 className="mb-2 text-2xl font-bold text-slate-900">로그인</h3>
+          <h5 className="mb-8 text-sm font-medium text-slate-500">
             계속하려면 로그인해주세요
           </h5>
           {/* 일반 로그인 */}
@@ -111,7 +111,7 @@ const Login = () => {
                 {...register("email")}
                 name="email"
                 placeholder="Input text"
-                className=" h-12 border-slate-300 bg-white px-7 text-xl shadow-sm lg:w-80"
+                className="h-12 rounded-lg border-slate-300 bg-white px-5 text-base shadow-sm lg:w-80"
               />
             </div>
             <div className="mb-6 text-destructive">{errors.email?.message}</div>
@@ -124,22 +124,22 @@ const Login = () => {
                 name="password"
                 placeholder="Input text"
                 type="password"
-                className=" mt-1 h-12 border-slate-300 bg-white px-7 text-xl shadow-sm lg:w-80"
+                className="h-12 rounded-lg border-slate-300 bg-white px-5 text-base shadow-sm lg:w-80"
               />
             </div>
             <div className="text-destructive">{errors.password?.message}</div>
             <Button
               type="submit"
-              className="mt-8 h-12 w-72 bg-third text-base font-semibold"
+              className="mt-8 h-12 w-full rounded-lg bg-[#4A8AF4] text-base font-semibold text-white hover:bg-[#3b7ae5] lg:w-80"
               disabled={isSubmitting}
             >
               {isSubmitting ? "Login on Progress..." : "로그인"}
             </Button>
             <div className="flex justify-center pt-4">
-              <div className="pr-2 text-sm font-extrabold text-slate-900">
+              <div className="pr-2 text-sm font-medium text-slate-900">
                 아직 계정이 없으신가요?
               </div>
-              <Link href={ROUTES.SIGNUP} className="text-blue-40 text-sm">
+              <Link href={ROUTES.SIGNUP} className="text-sm text-blue-400">
                 회원가입
               </Link>
             </div>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -60,7 +60,7 @@ const Login = () => {
 
   return (
     <div className="flex h-full w-full items-center justify-center px-6 lg:px-0">
-      <div className="flex w-full max-w-md flex-col items-center justify-center overflow-hidden rounded-2xl bg-white lg:relative lg:h-[653px] lg:max-w-none lg:w-[60rem] lg:shadow-2xl xl:w-[70rem]">
+      <div className="flex w-full max-w-md flex-col items-center justify-center rounded-2xl bg-white lg:relative lg:h-[653px] lg:max-w-none lg:w-[60rem] lg:shadow-2xl xl:w-[70rem]">
         <Image
           width="680"
           height="753"

--- a/apps/web/components/Header/_component/Sidebar/Sheet.tsx
+++ b/apps/web/components/Header/_component/Sidebar/Sheet.tsx
@@ -50,7 +50,8 @@ const sheetVariants = cva(
 )
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<
@@ -61,6 +62,7 @@ const SheetContent = React.forwardRef<
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
+      aria-describedby={undefined}
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >

--- a/apps/web/components/Header/_component/Sidebar/SheetInnerContent/index.tsx
+++ b/apps/web/components/Header/_component/Sidebar/SheetInnerContent/index.tsx
@@ -2,12 +2,12 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar"
 import {
-  FileText,
-  ImageIcon,
+  Archive,
+  Building2,
   Instagram,
   LogIn,
-  Megaphone,
-  Music4,
+  Package,
+  Users,
   Youtube
 } from "lucide-react"
 import { signOut, useSession } from "next-auth/react"
@@ -33,7 +33,7 @@ const SheetInnerContent = ({
   const { data: session } = useSession()
 
   return (
-    <div className="items-between flex h-full flex-col justify-center">
+    <div className="flex h-full flex-col justify-between">
       <Link
         href={!session ? ROUTES.LOGIN : ROUTES.PROFILE.INDEX}
         className="flex w-full items-center justify-start py-3"
@@ -57,7 +57,7 @@ const SheetInnerContent = ({
               <div className="h-5 w-full pl-3 text-left text-lg font-semibold text-black">
                 {session.user?.name}
               </div>
-              <div className="h-1/6 w-full pl-3 pt-2 text-left text-sm text-gray-400">
+              <div className="h-1/6 w-full pl-3 pt-2 text-left text-sm text-gray-400 underline">
                 <span>&gt;</span> 마이페이지
               </div>
             </div>
@@ -67,44 +67,38 @@ const SheetInnerContent = ({
       <Separator />
       <div className="flex-auto ">
         {/* Main */}
-        <div className="my-5">
-          <NavLinkHeader className="mb-3">MAIN</NavLinkHeader>
+        <div className="my-6">
+          <NavLinkHeader className="mb-4">MAIN</NavLinkHeader>
 
           <div className="space-y-7">
             <NavLink
-              href={ROUTES.NOTICE.LIST}
-              icon={<Megaphone size={iconSize} className={iconcolor} />}
+              href={ROUTES.PERFORMANCE.TEAM.LIST(DEFAULT_PERFORMANCE_ID)}
+              icon={<Users size={iconSize} className={iconcolor} />}
               onClick={() => setIsOpen(false)}
             >
-              공지사항
+              팀 모집
             </NavLink>
+            <span className="flex w-full cursor-not-allowed items-center gap-x-4 text-gray-300">
+              <Building2 size={iconSize} />
+              <span className="text-lg font-medium">공간 대여</span>
+            </span>
+            <span className="flex w-full cursor-not-allowed items-center gap-x-4 text-gray-300">
+              <Package size={iconSize} />
+              <span className="text-lg font-medium">물품 대여</span>
+            </span>
             <NavLink
               href={ROUTES.PERFORMANCE.LIST}
-              icon={<Music4 size={iconSize} className={iconcolor} />}
+              icon={<Archive size={iconSize} className={iconcolor} />}
               onClick={() => setIsOpen(false)}
             >
-              공연목록
-            </NavLink>
-            <NavLink
-              href={ROUTES.PERFORMANCE.TEAM.LIST(DEFAULT_PERFORMANCE_ID)}
-              icon={<FileText size={iconSize} className={iconcolor} />}
-              onClick={() => setIsOpen(false)}
-            >
-              세션지원
-            </NavLink>
-            <NavLink
-              href={ROUTES.MEMBER.LIST}
-              icon={<ImageIcon size={iconSize} className={iconcolor} />}
-              onClick={() => setIsOpen(false)}
-            >
-              멤버목록
+              아카이브
             </NavLink>
           </div>
         </div>
         <Separator />
         {/* Links */}
-        <div className="my-5">
-          <NavLinkHeader className="mb-3">LINKS</NavLinkHeader>
+        <div className="my-6">
+          <NavLinkHeader className="mb-4">LINKS</NavLinkHeader>
 
           <div className="space-y-7">
             <NavLink
@@ -140,19 +134,14 @@ const SheetInnerContent = ({
             </Link>
           </>
         ) : (
-          <>
-            <LogIn
-              onClick={() => signOut()}
-              size={iconSize}
-              className="cursor-pointer text-red-600"
-            />
-            <div
-              className="cursor-pointer text-xl font-medium text-red-600"
-              onClick={() => signOut()}
-            >
-              Logout Account
-            </div>
-          </>
+          <button
+            type="button"
+            className="flex cursor-pointer items-center gap-4 text-red-600"
+            onClick={() => signOut()}
+          >
+            <LogIn size={iconSize} />
+            <span className="text-xl font-medium">Logout Account</span>
+          </button>
         )}
       </div>
     </div>

--- a/apps/web/components/Header/index.tsx
+++ b/apps/web/components/Header/index.tsx
@@ -19,7 +19,6 @@ type MenuItem = {
   name: string
   url: string
   active: boolean
-  experimental?: boolean
 }
 
 const Header = ({
@@ -32,25 +31,20 @@ const Header = ({
   mode?: HeaderMode
 }) => {
   const menuItems: MenuItem[] = [
-    { name: "소개", url: ROUTES.HOME, active: false, experimental: true },
-    { name: "신청", url: ROUTES.HOME, active: false, experimental: true },
-    { name: "모집", url: ROUTES.HOME, active: false, experimental: true },
     {
-      name: "예약",
+      name: "팀 모집",
       url: ROUTES.PERFORMANCE.TEAM.LIST(DEFAULT_PERFORMANCE_ID),
       active: true
     },
     {
-      name: "동방",
+      name: "공간 대여",
       url: ROUTES.RESERVATION.CLUBROOM,
-      active: true,
-      experimental: true
+      active: false
     },
     {
-      name: "장비",
+      name: "물품 대여",
       url: ROUTES.RESERVATION.EQUIPMENT,
-      active: true,
-      experimental: true
+      active: false
     },
     { name: "아카이브", url: ROUTES.PERFORMANCE.LIST, active: true }
   ]
@@ -108,7 +102,6 @@ const Header = ({
                 href={menuItem.url}
                 isActive={menuItem.active}
                 mode={mode}
-                isAdminOnly={menuItem.experimental}
               >
                 {menuItem.name}
               </NavLink>


### PR DESCRIPTION
## Summary
- 로그인 페이지: 반응형 디자인, 폰트 스타일, 버튼 색상(#4A8AF4) 및 모바일 레이아웃 개선
- 회원가입 페이지: 취소/회원가입 pill 버튼 추가, 세션 설명 텍스트 변경
- 사이드바: 메뉴 항목 재구성(팀 모집, 공간 대여, 물품 대여, 아카이브), 로그아웃 버튼 버그 수정, aria 경고 해결
- 데스크톱 네비게이션: 모바일 사이드바와 메뉴 항목 통일, 미사용 항목(소개/신청/모집) 제거
- 로그인 페이지 input focus ring 짤림 수정

## Test plan
- [ ] 로그인 페이지 데스크톱/모바일 반응형 확인
- [ ] 회원가입 페이지 버튼 스타일 및 동작 확인
- [ ] 사이드바 메뉴 항목 링크 및 비활성화 항목 확인
- [ ] 데스크톱 네비게이션 메뉴 항목 확인 (팀 모집, 공간 대여, 물품 대여, 아카이브)
- [ ] 로그아웃 버튼 동작 확인
- [ ] Input focus ring 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)