### PR TITLE
feat: redesign team list page (desktop + mobile)

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -38,6 +38,7 @@ const MemberSessionCard = ({
   const unapplyMutation = useUnapplyFromTeam({
     onSuccess: (team) => {
       queryClient.invalidateQueries({ queryKey: ["team", teamId] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
       toast({
         title: "탈퇴 완료",
         description: "팀에서 탈퇴되었습니다."

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
@@ -18,6 +18,7 @@ const useTeamApplication = (teamId: number) => {
   const applyMutation = useApplyToTeam({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["team", teamId] })
+      queryClient.invalidateQueries({ queryKey: ["teams"] })
       toast({
         title: "지원 완료",
         description: "팀에 지원이 완료되었습니다."

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/index.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/index.tsx
@@ -45,12 +45,11 @@ const TeamCard = ({
   const { canEdit } = useTeamPermission({ leaderId: leader.id })
 
   return (
-    <div className="rounded-lg bg-white p-5 shadow-md">
+    <div className="border-b border-gray-200 bg-white px-1 py-4">
       <Link href={ROUTES.PERFORMANCE.TEAM.DETAIL(performanceId, id)}>
         <div>
           {/* 곡명 & 상태 */}
           <div className="text-md flex items-start justify-between">
-            {/* 곡명 */}
             <div className="flex items-center gap-x-2">
               <h4 className="flex items-center gap-x-1 self-stretch font-bold text-slate-700">
                 {songName}
@@ -62,7 +61,6 @@ const TeamCard = ({
               </h4>
             </div>
 
-            {/* 상태 */}
             <StatusBadge
               status={missingTeamSessions.length > 0 ? "Active" : "Inactive"}
               className="text-xs"
@@ -71,22 +69,17 @@ const TeamCard = ({
 
           {/* 아티스트명 & 태그 */}
           <div className="mt-1 flex items-center justify-between text-xs">
-            {/* 아티스트명 */}
             <h4 className="text-sm text-slate-500">{songArtist}</h4>
 
-            {/* 태그(신입고정, 자작곡) */}
             <div className="flex items-center gap-x-1">
-              {/* 신입고정 */}
               {isFreshmenFixed && <FreshmenFixedBadge size={"small"} />}
-
-              {/* 자작곡 */}
               {isSelfMade && <SelfMadeSongBadge />}
             </div>
           </div>
 
           {/* 팀장 */}
-          <div className="mt-3 flex items-center justify-between text-slate-500">
-            <h4 className="w-20 text-xs">팀장</h4>
+          <div className="mt-3 flex w-full items-center justify-between">
+            <h4 className="text-xs text-slate-500">팀장</h4>
             <div className="flex items-center gap-x-3">
               <Avatar className="h-5 w-5">
                 <AvatarImage src={leader.image ?? undefined} />
@@ -94,21 +87,21 @@ const TeamCard = ({
                   {leader.name.substring(0, 1)}
                 </AvatarFallback>
               </Avatar>
-              <span className="text-xs">{leader.name}</span>
+              <span className="text-xs text-slate-500">{leader.name}</span>
             </div>
           </div>
 
-          {/* 필요세션 */}
-          <div className="mt-4 flex items-center justify-between text-xs">
-            <h4 className="w-20 text-xs text-neutral-500">필요세션</h4>
-            <div className="gap-x-1 text-right">
+          {/* 모집세션 */}
+          <div className="mt-4 flex items-start justify-between text-xs">
+            <h4 className="text-xs text-neutral-500">모집세션</h4>
+            <div className="flex flex-wrap justify-end gap-1.5">
               {missingTeamSessions?.map((ts) => {
                 const missingIndices = getMissingIndices(ts)
                 return missingIndices.map((index) => (
                   <SessionBadge
                     key={`${ts.session.name}-${index}`}
                     session={`${getSessionDisplayName(ts.session.name)}${index}`}
-                    className="m-0.5 rounded-lg p-1"
+                    className="rounded-[5px]"
                   />
                 ))
               })}
@@ -116,38 +109,6 @@ const TeamCard = ({
           </div>
         </div>
       </Link>
-
-      {/* 액션: 편집, 삭제 */}
-      {canEdit && (
-        <div className="mt-3 grid grid-cols-2 gap-x-4">
-          <Button
-            asChild
-            className="flex h-9 w-full items-center gap-x-2 rounded-lg border-none bg-slate-100 text-xs text-primary drop-shadow-sm"
-            variant="outline"
-          >
-            <Link href={ROUTES.PERFORMANCE.TEAM.EDIT(performanceId, id)}>
-              <PencilLine size={14} strokeWidth={2} className="font-bold" />
-              편집하기
-            </Link>
-          </Button>
-          <TeamDeleteButton
-            teamId={id}
-            className="w-full"
-            redirectUrl={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
-          >
-            <Button
-              asChild
-              className="flex h-9 w-full items-center gap-x-2 rounded-lg bg-slate-100 text-xs text-primary drop-shadow-sm"
-              variant="destructive"
-            >
-              <div>
-                <Trash2 size={14} strokeWidth={2} className="font-bold" />
-                삭제하기
-              </div>
-            </Button>
-          </TeamDeleteButton>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/index.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard/index.tsx
@@ -45,7 +45,7 @@ const TeamCard = ({
   const { canEdit } = useTeamPermission({ leaderId: leader.id })
 
   return (
-    <div className="border-b border-gray-200 bg-white px-1 py-4">
+    <div className="rounded-lg bg-white p-5 shadow-md">
       <Link href={ROUTES.PERFORMANCE.TEAM.DETAIL(performanceId, id)}>
         <div>
           {/* 곡명 & 상태 */}
@@ -109,6 +109,38 @@ const TeamCard = ({
           </div>
         </div>
       </Link>
+
+      {/* 액션: 편집, 삭제 */}
+      {canEdit && (
+        <div className="mt-3 grid grid-cols-2 gap-x-4">
+          <Button
+            asChild
+            className="flex h-9 w-full items-center gap-x-2 rounded-lg border-none bg-slate-100 text-xs text-primary drop-shadow-sm"
+            variant="outline"
+          >
+            <Link href={ROUTES.PERFORMANCE.TEAM.EDIT(performanceId, id)}>
+              <PencilLine size={14} strokeWidth={2} className="font-bold" />
+              편집하기
+            </Link>
+          </Button>
+          <TeamDeleteButton
+            teamId={id}
+            className="w-full"
+            redirectUrl={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
+          >
+            <Button
+              asChild
+              className="flex h-9 w-full items-center gap-x-2 rounded-lg bg-slate-100 text-xs text-primary drop-shadow-sm"
+              variant="destructive"
+            >
+              <div>
+                <Trash2 size={14} strokeWidth={2} className="font-bold" />
+                삭제하기
+              </div>
+            </Button>
+          </TeamDeleteButton>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/RelatedPerformanceList/SelectView.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/RelatedPerformanceList/SelectView.tsx
@@ -35,7 +35,7 @@ const SelectView = ({
       }
     >
       <SelectTrigger className="flex-row-reverse gap-x-2 text-gray-500">
-        <SelectValue>Performances</SelectValue>
+        <SelectValue placeholder={currentPerformance?.name} />
       </SelectTrigger>
       <SelectContent>
         {performanceOptions.map((p) => (

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/RelatedPerformanceList/SelectView.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/RelatedPerformanceList/SelectView.tsx
@@ -35,7 +35,7 @@ const SelectView = ({
       }
     >
       <SelectTrigger className="flex-row-reverse gap-x-2 text-gray-500">
-        <SelectValue placeholder={currentPerformance?.name} />
+        <SelectValue>Performances</SelectValue>
       </SelectTrigger>
       <SelectContent>
         {performanceOptions.map((p) => (

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListSkeleton.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListSkeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 const TableRowSkeleton = () => (
   <tr className="bg-white drop-shadow-[0_1px_2px_rgb(0,0,0,0.06)]">
     {/* 곡명 */}
-    <td className="p-4">
+    <td className="rounded-l-lg p-4">
       <Skeleton className="mb-1.5 h-4 w-32" />
       <Skeleton className="h-3 w-20" />
     </td>
@@ -16,9 +16,9 @@ const TableRowSkeleton = () => (
     {/* 필요세션 */}
     <td className="p-4">
       <div className="flex gap-1">
-        <Skeleton className="h-6 w-12 rounded-full" />
-        <Skeleton className="h-6 w-12 rounded-full" />
-        <Skeleton className="h-6 w-12 rounded-full" />
+        <Skeleton className="h-6 w-12 rounded-[5px]" />
+        <Skeleton className="h-6 w-12 rounded-[5px]" />
+        <Skeleton className="h-6 w-12 rounded-[5px]" />
       </div>
     </td>
     {/* 모집상태 */}
@@ -34,7 +34,7 @@ const TableRowSkeleton = () => (
       </div>
     </td>
     {/* 액션 */}
-    <td className="p-4">
+    <td className="rounded-r-lg p-4">
       <div className="flex justify-center">
         <Skeleton className="h-5 w-4 rounded" />
       </div>
@@ -80,10 +80,12 @@ const TeamListSkeleton = () => {
       {/* 헤더 */}
       <div className="flex flex-col justify-center space-y-1 pb-2 pt-10 text-center md:space-y-5 md:pb-[91px] md:pt-[135px]">
         <Skeleton className="mx-auto h-8 w-40 md:h-12 md:w-60" />
-        <div className="flex items-center justify-center gap-2">
+        <div className="hidden items-center justify-center gap-2 md:flex">
           <Skeleton className="h-4 w-4 rounded" />
           <Skeleton className="h-4 w-8" />
           <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
         </div>
       </div>
 
@@ -91,33 +93,33 @@ const TeamListSkeleton = () => {
       <div className="hidden md:block">
         {/* 검색 + 버튼 */}
         <div className="flex items-center justify-between py-[25px]">
-          <Skeleton className="h-10 w-[300px] rounded-md" />
+          <Skeleton className="h-10 w-[300px] rounded-full" />
           <div className="flex gap-4">
-            <Skeleton className="h-10 w-[136px] rounded-[6px]" />
-            <Skeleton className="h-10 w-[136px] rounded-[6px]" />
+            <Skeleton className="h-10 w-[136px] rounded-full" />
+            <Skeleton className="h-10 w-[136px] rounded-full" />
           </div>
         </div>
 
         {/* 테이블 */}
-        <table className="w-full">
+        <table className="w-full border-separate border-spacing-y-1">
           <thead>
-            <tr className="bg-zinc-700">
-              <th className="p-3 text-left text-sm font-bold text-white">
+            <tr>
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-left text-sm font-semibold text-neutral-600 first:rounded-l-lg first:border-l last:rounded-r-lg last:border-r">
                 곡명
               </th>
-              <th className="p-3 text-center text-sm font-bold text-white">
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-center text-sm font-semibold text-neutral-600">
                 팀장
               </th>
-              <th className="p-3 text-left text-sm font-bold text-white">
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-left text-sm font-semibold text-neutral-600">
                 필요 세션
               </th>
-              <th className="p-3 text-center text-sm font-bold text-white">
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-center text-sm font-semibold text-neutral-600">
                 모집상태
               </th>
-              <th className="p-3 text-center text-sm font-bold text-white">
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-center text-sm font-semibold text-neutral-600">
                 영상링크
               </th>
-              <th className="p-3 text-sm font-bold text-white" />
+              <th className="border-y border-gray-200 bg-gray-100 p-3 text-sm font-semibold text-neutral-600 last:rounded-r-lg last:border-r" />
             </tr>
           </thead>
           <tbody className="[&_tr]:mb-1">

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
@@ -15,7 +15,7 @@ const DesktopFilterCheckbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "data-[state=checked]:1 peer h-6 w-6 shrink-0 rounded-sm border border-slate-400 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-700 data-[state=checked]:bg-sky-700 data-[state=checked]:text-primary-foreground",
+      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-500 data-[state=checked]:bg-sky-500 data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const DesktopFilterCheckbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-6 w-6 font-extrabold" strokeWidth={4} />
+      <Check className="h-3.5 w-3.5" strokeWidth={3} />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))
@@ -56,7 +56,7 @@ const DesktopFilter = ({
         )}
       </div>
 
-      <div className="flex flex-wrap gap-x-5 gap-y-3">
+      <div className="grid grid-cols-5 gap-x-5 gap-y-3">
         {filterValues.map((v) => (
           <div key={v.label} className="flex items-center gap-x-2">
             <DesktopFilterCheckbox

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
@@ -33,35 +33,42 @@ interface DesktopFilterProps {
   className?: string
   header: string
   filterValues: FilterValue[]
+  onSelectAll?: () => void
 }
 
 const DesktopFilter = ({
   className,
   header,
-  filterValues
+  filterValues,
+  onSelectAll
 }: DesktopFilterProps) => {
   return (
     <div className={className}>
-      <div className="mb-6 text-lg text-primary">{header}</div>
-
-      <div
-        className={cn(
-          "grid gap-4",
-          filterValues.length > 4 ? "grid-cols-2" : "grid-cols-1"
+      <div className="mb-4 flex items-center gap-x-3">
+        <div className="text-sm font-semibold text-neutral-700">{header}</div>
+        {onSelectAll && (
+          <button
+            onClick={onSelectAll}
+            className="text-xs text-sky-500 hover:text-sky-600"
+          >
+            모두 선택
+          </button>
         )}
-      >
+      </div>
+
+      <div className="flex flex-wrap gap-x-5 gap-y-3">
         {filterValues.map((v) => (
-          <div key={v.label} className="flex w-[184px] items-center gap-x-3">
+          <div key={v.label} className="flex items-center gap-x-2">
             <DesktopFilterCheckbox
-              id={`filter-${v.label}`}
+              id={`desktop-filter-${header}-${v.label}`}
               name={v.label}
               value={v.label}
               checked={v.checked}
               onCheckedChange={(checked) => v.onChecked(!!checked)}
             />
             <Label
-              htmlFor={`filter-${v.label}`}
-              className="text-nowrap text-gray-900"
+              htmlFor={`desktop-filter-${header}-${v.label}`}
+              className="text-nowrap text-sm text-gray-900"
             >
               {v.label}
             </Label>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Mobile.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Mobile.tsx
@@ -15,7 +15,7 @@ const MobileFilterCheckbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "data-[state=checked]:1 peer h-3 w-3 shrink-0 rounded-sm border border-slate-400 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-700 data-[state=checked]:bg-sky-700 data-[state=checked]:text-primary-foreground",
+      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-500 data-[state=checked]:bg-sky-500 data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const MobileFilterCheckbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-3 w-3 font-extrabold" strokeWidth={4} />
+      <Check className="h-3.5 w-3.5" strokeWidth={3} />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))
@@ -38,12 +38,11 @@ interface MobileProps {
 const MobileFilter = ({ className, header, filterValues }: MobileProps) => {
   return (
     <div className={className}>
-      <div className="mb-4 flex items-center gap-x-3 text-xs">
-        <div className="font-semibold text-neutral-500">{header}</div>
-        {/* <button className="text-third">전체 선택</button> */}
+      <div className="mb-4 flex items-center gap-x-3">
+        <div className="text-sm font-semibold text-neutral-700">{header}</div>
       </div>
 
-      <div className="grid grid-cols-4 gap-x-5 gap-y-4">
+      <div className="grid grid-cols-3 gap-x-5 gap-y-3">
         {filterValues.map((v) => (
           <div
             key={v.label}
@@ -58,7 +57,7 @@ const MobileFilter = ({ className, header, filterValues }: MobileProps) => {
             />
             <Label
               htmlFor={`filter-${v.label}`}
-              className="text-[10px] text-slate-600"
+              className="text-sm text-gray-900"
             >
               {v.label}
             </Label>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -12,7 +12,7 @@ import {
 import Link from "next/link"
 import React from "react"
 
-import DeleteButton from "@/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/DeleteButton"
+import TeamDeleteButton from "@/components/TeamDeleteButton"
 import { useTeamPermission } from "@/hooks/useTeamPermission"
 import FreshmenFixedBadge from "@/components/TeamBadges/FreshmenFixedBadge"
 import SelfMadeSongBadge from "@/components/TeamBadges/SelfMadeSongBadge"
@@ -87,15 +87,20 @@ const ActionsCell = ({ row }: CellContext<TeamColumn, unknown>) => {
               편집하기
             </Link>
           </DropdownMenuItem>
-          <DropdownMenuItem className="p-0 selection:text-slate-700 hover:cursor-pointer">
-            <DeleteButton
-              className="flex h-full w-full items-center justify-center gap-x-2 px-6 py-2"
-              teamId={row.original.id}
+          <TeamDeleteButton
+            teamId={row.original.id}
+            redirectUrl={ROUTES.PERFORMANCE.TEAM.LIST(
+              row.original.performanceId
+            )}
+          >
+            <DropdownMenuItem
+              onSelect={(e) => e.preventDefault()}
+              className="flex items-center justify-center gap-x-2 px-6 py-2 selection:text-slate-700 hover:cursor-pointer"
             >
               <Trash2 />
               삭제하기
-            </DeleteButton>
-          </DropdownMenuItem>
+            </DropdownMenuItem>
+          </TeamDeleteButton>
         </DropdownMenuContent>
       </DropdownMenu>
     )
@@ -205,6 +210,13 @@ export const columns: ColumnDef<TeamColumn>[] = [
         )
       }
     }
+  },
+  {
+    accessorKey: "createdAt",
+    header: () => null,
+    cell: () => null,
+    enableHiding: true,
+    meta: { hidden: true }
   },
   {
     id: "actions",

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -174,9 +174,12 @@ export const columns: ColumnDef<TeamColumn>[] = [
     }
   },
   {
-    accessorKey: "status",
-    header: () => (
-      <div className="flex items-center justify-center">모집상태</div>
+    id: "status",
+    accessorFn: (row) => (isTeamSatisfied(row.teamSessions) ? 1 : 0),
+    header: ({ column }) => (
+      <div className="flex w-full justify-center">
+        <SortButton column={column}>모집상태</SortButton>
+      </div>
     ),
     cell: ({ row }) => {
       const teamSessions = row.original.teamSessions
@@ -194,21 +197,18 @@ export const columns: ColumnDef<TeamColumn>[] = [
       <div className="flex items-center justify-center">영상링크</div>
     ),
     cell: ({ row }) => {
-      const youtubeLink = YoutubeVideo.getURL(
-        row.getValue("songYoutubeVideoUrl")
+      const rawUrl = row.original.songYoutubeVideoUrl
+      if (!rawUrl) return null
+      return (
+        <Link
+          href={YoutubeVideo.getURL(rawUrl)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex w-full items-center justify-center"
+        >
+          <Paperclip size={24} />
+        </Link>
       )
-      if (youtubeLink) {
-        return (
-          <Link
-            href={youtubeLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex w-full items-center justify-center"
-          >
-            <Paperclip size={24} />
-          </Link>
-        )
-      }
     }
   },
   {

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -215,8 +215,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
     accessorKey: "createdAt",
     header: () => null,
     cell: () => null,
-    enableHiding: true,
-    meta: { hidden: true }
+    enableHiding: true
   },
   {
     id: "actions",

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -150,7 +150,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
   {
     id: "requiredSessions",
     header: () => (
-      <div className="flex w-full items-center justify-start">필요 세션</div>
+      <div className="flex w-full items-center justify-start">필요세션</div>
     ),
     cell: ({ row }) => {
       return (

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -119,7 +119,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
           {row.original.songName}
           {!row.original.posterImage && (
             <span>
-              <Image className="h-3 w-3 font-normal text-neutral-500" />
+              <Image size={15} className="text-neutral-800" strokeWidth={1.5} />
             </span>
           )}
         </div>
@@ -154,7 +154,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
     ),
     cell: ({ row }) => {
       return (
-        <div className="flex justify-start gap-1 text-right font-medium">
+        <div className="flex justify-start gap-2.5 text-right font-medium">
           {row.original.teamSessions.map((ts) => {
             const missingIndices = getMissingIndices(ts)
             return missingIndices.map((index) => (

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -12,8 +12,9 @@ import {
   useReactTable
 } from "@tanstack/react-table"
 import { ArrowDownUp, CirclePlus, Filter, Plus, X } from "lucide-react"
+import { useSession } from "next-auth/react"
 import Link from "next/link"
-import { useReducer, useState } from "react"
+import { useMemo, useReducer, useState } from "react"
 
 import TeamHeaderButton from "@/app/(general)/(light)/performances/[id]/teams/_components/Mobile/HeaderButton"
 import TeamCard from "@/app/(general)/(light)/performances/[id]/teams/_components/Mobile/TeamCard"
@@ -173,6 +174,11 @@ export function TeamListDataTable<TValue>({
   relatedPerformances,
   performanceId
 }: DataTableProps<TValue>) {
+  const { data: session } = useSession()
+  const visibleColumns = useMemo(
+    () => (session ? columns : columns.filter((c) => c.id !== "actions")),
+    [session, columns]
+  )
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
@@ -290,7 +296,7 @@ export function TeamListDataTable<TValue>({
 
   const table = useReactTable({
     data: state.result,
-    columns,
+    columns: visibleColumns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
@@ -391,7 +397,7 @@ export function TeamListDataTable<TValue>({
                   return (
                     <TableHead
                       key={header.id}
-                      className="border border-gray-200 bg-gray-100 py-0 font-semibold text-neutral-600 first:rounded-l-lg last:rounded-r-lg"
+                      className="border-y border-gray-200 bg-gray-100 py-0 font-semibold text-neutral-600 first:rounded-l-lg first:border-l last:rounded-r-lg last:border-r"
                     >
                       {header.isPlaceholder
                         ? null

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -11,15 +11,7 @@ import {
   SortingState,
   useReactTable
 } from "@tanstack/react-table"
-import {
-  ArrowDownUp,
-  ChevronLeft,
-  ChevronRight,
-  CirclePlus,
-  Filter,
-  Plus,
-  X
-} from "lucide-react"
+import { ArrowDownUp, CirclePlus, Filter, Plus, X } from "lucide-react"
 import { useSession } from "next-auth/react"
 import Link from "next/link"
 import { useMemo, useReducer, useState } from "react"
@@ -38,6 +30,7 @@ import {
   TableHeader,
   TableRow
 } from "@/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table"
+import { DataTablePagination } from "@/components/DataTable/Pagination"
 import Search from "@/components/Search"
 import { Button } from "@/components/ui/button"
 import {
@@ -628,40 +621,8 @@ export function TeamListDataTable<TValue>({
 
         {/* 모바일 페이지네이션 */}
         {table.getRowModel().rows.length > 0 && (
-          <div className="flex items-center justify-center gap-2 py-6">
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="text-sm text-muted-foreground">Page</span>
-            <select
-              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-              value={table.getState().pagination.pageIndex}
-              onChange={(e) => table.setPageIndex(Number(e.target.value))}
-            >
-              {Array.from({ length: table.getPageCount() }, (_, i) => (
-                <option key={i} value={i}>
-                  {i + 1}
-                </option>
-              ))}
-            </select>
-            <span className="text-sm text-muted-foreground">
-              of {table.getPageCount()}
-            </span>
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
+          <div className="py-6">
+            <DataTablePagination table={table} />
           </div>
         )}
       </div>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -494,7 +494,7 @@ export function TeamListDataTable<TValue>({
       </div>
 
       {/* 모바일: 카드 보기 */}
-      <div className="md:hidden">
+      <div className="px-4 md:hidden">
         {/* 헤더 */}
         <div className="space-y-3">
           {/* 검색, 필터, 정렬 */}
@@ -515,7 +515,15 @@ export function TeamListDataTable<TValue>({
             <Drawer>
               <DrawerTrigger>
                 <TeamHeaderButton asChild variant="outline">
-                  <Filter className="text-gray-400" size={16} />
+                  <Filter
+                    className={
+                      state.filters.필요세션.size > 0 ||
+                      state.filters.모집상태 !== "all"
+                        ? "text-primary"
+                        : "text-gray-400"
+                    }
+                    size={16}
+                  />
                 </TeamHeaderButton>
               </DrawerTrigger>
               <DrawerContent className="px-0 pb-10">
@@ -565,7 +573,7 @@ export function TeamListDataTable<TValue>({
                 <TeamHeaderButton asChild variant="outline">
                   <ArrowDownUp
                     strokeWidth={1.75}
-                    className="text-gray-400"
+                    className={sortQuery ? "text-primary" : "text-gray-400"}
                     size={16}
                   />
                 </TeamHeaderButton>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -360,7 +360,7 @@ export function TeamListDataTable<TValue>({
   ]
 
   return (
-    <div className={`overflow-x-clip ${className ?? ""}`}>
+    <div className={className}>
       {/* 데스크톱: 테이블 보기 */}
       <div className="hidden md:block">
         {/* 헤더 */}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -406,7 +406,7 @@ export function TeamListDataTable<TValue>({
               <PopoverContent
                 align="end"
                 onInteractOutside={() => setFilterOpen(false)}
-                className="w-[480px] p-0"
+                className="w-[480px] rounded-[12px] p-0"
               >
                 {/* 헤더 */}
                 <div className="flex items-center justify-between px-6 pb-3 pt-5">

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -357,7 +357,7 @@ export function TeamListDataTable<TValue>({
   ]
 
   return (
-    <div className={className}>
+    <div className={`overflow-x-hidden ${className ?? ""}`}>
       {/* 데스크톱: 테이블 보기 */}
       <div className="hidden md:block">
         {/* 헤더 */}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -11,7 +11,15 @@ import {
   SortingState,
   useReactTable
 } from "@tanstack/react-table"
-import { ArrowDownUp, CirclePlus, Filter, Plus, X } from "lucide-react"
+import {
+  ArrowDownUp,
+  ChevronLeft,
+  ChevronRight,
+  CirclePlus,
+  Filter,
+  Plus,
+  X
+} from "lucide-react"
 import { useSession } from "next-auth/react"
 import Link from "next/link"
 import { useMemo, useReducer, useState } from "react"
@@ -617,6 +625,45 @@ export function TeamListDataTable<TValue>({
             </div>
           )}
         </div>
+
+        {/* 모바일 페이지네이션 */}
+        {table.getRowModel().rows.length > 0 && (
+          <div className="flex items-center justify-center gap-2 py-6">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground">Page</span>
+            <select
+              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+              value={table.getState().pagination.pageIndex}
+              onChange={(e) => table.setPageIndex(Number(e.target.value))}
+            >
+              {Array.from({ length: table.getPageCount() }, (_, i) => (
+                <option key={i} value={i}>
+                  {i + 1}
+                </option>
+              ))}
+            </select>
+            <span className="text-sm text-muted-foreground">
+              of {table.getPageCount()}
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -354,11 +354,13 @@ export function TeamListDataTable<TValue>({
     { value: "songName-asc", display: "곡명 오름차순" },
     { value: "songName-desc", display: "곡명 내림차순" },
     { value: "createdAt-desc", display: "최신순" },
-    { value: "createdAt-asc", display: "오래된순" }
+    { value: "createdAt-asc", display: "오래된순" },
+    { value: "status-asc", display: "모집중 우선" },
+    { value: "status-desc", display: "모집완료 우선" }
   ]
 
   return (
-    <div className={`overflow-x-hidden ${className ?? ""}`}>
+    <div className={`overflow-x-clip ${className ?? ""}`}>
       {/* 데스크톱: 테이블 보기 */}
       <div className="hidden md:block">
         {/* 헤더 */}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -417,10 +417,13 @@ export function TeamListDataTable<TValue>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
-                  className="bg-white drop-shadow-[0_1px_2px_rgb(0,0,0,0.06)] transition-all duration-300 hover:drop-shadow-[0_4px_4px_rgb(0,0,0,0.25)]"
+                  className="bg-white drop-shadow-[0_1px_2px_rgb(0,0,0,0.06)] transition-all duration-300 hover:drop-shadow-[2px_2px_4px_rgb(0,0,0,0.06)]"
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="bg-transparent">
+                    <TableCell
+                      key={cell.id}
+                      className="bg-transparent first:rounded-l-lg last:rounded-r-lg"
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext()

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -340,7 +340,7 @@ export function TeamListDataTable<TValue>({
             {/* 생성 버튼 */}
             <Button
               asChild
-              className="h-10 w-[136px] rounded-[6px] text-[20px] font-semibold"
+              className="h-10 w-[136px] rounded-full text-[20px] font-semibold"
             >
               <Link href={ROUTES.PERFORMANCE.TEAM.CREATE(performanceId)}>
                 <CirclePlus size={24} className="me-[9px]" />
@@ -353,7 +353,7 @@ export function TeamListDataTable<TValue>({
               <PopoverTrigger>
                 <Button
                   asChild
-                  className="h-10 w-[136px] rounded-[6px] text-[20px] font-semibold"
+                  className="h-10 w-[136px] rounded-full text-[20px] font-semibold"
                   onClick={() => setFilterOpen(true)}
                   variant={filterOpen ? "outline" : undefined}
                 >
@@ -391,7 +391,7 @@ export function TeamListDataTable<TValue>({
                   return (
                     <TableHead
                       key={header.id}
-                      className="bg-zinc-700 py-0 font-bold text-white"
+                      className="border border-gray-200 bg-gray-100 py-0 font-semibold text-neutral-600 first:rounded-l-lg last:rounded-r-lg"
                     >
                       {header.isPlaceholder
                         ? null

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -327,10 +327,11 @@ export function TeamListDataTable<TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: (updater) => {
       const next = typeof updater === "function" ? updater(sorting) : updater
-      if (next.length === 0) {
+      const first = next[0]
+      if (!first) {
         setSortQuery(null)
       } else {
-        setSortQuery(`${next[0].id}-${next[0].desc ? "desc" : "asc"}`)
+        setSortQuery(`${first.id}-${first.desc ? "desc" : "asc"}`)
       }
     },
     getSortedRowModel: getSortedRowModel(),
@@ -494,11 +495,11 @@ export function TeamListDataTable<TValue>({
       </div>
 
       {/* 모바일: 카드 보기 */}
-      <div className="px-4 md:hidden">
+      <div className="md:hidden">
         {/* 헤더 */}
         <div className="space-y-3">
           {/* 검색, 필터, 정렬 */}
-          <div className="flex items-center justify-center gap-x-3">
+          <div className="flex items-center gap-x-3">
             {/* 검색 */}
             <Search
               placeholder="검색"
@@ -508,7 +509,7 @@ export function TeamListDataTable<TValue>({
                 setSearchQuery(value || null)
                 table.getColumn("songName")?.setFilterValue(value)
               }}
-              className="h-9 w-full max-w-full border-gray-200 drop-shadow-search"
+              className="h-9 min-w-0 flex-1 border-gray-200 drop-shadow-search"
             />
 
             {/* 필터 */}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -406,17 +406,59 @@ export function TeamListDataTable<TValue>({
               <PopoverContent
                 align="end"
                 onInteractOutside={() => setFilterOpen(false)}
-                className="flex gap-6 px-9 py-6 md:h-[256px] md:w-[400px]"
+                className="w-[480px] p-0"
               >
-                <TeamListTableFilter
-                  header="필요세션"
-                  filterValues={filterValues.필요세션}
-                />
-                <Separator orientation="vertical" className="h-[216px]" />
-                <TeamListTableFilter
-                  header="모집상태"
-                  filterValues={filterValues.모집상태}
-                />
+                {/* 헤더 */}
+                <div className="flex items-center justify-between px-6 pb-3 pt-5">
+                  <div className="flex items-baseline gap-x-3">
+                    <h3 className="text-xl font-bold">Filter</h3>
+                    <button
+                      onClick={() => {
+                        dispatch({
+                          type: "clearFilter",
+                          payload: { target: "필요세션" }
+                        })
+                        dispatch({
+                          type: "setFilter",
+                          payload: { target: "모집상태", value: "all" }
+                        })
+                      }}
+                      className="text-xs text-sky-500 hover:text-sky-600"
+                    >
+                      초기화
+                    </button>
+                  </div>
+                  <button onClick={() => setFilterOpen(false)}>
+                    <X className="h-4 w-4 text-slate-400" />
+                  </button>
+                </div>
+
+                <Separator />
+
+                {/* 필터 내용 */}
+                <div className="space-y-5 px-6 py-5">
+                  <TeamListTableFilter
+                    header="필요세션"
+                    filterValues={filterValues.필요세션}
+                    onSelectAll={() =>
+                      dispatch({
+                        type: "clearFilter",
+                        payload: { target: "필요세션" }
+                      })
+                    }
+                  />
+                  <Separator />
+                  <TeamListTableFilter
+                    header="모집상태"
+                    filterValues={filterValues.모집상태}
+                    onSelectAll={() =>
+                      dispatch({
+                        type: "setFilter",
+                        payload: { target: "모집상태", value: "all" }
+                      })
+                    }
+                  />
+                </div>
               </PopoverContent>
             </Popover>
           </div>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/drawer.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/drawer.tsx
@@ -6,7 +6,7 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 const Drawer = ({
-  shouldScaleBackground = true,
+  shouldScaleBackground = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
   <DrawerPrimitive.Root

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/filter.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/filter.tsx
@@ -12,12 +12,14 @@ interface TeamListTableFilterProps {
   className?: string
   header: string
   filterValues: FilterValue[]
+  onSelectAll?: () => void
 }
 
 const TeamListTableFilter = ({
   className,
   header,
-  filterValues
+  filterValues,
+  onSelectAll
 }: TeamListTableFilterProps) => {
   return (
     <div className={className}>
@@ -25,6 +27,7 @@ const TeamListTableFilter = ({
         className="hidden lg:block"
         header={header}
         filterValues={filterValues}
+        onSelectAll={onSelectAll}
       />
       <MobileFilter
         className="lg:hidden"

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
@@ -9,7 +9,10 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn(
+        "w-full caption-bottom border-separate border-spacing-0 text-sm",
+        className
+      )}
       {...props}
     />
   </div>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
@@ -6,11 +6,11 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-x-auto overflow-y-visible px-1">
     <table
       ref={ref}
       className={cn(
-        "w-full caption-bottom border-separate border-spacing-0 text-sm",
+        "w-full caption-bottom border-separate [border-spacing:0_16px] text-sm",
         className
       )}
       {...props}
@@ -54,7 +54,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-t-[16px] border-t-neutral-50 transition-colors data-[state=selected]:bg-muted",
+      "transition-colors data-[state=selected]:bg-muted",
       className
     )}
     {...props}
@@ -84,7 +84,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "border-t-8 border-white bg-white px-4 py-6 align-middle [&:has([role=checkbox])]:pr-0",
+      "bg-white px-4 py-6 align-middle [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
@@ -52,7 +52,11 @@ const TeamList = () => {
           },
           {
             display: currentPerformance?.name ?? "공연",
-            href: ROUTES.PERFORMANCE.DETAIL(performanceId)
+            href: ROUTES.PERFORMANCE.TEAM.LIST(performanceId),
+            dropdownItems: relatedPerformances.map((p) => ({
+              label: p.name,
+              href: ROUTES.PERFORMANCE.TEAM.LIST(p.id)
+            }))
           },
           {
             display: "공연팀 목록",

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/page.tsx
@@ -33,6 +33,10 @@ const TeamList = () => {
     return <div>오류가 발생했습니다.</div>
   }
 
+  const currentPerformance = relatedPerformances.find(
+    (p) => p.id === performanceId
+  )
+
   return (
     <div>
       {/* 팀 배너 */}
@@ -45,6 +49,10 @@ const TeamList = () => {
           },
           {
             display: "모집"
+          },
+          {
+            display: currentPerformance?.name ?? "공연",
+            href: ROUTES.PERFORMANCE.DETAIL(performanceId)
           },
           {
             display: "공연팀 목록",

--- a/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
+++ b/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
@@ -1,8 +1,18 @@
-import { ChevronRight } from "lucide-react"
+"use client"
+
+import { ChevronDown, ChevronRight } from "lucide-react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import React from "react"
 
 import { DefaultPageHeaderBreadCrumbRoute } from "@/components/PageHeaders/Default"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 
 function isLast(index: number, length: number) {
   return index === length - 1
@@ -15,11 +25,35 @@ interface DefaultPageHeaderBreadCrumbProps {
 const DefaultPageHeaderBreadCrumb = ({
   routes
 }: DefaultPageHeaderBreadCrumbProps) => {
+  const router = useRouter()
+
   return (
     <div className="flex items-center justify-center gap-x-0.5 text-xs font-medium text-slate-400 md:gap-x-1.5 md:text-base">
       {routes.map((route, index) => (
         <React.Fragment key={index}>
-          {route.href ? (
+          {route.dropdownItems ? (
+            <Select
+              value={route.href ?? ""}
+              onValueChange={(value) => router.push(value)}
+            >
+              <SelectTrigger
+                className={`inline-flex h-auto w-auto items-center gap-1 border-none bg-transparent p-0 shadow-none ring-0 focus:ring-0 focus:ring-offset-0 ${
+                  isLast(index, routes.length)
+                    ? "font-semibold text-primary"
+                    : "text-slate-400"
+                } [&>svg]:h-3 [&>svg]:w-3`}
+              >
+                <SelectValue>{route.display}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {route.dropdownItems.map((item) => (
+                  <SelectItem key={item.href} value={item.href}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : route.href ? (
             <span
               className={
                 isLast(index, routes.length) ? "font-semibold text-primary" : ""

--- a/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
+++ b/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
@@ -28,7 +28,7 @@ const DefaultPageHeaderBreadCrumb = ({
   const router = useRouter()
 
   return (
-    <div className="flex items-center justify-center gap-x-0.5 text-xs font-medium text-slate-400 md:gap-x-1.5 md:text-base">
+    <div className="hidden items-center justify-center gap-x-0.5 text-xs font-medium text-slate-400 md:flex md:gap-x-1.5 md:text-base">
       {routes.map((route, index) => (
         <React.Fragment key={index}>
           {route.dropdownItems ? (

--- a/apps/web/components/PageHeaders/Default/index.tsx
+++ b/apps/web/components/PageHeaders/Default/index.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 export type DefaultPageHeaderBreadCrumbRoute = {
   display: React.ReactNode
   href?: string
+  dropdownItems?: { label: string; href: string }[]
 }
 
 export const DefaultHomeIcon = () => {

--- a/apps/web/components/Search.tsx
+++ b/apps/web/components/Search.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon, XIcon } from "lucide-react"
+import { SearchIcon } from "lucide-react"
 import React from "react"
 
 import { cn } from "@/lib/utils"
@@ -6,33 +6,11 @@ import { cn } from "@/lib/utils"
 const Search = React.forwardRef<
   HTMLInputElement,
   React.InputHTMLAttributes<HTMLInputElement>
->(({ className, onChange, ...props }, ref) => {
-  const [value, setValue] = React.useState((props.defaultValue as string) ?? "")
-  const inputRef = React.useRef<HTMLInputElement | null>(null)
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value)
-    onChange?.(e)
-  }
-
-  const handleClear = () => {
-    setValue("")
-    const input = inputRef.current
-    if (input) {
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value"
-      )?.set
-      nativeInputValueSetter?.call(input, "")
-      input.dispatchEvent(new Event("input", { bubbles: true }))
-      input.focus()
-    }
-  }
-
+>(({ className, ...props }, ref) => {
   return (
     <div
       className={cn(
-        "flex h-10 w-full items-center gap-x-2.5 rounded-[20px] border border-gray-200 bg-white px-[13px] py-2 text-sm ring-offset-background drop-shadow-[0_1px_2px_rgb(64,63,84,0.1)] transition duration-300 focus-within:ring-0 focus-within:ring-offset-0 focus-within:drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)] md:w-80",
+        "flex h-10 w-80 items-center gap-x-2.5 rounded-full border border-gray-200 bg-white px-[13px] py-2 text-sm ring-offset-background drop-shadow-[0_1px_2px_rgb(64,63,84,0.1)] transition duration-300 focus-within:ring-0 focus-within:ring-offset-0 focus-within:drop-shadow-[0_4px_4px_rgba(0,0,0,0.25)]",
         className
       )}
     >
@@ -40,27 +18,11 @@ const Search = React.forwardRef<
       <input
         {...props}
         placeholder="검색"
-        type="text"
-        ref={(node) => {
-          inputRef.current = node
-          if (typeof ref === "function") ref(node)
-          else if (ref) ref.current = node
-        }}
-        value={value}
-        onChange={handleChange}
+        type="search"
+        ref={ref}
         className="w-full placeholder:text-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         style={{ caretColor: "#111827" }}
       />
-      {value && (
-        <button
-          type="button"
-          onClick={handleClear}
-          className="flex-shrink-0 text-gray-400 hover:text-gray-600"
-          aria-label="검색어 지우기"
-        >
-          <XIcon size={16} strokeWidth={2} />
-        </button>
-      )}
     </div>
   )
 })

--- a/apps/web/components/TeamBadges/SessionBadge.tsx
+++ b/apps/web/components/TeamBadges/SessionBadge.tsx
@@ -10,7 +10,7 @@ const SessionBadge = ({ session, className }: SessionBadgeProps) => {
   return (
     <Badge
       className={cn(
-        "rounded bg-slate-200 hover:bg-slate-200 text-[13px] font-normal leading-none text-slate-700 text-nowrap px-2 select-none",
+        "h-6 rounded-[5px] bg-neutral-200 hover:bg-neutral-200 text-xs font-medium text-neutral-600 text-nowrap px-1.5 select-none",
         className
       )}
     >


### PR DESCRIPTION
## 요약
- **브레드크럼 드롭다운**: 3번째 브레드크럼 요소(공연 이름)를 드롭다운으로 변경하여 다른 공연으로 전환 가능
- **데스크톱 테이블 리디자인**: `border-separate` + `border-spacing-y`로 행 간격 구현, 헤더/본문 셀 라운딩, Figma 스펙에 맞는 행 드롭쉐도우 및 호버 효과, 비로그인 시 액션 컬럼 숨김
- **세션 뱃지**: Figma 스펙 반영 (neutral-200 배경, neutral-600 텍스트, 5px 라운딩, medium 굵기)
- **모바일 카드**: 라벨 변경(모집세션), 뱃지 flex-wrap, 쉐도우 카드 컨테이너 및 로그인 시 편집/삭제 액션 버튼 유지
- **모바일 페이지네이션**: 기존 `DataTablePagination` 컴포넌트 활용
- **데스크톱 필터 팝오버 리디자인**: Figma 기준 헤더(Filter/초기화/닫기), 섹션별 "모두 선택", 세로 레이아웃, 12px 라운딩, 480px 너비
- **모바일 필터 Drawer**: 체크박스 18px, 라벨 text-sm, 3컬럼 그리드로 가독성 개선
- **모집상태 정렬**: accessorFn 기반 모집중/모집완료 우선 정렬 추가
- **유튜브 링크 가드**: songYoutubeVideoUrl이 null일 때 아이콘/링크 미표시
- **캐시 무효화**: 팀 신청/탈퇴 시 팀 목록 캐시도 invalidate하여 상태 즉시 반영
- **검색창 그림자**: overflow-x 제한 제거로 drop-shadow 클리핑 해결
- **스켈레톤 업데이트**: 리디자인된 헤더/테이블에 맞춰 로딩 스켈레톤 수정

## 변경 파일
- `BreadCrumb.tsx` / `Default/index.tsx` — 브레드크럼 드롭다운 지원
- `table.tsx` — border-separate, border-spacing, overflow 수정
- `data-table.tsx` — nuqs 쿼리 동기화, 필터 팝오버 리디자인, 정렬 옵션 추가, overflow 제거
- `columns.tsx` — 모집상태 sortable 컬럼, 유튜브 링크 null 가드
- `Filter/Desktop.tsx` — 18px 체크박스, grid-cols-5, onSelectAll, sky-500 색상
- `Filter/Mobile.tsx` — 18px 체크박스, text-sm 라벨, grid-cols-3
- `filter.tsx` — onSelectAll prop 전달
- `drawer.tsx` — shouldScaleBackground=false
- `SessionBadge.tsx` — Figma 스펙 스타일링
- `TeamCard/index.tsx` — 라벨, 뱃지 래핑, 컨테이너 + 액션 복원
- `TeamListSkeleton.tsx` — 리디자인된 UI에 맞춰 스켈레톤 업데이트
- `useTeamApplication.ts` — 팀 신청 시 목록 캐시 invalidate
- `MemberSessionCard.tsx` — 팀 탈퇴 시 목록 캐시 invalidate
- `teams/page.tsx` — 브레드크럼 `dropdownItems` prop 추가

## 테스트 계획
- [ ] 데스크톱: 테이블 헤더 라운딩, 행 쉐도우/호버, 행 간격 확인
- [ ] 데스크톱: 브레드크럼 드롭다운으로 공연 전환 동작 확인
- [ ] 데스크톱: 비로그인 → 액션 컬럼 숨김, 로그인 → 액션 컬럼 표시
- [ ] 데스크톱: 필터 팝오버 — 초기화, 모두 선택, 닫기 동작 확인
- [ ] 데스크톱: 모집상태 정렬 (모집중/모집완료 우선) 동작 확인
- [ ] 모바일: 카드 쉐도우 컨테이너, 로그인 시 편집/삭제 버튼 확인
- [ ] 모바일: 필터 Drawer 체크박스/라벨 사이즈 확인
- [ ] 모바일: 검색창 focus 시 그림자 클리핑 없음 확인
- [ ] 모바일: 페이지네이션 정상 렌더링 및 페이지 이동 확인
- [ ] 팀 신청 후 목록 복귀 시 상태(Active/Inactive) 즉시 반영 확인
- [ ] 유튜브 링크 없는 팀에 Paperclip 아이콘 미표시 확인
- [ ] 세션 뱃지 Figma 스펙 일치 확인 (색상, 크기, 굵기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)