### PR TITLE
feat: redesign team detail page (desktop + mobile)

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
@@ -3,7 +3,10 @@ import FreshmenFixedBadge from "@/components/TeamBadges/FreshmenFixedBadge"
 import StatusBadge from "@/components/TeamBadges/StatusBadge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { isTeamSatisfied } from "@/lib/team/teamSession"
-import { getRepresentativeRelativeTime } from "@/lib/utils"
+import {
+  formatGenerationOrder,
+  getRepresentativeRelativeTime
+} from "@/lib/utils"
 import { TeamDetail } from "@repo/shared-types"
 
 interface BasicInfoProps {
@@ -15,16 +18,7 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
   const isSatisfied = isTeamSatisfied(team.teamSessions ?? [])
 
   return (
-    <div className="relative h-fit w-full rounded-2xl bg-white px-10 py-14 text-lg font-semibold shadow-md md:w-[466px] md:px-[40px] md:py-[60px]">
-      {/* 수정 및 삭제 버튼(데스크탑) */}
-      {canEdit && (
-        <DeleteEditButton
-          className="absolute right-[40px] top-[60px] hidden w-[92px]  md:flex"
-          performanceId={team.id}
-          team={team}
-        />
-      )}
-
+    <div className="relative h-fit w-full rounded-2xl bg-white px-[26px] py-[30px] text-lg font-semibold shadow-[0_4px_30px_0_rgba(59,130,246,0.07)] md:w-[466px] md:px-[40px] md:py-[60px]">
       {/* 신입고정 뱃지 */}
       {team.isFreshmenFixed && (
         <FreshmenFixedBadge
@@ -33,29 +27,38 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
         />
       )}
 
-      {/* 팀장 */}
-      <div className="mb-6 flex items-center justify-start gap-x-[8px] md:mb-[24px] md:gap-x-[10px]">
+      {/* 팀장 + 수정/삭제 */}
+      <div className="mb-3 flex items-center justify-start gap-x-[8px] md:mb-[24px] md:gap-x-[10px]">
         <Avatar className="h-[24px] w-[24px] md:h-[48px] md:w-[48px]">
           <AvatarImage src={team.leader?.image ?? undefined} />
           <AvatarFallback>{team.leader?.name.substring(0, 1)}</AvatarFallback>
         </Avatar>
         <div className="text-xs font-medium leading-3 text-primary md:text-base">
+          {team.leader.generation &&
+            `${formatGenerationOrder(team.leader.generation.order)}기 `}
           {team.leader.name}
         </div>
-        <div className=" text-xs font-light leading-3 text-gray-400 md:text-base md:font-normal">
+        <div className="text-xs font-light leading-3 text-gray-400 md:text-base md:font-normal">
           {getRepresentativeRelativeTime(team.createdAt)}
         </div>
+        {canEdit && (
+          <DeleteEditButton
+            className="hidden md:flex"
+            performanceId={team.performanceId}
+            team={team}
+          />
+        )}
       </div>
 
       {/* 곡 정보 */}
       <div className="space-y-0.5">
         <div className="flex items-center justify-between gap-x-[12px] md:gap-x-3">
-          <h3 className="h-fit items-baseline text-2xl font-extrabold md:text-3xl">
+          <h3 className="text-xl font-semibold leading-none text-slate-800 md:text-3xl">
             {team.songName}
           </h3>
           <StatusBadge
             status={isSatisfied ? "Inactive" : "Active"}
-            className="mb-1 h-5 w-20 justify-center max-sm:text-xs md:h-[32px] md:w-[130px]"
+            className="mb-1 h-5 shrink-0 justify-center max-sm:text-xs md:h-[32px] md:w-[130px]"
             dotClassName="text-xs"
           />
         </div>
@@ -65,9 +68,11 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
       </div>
 
       {/* 설명 */}
-      <p className="pt-[14px] text-base font-normal leading-snug tracking-wide text-slate-700 md:pt-[28px] md:leading-normal ">
-        {team.description}
-      </p>
+      {team.description && (
+        <p className="pt-[14px] text-base font-normal leading-snug tracking-wide text-slate-700 md:pt-[28px] md:leading-normal">
+          {team.description}
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
@@ -56,6 +56,7 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
           <StatusBadge
             status={isSatisfied ? "Inactive" : "Active"}
             className="mb-1 h-5 w-20 justify-center max-sm:text-xs md:h-[32px] md:w-[130px]"
+            dotClassName="text-xs"
           />
         </div>
         <h4 className="h-[34px] text-sm font-normal text-gray-500 md:text-2xl">

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo.tsx
@@ -43,7 +43,7 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
         </div>
         {canEdit && (
           <DeleteEditButton
-            className="hidden md:flex"
+            className="ml-auto hidden md:flex"
             performanceId={team.performanceId}
             team={team}
           />
@@ -53,7 +53,7 @@ const BasicInfo = ({ team, canEdit = false }: BasicInfoProps) => {
       {/* 곡 정보 */}
       <div className="space-y-0.5">
         <div className="flex items-center justify-between gap-x-[12px] md:gap-x-3">
-          <h3 className="text-xl font-semibold leading-none text-slate-800 md:text-3xl">
+          <h3 className="text-xl font-semibold leading-none text-slate-800 md:text-4xl">
             {team.songName}
           </h3>
           <StatusBadge

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/hooks/use-toast"
 import { useUnapplyFromTeam } from "@/hooks/api/useTeam"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { getSessionDisplayName } from "@/constants/session"
+import { formatGenerationOrder } from "@/lib/utils"
 import { SessionName } from "@repo/database"
 import { TeamDetail } from "@repo/shared-types"
 
@@ -67,17 +68,19 @@ const MemberSessionCard = ({
       <div className="relative flex h-[48px] w-[466px] items-center md:pl-4 ">
         {/* 아바타 */}
         <Avatar className="mr-[12px] md:mr-[24px]">
-          <AvatarImage src="https://github.com/shadcn.png" />
+          <AvatarImage src={user.image ?? undefined} />
           <AvatarFallback>{user.name?.substring(0, 1)}</AvatarFallback>
         </Avatar>
 
         {/* 설명 */}
         <div>
           <div className="mb-[8px] block text-sm font-semibold md:hidden md:text-lg">
-            {sessionName}
+            {getSessionDisplayName(sessionName)}
             {sessionIndex}
           </div>
           <div className="text-sm font-normal leading-3 text-slate-700 md:text-xl md:font-medium md:leading-relaxed">
+            {user.generation &&
+              `${formatGenerationOrder(user.generation.order)}기 `}
             {user.name}
           </div>
           <div className="hidden text-sm text-gray-400 md:block">

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -65,7 +65,7 @@ const MemberSessionCard = ({
       </div>
 
       {/* 유저 정보 */}
-      <div className="relative flex h-[48px] w-[466px] items-center md:pl-4 ">
+      <div className="relative flex h-[48px] w-full items-center md:w-[466px] md:pl-4">
         {/* 아바타 */}
         <Avatar className="mr-[12px] md:mr-[24px]">
           <AvatarImage src={user.image ?? undefined} />

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/PosterImage.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/PosterImage.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { ScanSearch } from "lucide-react"
+import Image from "next/image"
+import { useState } from "react"
+
+import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+interface PosterImageProps {
+  src: string
+}
+
+const PosterImage = ({ src }: PosterImageProps) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <div
+        className="group relative hidden aspect-[3/4] w-full cursor-pointer overflow-clip rounded-[20px] md:block"
+        onClick={() => setOpen(true)}
+      >
+        <Image
+          className="rounded-[20px] object-cover"
+          src={src}
+          alt="poster"
+          fill
+        />
+        <div className="absolute inset-0 bg-black/0 transition-colors group-hover:bg-black/30" />
+        <div className="absolute bottom-4 right-4 rounded-full bg-white/90 p-2.5 text-slate-800 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+          <ScanSearch size={20} />
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogPortal>
+          <DialogOverlay
+            className="cursor-pointer bg-black/90"
+            onClick={() => setOpen(false)}
+          />
+          <DialogPrimitive.Content
+            className="fixed inset-0 z-50 flex items-center justify-center p-8"
+            onClick={() => setOpen(false)}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            <DialogPrimitive.Title className="sr-only">
+              포스터 이미지
+            </DialogPrimitive.Title>
+            <div
+              className="relative h-full w-full max-w-3xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Image
+                src={src}
+                alt="poster fullscreen"
+                fill
+                className="object-contain"
+              />
+            </div>
+          </DialogPrimitive.Content>
+        </DialogPortal>
+      </Dialog>
+    </>
+  )
+}
+
+export default PosterImage

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard.tsx
@@ -20,7 +20,7 @@ const SessionSetCard = ({
         `rounded-xl border-s-8 border-s-blue-900 bg-white px-[32px] py-[30px] md:px-[68px] md:py-[56px]`
       )}
     >
-      <h5 className="select-none text-base font-bold leading-[18px] text-slate-700 md:text-2xl md:leading-normal">
+      <h5 className="select-none text-base font-bold leading-[18px] text-slate-700 md:text-[30px] md:leading-[36px]">
         {header}
       </h5>
       {children}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard.tsx
@@ -17,10 +17,10 @@ const SessionSetCard = ({
     <div
       className={cn(
         className,
-        `rounded-xl border-s-8 border-s-blue-900 bg-white px-[40px] py-[40px] md:px-[68px] md:py-[56px]`
+        `rounded-xl border-s-8 border-s-blue-900 bg-white px-[32px] py-[30px] md:px-[68px] md:py-[56px]`
       )}
     >
-      <h5 className="select-none text-base font-bold leading-[18px] text-slate-700  md:text-2xl md:leading-normal">
+      <h5 className="select-none text-base font-bold leading-[18px] text-slate-700 md:text-2xl md:leading-normal">
         {header}
       </h5>
       {children}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import { useSession } from "next-auth/react"
-import Image from "next/image"
 import { useParams, useRouter } from "next/navigation"
 
 import ApplyButton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/ApplyButton"
 import BasicInfo from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/BasicInfo"
 import DeleteEditButton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/DeleteEditButton"
 import MemberSessionCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard"
+import PosterImage from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/PosterImage"
 import SessionSetCard from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/SessionSetCard"
 import TeamDetailSkeleton from "@/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailSkeleton"
 import NotFoundPage from "@/app/_(errors)/NotFound"
@@ -51,7 +51,7 @@ const TeamDetail = () => {
   }
 
   return (
-    <div className="container flex w-full flex-col items-center px-0 pb-10 pt-2 md:pt-16">
+    <div className="container flex w-full flex-col items-center px-0 pb-10 pt-2 md:pt-6">
       {/* 기울어진 배경 - 슬레이트 */}
       <div
         className="absolute left-0 top-0 z-0 h-[283px] w-full bg-slate-300 md:h-[600px]"
@@ -68,7 +68,7 @@ const TeamDetail = () => {
       <OleoPageHeader
         title="Join Your Team"
         goBackHref={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
-        className="relative mb-1 md:mb-10"
+        className="relative mb-1 md:mb-10 md:mt-10"
       />
 
       {/* 유튜브 임베드 */}
@@ -92,16 +92,7 @@ const TeamDetail = () => {
         {/* 기본 정보 및 포스터*/}
         <div className="flex w-[93%] flex-col gap-y-5 md:w-[466px] md:shrink-0 md:gap-y-[24px]">
           <BasicInfo team={team} canEdit={canEdit} />
-          {team.posterImage && (
-            <div className="relative hidden aspect-[3/4] w-full overflow-clip rounded-lg md:block">
-              <Image
-                className="rounded-lg object-cover"
-                src={team.posterImage}
-                alt="poster"
-                fill
-              />
-            </div>
-          )}
+          {team.posterImage && <PosterImage src={team.posterImage} />}
         </div>
 
         {/* 세션 구성 */}
@@ -146,7 +137,7 @@ const TeamDetail = () => {
                 Member
               </div>
             </div>
-            <div className="mt-1 grid grid-cols-1 divide-y divide-slate-200 md:mt-0">
+            <div className="mt-1 grid grid-cols-1 divide-y divide-slate-200 md:mt-0 md:border-y md:border-slate-200">
               {team.teamSessions?.map((ts) =>
                 ts.members.map((member) => (
                   <MemberSessionCard

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { Separator } from "@radix-ui/react-separator"
-import { Maximize2 } from "lucide-react"
 import { useSession } from "next-auth/react"
 import Image from "next/image"
 import { useParams, useRouter } from "next/navigation"
@@ -53,7 +51,7 @@ const TeamDetail = () => {
   }
 
   return (
-    <div className="container flex w-full flex-col items-center px-0 pt-16">
+    <div className="container flex w-full flex-col items-center px-0 pb-10 pt-2 md:pt-16">
       {/* 기울어진 배경 - 슬레이트 */}
       <div
         className="absolute left-0 top-0 z-0 h-[283px] w-full bg-slate-300 md:h-[600px]"
@@ -70,7 +68,7 @@ const TeamDetail = () => {
       <OleoPageHeader
         title="Join Your Team"
         goBackHref={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
-        className="relative mb-10"
+        className="relative mb-1 md:mb-10"
       />
 
       {/* 유튜브 임베드 */}
@@ -90,9 +88,9 @@ const TeamDetail = () => {
         </div>
       )}
 
-      <div className="relative z-10 flex w-full gap-[24px] max-md:flex-col max-md:items-center md:flex md:w-[1152px]">
+      <div className="relative z-10 flex w-full gap-5 max-md:flex-col max-md:items-center md:flex md:w-[1152px] md:gap-[24px]">
         {/* 기본 정보 및 포스터*/}
-        <div className="flex w-full flex-col gap-y-[24px]">
+        <div className="flex w-[93%] flex-col gap-y-5 md:w-[466px] md:shrink-0 md:gap-y-[24px]">
           <BasicInfo team={team} canEdit={canEdit} />
           {team.posterImage && (
             <div className="relative hidden aspect-[3/4] w-full overflow-clip rounded-lg md:block">
@@ -112,9 +110,9 @@ const TeamDetail = () => {
           {team.teamSessions && team.teamSessions.length > 0 && (
             <SessionSetCard
               header="세션구성"
-              className="h-fit bg-white shadow-md"
+              className="h-fit bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
             >
-              <div className="flex flex-wrap gap-x-2 gap-y-2 pt-[20px] md:pt-[40px]">
+              <div className="mt-[20px] flex flex-wrap gap-x-2 gap-y-2 md:mt-[40px]">
                 {team.teamSessions.map((ts) => {
                   // capacity만큼의 슬롯을 모두 표시 (1부터 capacity까지)
                   return Array.from(
@@ -138,18 +136,17 @@ const TeamDetail = () => {
           {/* 마감된 세션 */}
           <SessionSetCard
             header="마감된 세션"
-            className="col-span-2 bg-white shadow-md"
+            className="col-span-2 bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
           >
-            <div className="grid grid-cols-1 divide-y divide-slate-200">
-              <div className="mt-4 hidden text-sm font-medium leading-normal text-slate-500 md:flex">
-                <div className="flex h-[48px] w-[160px] items-center pl-4">
-                  Session
-                </div>
-                <div className="flex h-[48px] w-[466px] items-center pl-4">
-                  Member
-                </div>
+            <div className="mt-1 hidden text-sm font-medium leading-normal text-slate-500 md:flex">
+              <div className="flex h-[48px] w-[160px] items-center pl-4">
+                Session
               </div>
-              <Separator className="hidden h-[1.5px] w-full bg-slate-200 md:block" />
+              <div className="flex h-[48px] w-[466px] items-center pl-4">
+                Member
+              </div>
+            </div>
+            <div className="mt-1 grid grid-cols-1 divide-y divide-slate-200 md:mt-0">
               {team.teamSessions?.map((ts) =>
                 ts.members.map((member) => (
                   <MemberSessionCard
@@ -179,16 +176,21 @@ const TeamDetail = () => {
                 <span className="hidden md:inline">세션 지원</span>
               </>
             }
-            className="col-span-2 bg-white shadow-md"
+            className="col-span-2 bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
           >
-            <ul className="mb-6 w-full pt-[12px] text-sm font-normal leading-6 text-gray-600 md:w-[537px] md:pt-[16px]">
+            <ul className="mb-6 mt-[12px] w-full text-sm font-normal leading-6 text-gray-600 md:mt-[16px] md:w-[537px]">
               <li className="mb-1 md:mb-[10px]">
                 ・아래 버튼을 눌러 해당 팀에 참여 신청을 할 수 있으며,
                 선착순으로 마감됩니다
               </li>
               <li>
-                ・아래 버튼을 다시 누르거나 마이페이지에 접속하여 신청을 취소할
-                수 있습니다
+                <span className="md:hidden">
+                  ・아래 버튼을 다시 누르거나 마이페이지에 접속하여 신청을
+                  취소할 수 있습니다
+                </span>
+                <span className="hidden md:inline">
+                  ・해당 페이지 혹은 마이페이지를 통해 신청을 취소할 수 있습니다
+                </span>
               </li>
             </ul>
 
@@ -219,7 +221,11 @@ const TeamDetail = () => {
 
             {/* 지원하기 버튼 (모바일) */}
             {selectedSessions.length > 0 && (
-              <Button className="mt-6 w-full md:hidden" onClick={onSubmit}>
+              <Button
+                shape="round"
+                className="mt-6 w-full md:hidden"
+                onClick={onSubmit}
+              >
                 지원하기
               </Button>
             )}
@@ -231,17 +237,25 @@ const TeamDetail = () => {
                 모든 세션이 마감되었습니다.
               </div>
             )}
-          </SessionSetCard>
 
-          {/* 지원하기 버튼 (데스크탑) - 카드 바깥, 우측 정렬 */}
-          {selectedSessions.length > 0 && (
-            <div className="hidden justify-end md:flex">
-              <Button variant="outline" className="gap-1" onClick={onSubmit}>
-                지원하기
-                <span aria-hidden="true">&gt;</span>
-              </Button>
-            </div>
-          )}
+            {/* 지원하기 버튼 (데스크탑) - 카드 안쪽 하단 우측 */}
+            {selectedSessions.length > 0 && (
+              <>
+                <div className="my-4 hidden h-px w-full bg-slate-200 md:block" />
+                <div className="hidden justify-end md:flex">
+                  <Button
+                    variant="outlinePrimary"
+                    shape="round"
+                    className="w-[120px] gap-2"
+                    onClick={onSubmit}
+                  >
+                    지원하기
+                    <span aria-hidden="true">&gt;</span>
+                  </Button>
+                </div>
+              </>
+            )}
+          </SessionSetCard>
         </div>
       </div>
     </div>

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -103,7 +103,7 @@ const TeamDetail = () => {
               header="세션구성"
               className="h-fit bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
             >
-              <div className="mt-[20px] flex flex-wrap gap-x-2 gap-y-2 md:mt-[40px]">
+              <div className="mt-[20px] flex flex-wrap gap-[10px] md:mt-[40px]">
                 {team.teamSessions.map((ts) => {
                   // capacity만큼의 슬롯을 모두 표시 (1부터 capacity까지)
                   return Array.from(
@@ -115,7 +115,7 @@ const TeamDetail = () => {
                       <SessionBadge
                         key={`${ts.session.id}-${index}`}
                         session={sessionWithIndex}
-                        className="h-[22px] w-[56px] justify-center rounded bg-slate-200 px-[5px] py-[6px] text-xs hover:bg-slate-300 md:h-[34px] md:w-[74px] md:rounded-[20px] md:text-base"
+                        className="justify-center rounded px-[6px] py-[2px] md:rounded-[20px] md:px-3 md:py-1.5 md:text-base"
                       />
                     )
                   })
@@ -169,7 +169,7 @@ const TeamDetail = () => {
             }
             className="col-span-2 bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
           >
-            <ul className="mb-6 mt-[12px] w-full text-sm font-normal leading-6 text-gray-600 md:mt-[16px] md:w-[537px]">
+            <ul className="mb-6 mt-[12px] w-full text-xs font-normal leading-5 text-gray-600 md:mt-[16px] md:w-[537px]">
               <li className="mb-1 md:mb-[10px]">
                 ・아래 버튼을 눌러 해당 팀에 참여 신청을 할 수 있으며,
                 선착순으로 마감됩니다

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -51,7 +51,7 @@ const TeamDetail = () => {
   }
 
   return (
-    <div className="container flex w-full flex-col items-center px-0 pb-10 pt-2 md:pt-6">
+    <div className="container flex w-full flex-col items-center px-0 pb-10 pt-2 md:pt-0">
       {/* 기울어진 배경 - 슬레이트 */}
       <div
         className="absolute left-0 top-0 z-0 h-[283px] w-full bg-slate-300 md:h-[600px]"
@@ -68,7 +68,7 @@ const TeamDetail = () => {
       <OleoPageHeader
         title="Join Your Team"
         goBackHref={ROUTES.PERFORMANCE.TEAM.LIST(performanceId)}
-        className="relative mb-1 md:mb-10 md:mt-10"
+        className="relative mb-1 md:mb-[78px] md:mt-[78px] md:w-[1152px]"
       />
 
       {/* 유튜브 임베드 */}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -173,7 +173,12 @@ const TeamDetail = () => {
 
           {/* 팀 참여 신청 */}
           <SessionSetCard
-            header="참여 신청"
+            header={
+              <>
+                <span className="md:hidden">참여 신청</span>
+                <span className="hidden md:inline">세션 지원</span>
+              </>
+            }
             className="col-span-2 bg-white shadow-md"
           >
             <ul className="mb-6 w-full pt-[12px] text-sm font-normal leading-6 text-gray-600 md:w-[537px] md:pt-[16px]">
@@ -212,9 +217,9 @@ const TeamDetail = () => {
               })}
             </div>
 
-            {/* 지원하기 버튼 */}
+            {/* 지원하기 버튼 (모바일) */}
             {selectedSessions.length > 0 && (
-              <Button className="mt-6 w-full" onClick={onSubmit}>
+              <Button className="mt-6 w-full md:hidden" onClick={onSubmit}>
                 지원하기
               </Button>
             )}
@@ -227,6 +232,16 @@ const TeamDetail = () => {
               </div>
             )}
           </SessionSetCard>
+
+          {/* 지원하기 버튼 (데스크탑) - 카드 바깥, 우측 정렬 */}
+          {selectedSessions.length > 0 && (
+            <div className="hidden justify-end md:flex">
+              <Button variant="outline" className="gap-1" onClick={onSubmit}>
+                지원하기
+                <span aria-hidden="true">&gt;</span>
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -85,12 +85,12 @@ const TeamDetail = () => {
 
       {/*수정 및 삭제 (모바일)*/}
       {canEdit && (
-        <div className="block h-auto w-[93%] justify-items-end pb-5  md:hidden  min-[878px]:w-11/12 lg:w-5/6">
+        <div className="relative z-10 block h-auto w-[93%] justify-items-end pb-5  md:hidden  min-[878px]:w-11/12 lg:w-5/6">
           <DeleteEditButton performanceId={performanceId} team={team} />
         </div>
       )}
 
-      <div className="flex w-full gap-[24px] max-md:flex-col max-md:items-center md:flex md:w-[1152px]">
+      <div className="relative z-10 flex w-full gap-[24px] max-md:flex-col max-md:items-center md:flex md:w-[1152px]">
         {/* 기본 정보 및 포스터*/}
         <div className="flex w-full flex-col gap-y-[24px]">
           <BasicInfo team={team} canEdit={canEdit} />
@@ -140,7 +140,7 @@ const TeamDetail = () => {
             header="마감된 세션"
             className="col-span-2 bg-white shadow-md"
           >
-            <div className="grid grid-cols-1">
+            <div className="grid grid-cols-1 divide-y divide-slate-200">
               <div className="mt-4 hidden text-sm font-medium leading-normal text-slate-500 md:flex">
                 <div className="flex h-[48px] w-[160px] items-center pl-4">
                   Session
@@ -176,7 +176,7 @@ const TeamDetail = () => {
             header="세션 지원"
             className="col-span-2 bg-white shadow-md"
           >
-            <ul className="mb-6 w-full pt-[12px] text-xs font-normal leading-normal text-gray-600 md:w-[537px] md:pt-[16px]">
+            <ul className="mb-6 w-full pt-[12px] text-sm font-normal leading-6 text-gray-600 md:w-[537px] md:pt-[16px]">
               <li className="mb-1 md:mb-[10px]">
                 ・아래 버튼을 눌러 해당 팀에 참여 신청을 할 수 있으며,
                 선착순으로 마감됩니다
@@ -214,7 +214,7 @@ const TeamDetail = () => {
 
             {/* 지원하기 버튼 */}
             {selectedSessions.length > 0 && (
-              <Button className="mt-6 w-full" onClick={onSubmit}>
+              <Button variant="outline" className="mt-6 w-full" onClick={onSubmit}>
                 선택한 세션에 지원하기 ({selectedSessions.length}개)
               </Button>
             )}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -173,7 +173,7 @@ const TeamDetail = () => {
 
           {/* 팀 참여 신청 */}
           <SessionSetCard
-            header="세션 지원"
+            header="참여 신청"
             className="col-span-2 bg-white shadow-md"
           >
             <ul className="mb-6 w-full pt-[12px] text-sm font-normal leading-6 text-gray-600 md:w-[537px] md:pt-[16px]">
@@ -214,8 +214,8 @@ const TeamDetail = () => {
 
             {/* 지원하기 버튼 */}
             {selectedSessions.length > 0 && (
-              <Button variant="outline" className="mt-6 w-full" onClick={onSubmit}>
-                선택한 세션에 지원하기 ({selectedSessions.length}개)
+              <Button className="mt-6 w-full" onClick={onSubmit}>
+                지원하기
               </Button>
             )}
 

--- a/apps/web/components/PageHeaders/OleoPageHeader.tsx
+++ b/apps/web/components/PageHeaders/OleoPageHeader.tsx
@@ -22,7 +22,7 @@ const OleoPageHeader = ({
   return (
     <div
       className={cn(
-        "my-2.5 flex h-[70px] w-full items-end justify-center md:mb-[54px] md:mt-[100px] md:items-center md:justify-between",
+        "flex h-auto w-full items-center justify-center md:mb-[54px] md:mt-[100px] md:h-[70px] md:items-center md:justify-between",
         className
       )}
     >

--- a/apps/web/components/TeamBadges/SessionBadge.tsx
+++ b/apps/web/components/TeamBadges/SessionBadge.tsx
@@ -10,7 +10,7 @@ const SessionBadge = ({ session, className }: SessionBadgeProps) => {
   return (
     <Badge
       className={cn(
-        "h-5 rounded bg-slate-200 hover:bg-slate-200 text-xs font-normal text-neutral-600 text-nowrap px-2 select-none",
+        "rounded bg-slate-200 hover:bg-slate-200 text-[13px] font-normal leading-none text-slate-700 text-nowrap px-2 select-none",
         className
       )}
     >

--- a/apps/web/components/TeamBadges/StatusBadge.tsx
+++ b/apps/web/components/TeamBadges/StatusBadge.tsx
@@ -24,7 +24,7 @@ const StatusBadge = ({
         status === "Inactive"
           ? "bg-red-100 text-destructive"
           : "bg-green-100 text-green-600",
-        "text-md whitespace-nowrap rounded-full border-none px-4 py-0.5 lg:py-1 font-semibold",
+        "whitespace-nowrap rounded-full border-none px-4 py-0.5 text-[10px] font-semibold leading-none tracking-[0.05em] lg:py-1",
         className
       )}
     >

--- a/apps/web/components/TeamBadges/StatusBadge.tsx
+++ b/apps/web/components/TeamBadges/StatusBadge.tsx
@@ -4,9 +4,19 @@ import { cn } from "@/lib/utils"
 interface StatusBadgeProps {
   status: "Inactive" | "Active"
   className?: string
+  dotClassName?: string
 }
 
-const StatusBadge = ({ status, className }: StatusBadgeProps) => {
+const STATUS_LABEL: Record<StatusBadgeProps["status"], string> = {
+  Active: "모집중",
+  Inactive: "마감",
+}
+
+const StatusBadge = ({
+  status,
+  className,
+  dotClassName = "text-[0.5rem]",
+}: StatusBadgeProps) => {
   return (
     <Badge
       variant="outline"
@@ -18,8 +28,8 @@ const StatusBadge = ({ status, className }: StatusBadgeProps) => {
         className
       )}
     >
-      <span className="me-2 text-[0.5rem]">●</span>
-      {status}
+      <span className={cn("me-2", dotClassName)}>●</span>
+      {STATUS_LABEL[status]}
     </Badge>
   )
 }

--- a/apps/web/components/TeamBadges/StatusBadge.tsx
+++ b/apps/web/components/TeamBadges/StatusBadge.tsx
@@ -8,14 +8,14 @@ interface StatusBadgeProps {
 }
 
 const STATUS_LABEL: Record<StatusBadgeProps["status"], string> = {
-  Active: "모집중",
-  Inactive: "마감",
+  Active: "Active",
+  Inactive: "Closed"
 }
 
 const StatusBadge = ({
   status,
   className,
-  dotClassName = "text-[0.5rem]",
+  dotClassName = "text-[0.5rem]"
 }: StatusBadgeProps) => {
   return (
     <Badge
@@ -24,7 +24,7 @@ const StatusBadge = ({
         status === "Inactive"
           ? "bg-red-100 text-destructive"
           : "bg-green-100 text-green-600",
-        "text-md rounded-full border-none px-4 py-0.5 lg:py-1 font-semibold",
+        "text-md whitespace-nowrap rounded-full border-none px-4 py-0.5 lg:py-1 font-semibold",
         className
       )}
     >

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -14,37 +14,48 @@ const buttonVariants = cva(
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        outlinePrimary:
+          "border-2 border-primary bg-background text-primary font-bold hover:bg-primary/5",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline"
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "h-10 px-4 py-2 text-base",
+        xs: "h-[34px] px-2 py-1 text-xs",
+        sm: "h-9 px-3 text-sm",
+        lg: "h-11 px-4 py-2.5 text-base",
+        xl: "h-[52px] px-5 py-3 text-lg",
+        "2xl": "h-14 px-6 py-3.5 text-xl",
         icon: "h-10 w-10"
+      },
+      shape: {
+        default: "rounded-md",
+        round: "rounded-full"
       }
     },
     defaultVariants: {
       variant: "default",
-      size: "default"
+      size: "default",
+      shape: "default"
     }
   }
 )
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, shape, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size, shape, className }))}
         ref={ref}
         {...props}
       />

--- a/apps/web/lib/youtube/Player.tsx
+++ b/apps/web/lib/youtube/Player.tsx
@@ -13,6 +13,7 @@ const YoutubePlayer: React.FC<YoutubePlayerProps> = ({
   return (
     <iframe
       src={`https://www.youtube.com/embed/${YoutubeVideo.getValidVideoIdOrNull(videoUrl)}`}
+      allowFullScreen
       {...iframeProps}
     />
   )


### PR DESCRIPTION
## Summary
- 팀 상세 페이지 모바일/데스크탑 피그마 디자인 1:1 반영
- Button 컴포넌트에 `shape` axis, `outlinePrimary` variant, 피그마 사이즈 시스템 추가
- 포스터 이미지 호버 시 크게보기 아이콘 + 클릭 시 전체화면 뷰어 (ESC/외부 클릭으로 닫기)
- YouTube iframe `allowFullScreen` 속성 추가
- StatusBadge/SessionBadge 피그마 텍스트 스펙 반영
- 카드 그림자, 패딩, 간격, 타이틀 텍스트 스타일 피그마 스펙 일치
- Join Your Team 헤더 상하 78px 균일 여백, 뒤로가기 버튼 정렬

## Test plan
- [ ] 모바일(430px) 레이아웃 확인 - 카드 간격, 뱃지, 버튼 스타일
- [ ] 데스크탑(1440px) 레이아웃 확인 - 테이블 테두리, 카드 타이틀, 곡 제목 크기
- [ ] 포스터 호버 → 크게보기 아이콘 표시 → 클릭 시 전체화면 → ESC/외부 클릭으로 닫기
- [ ] YouTube 전체화면 재생 동작 확인
- [ ] 지원하기 버튼 모바일(full-width round) / 데스크탑(outlinePrimary round) 확인
- [ ] 수정/삭제 버튼 우측 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)