### PR TITLE
feat(api) - add User-related API for Admin User

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common"
 import { ConfigService } from "@nestjs/config"
-import { JwtService, JwtSignOptions } from "@nestjs/jwt"
+import { JwtService } from "@nestjs/jwt"
 import { AuthError, ForbiddenError } from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
 import * as bcrypt from "bcrypt"
@@ -24,9 +24,7 @@ export class AuthService {
       user.isAdmin
     )
     await this.usersService.updateRefreshToken(user.id, tokens.refreshToken)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { hashedRefreshToken, ...userResponse } = user
-    return { ...tokens, user: userResponse }
+    return { ...tokens, user }
   }
 
   async login(loginDto: LoginUserDto) {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
     await this.usersService.updateRefreshToken(user.id, tokens.refreshToken)
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { password, hashedRefreshToken, ...userResponse } = user
+    const { password, ...userResponse } = user
     return { ...tokens, user: userResponse }
   }
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -68,26 +68,31 @@ export class AuthService {
       name,
       isAdmin
     }
-    const accessTokenExpiresIn = this.configService.get<string>(
-      "ACCESS_TOKEN_EXPIRES_IN"
-    )!
+
+    const accessTokenExpiresIn = parseInt(
+      this.configService.get<string>("ACCESS_TOKEN_EXPIRES_IN")!,
+      10
+    )
+    const refreshTokenExpiresIn = parseInt(
+      this.configService.get<string>("REFRESH_TOKEN_EXPIRES_IN")!,
+      10
+    )
+
     const [accessToken, refreshToken] = await Promise.all([
       this.jwtService.signAsync(jwtPayload, {
         secret: this.configService.get<string>("ACCESS_TOKEN_SECRET"),
-        expiresIn: accessTokenExpiresIn as JwtSignOptions["expiresIn"]
+        expiresIn: accessTokenExpiresIn
       }),
       this.jwtService.signAsync(jwtPayload, {
         secret: this.configService.get<string>("REFRESH_TOKEN_SECRET"),
-        expiresIn: this.configService.get<string>(
-          "REFRESH_TOKEN_EXPIRES_IN"
-        ) as JwtSignOptions["expiresIn"]
+        expiresIn: refreshTokenExpiresIn
       })
     ])
 
     return {
       accessToken,
       refreshToken,
-      expiresIn: parseInt(accessTokenExpiresIn)
+      expiresIn: accessTokenExpiresIn
     }
   }
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -68,11 +68,11 @@ export class AuthService {
     }
 
     const accessTokenExpiresIn = parseInt(
-      this.configService.get<string>("ACCESS_TOKEN_EXPIRES_IN")!,
+      this.configService.get<string>("ACCESS_TOKEN_EXPIRES_IN_SECONDS")!,
       10
     )
     const refreshTokenExpiresIn = parseInt(
-      this.configService.get<string>("REFRESH_TOKEN_EXPIRES_IN")!,
+      this.configService.get<string>("REFRESH_TOKEN_EXPIRES_IN_SECONDS")!,
       10
     )
 

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { createZodDto } from "nestjs-zod"
+import { UpdateUserSchema } from "@repo/shared-types"
+
+export class UpdateUserDto extends createZodDto(UpdateUserSchema) {}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get, UseGuards } from "@nestjs/common"
+import { Controller, Get, Post, Body, UseGuards } from "@nestjs/common"
 import { AccessTokenGuard } from "../auth/guards/access-token.guard"
 import { UsersService } from "./users.service"
+import { Public } from "../auth/decorators/public.decorator"
+import { AdminGuard } from "src/auth/guards/admin.guard"
+import { CreateUserDto } from "../users/dto/create-user.dto"
 
 @Controller("users")
 @UseGuards(AccessTokenGuard)
@@ -8,7 +11,14 @@ export class UsersController {
   constructor(private readonly userService: UsersService) {}
 
   @Get()
+  @Public()
   findAll() {
     return this.userService.findAll()
+  }
+
+  @Post()
+  @UseGuards(AdminGuard)
+  async create(@Body() createUserDto: CreateUserDto) {
+    return this.userService.create(createUserDto)
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -12,7 +12,7 @@ import {
 import { AccessTokenGuard } from "../auth/guards/access-token.guard"
 import { UsersService } from "./users.service"
 import { Public } from "../auth/decorators/public.decorator"
-import { AdminGuard } from "src/auth/guards/admin.guard"
+import { AdminGuard } from "../auth/guards/admin.guard"
 import { CreateUserDto } from "./dto/create-user.dto"
 import { UpdateUserDto } from "./dto/update-user.dto"
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -26,6 +26,12 @@ export class UsersController {
     return this.userService.findAll()
   }
 
+  @Get(":id")
+  @Public()
+  async findOne(@Param("id", ParseIntPipe) id: number) {
+    return this.userService.findOne(id)
+  }
+
   @Post()
   @UseGuards(AdminGuard)
   async create(@Body() createUserDto: CreateUserDto) {

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -6,7 +6,8 @@ import {
   Body,
   UseGuards,
   Param,
-  ParseIntPipe
+  ParseIntPipe,
+  Delete
 } from "@nestjs/common"
 import { AccessTokenGuard } from "../auth/guards/access-token.guard"
 import { UsersService } from "./users.service"
@@ -45,5 +46,11 @@ export class UsersController {
     @Body() updateUserDto: UpdateUserDto
   ) {
     return this.userService.updateUser(id, updateUserDto)
+  }
+
+  @Delete(":id")
+  @UseGuards(AdminGuard)
+  async deleteUser(@Param("id", ParseIntPipe) id: number) {
+    return this.userService.deleteUser(id)
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get, Post, Body, UseGuards } from "@nestjs/common"
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  UseGuards,
+  Param,
+  ParseIntPipe
+} from "@nestjs/common"
 import { AccessTokenGuard } from "../auth/guards/access-token.guard"
 import { UsersService } from "./users.service"
 import { Public } from "../auth/decorators/public.decorator"
 import { AdminGuard } from "src/auth/guards/admin.guard"
-import { CreateUserDto } from "../users/dto/create-user.dto"
+import { CreateUserDto } from "./dto/create-user.dto"
+import { UpdateUserDto } from "./dto/update-user.dto"
 
 @Controller("users")
 @UseGuards(AccessTokenGuard)
@@ -20,5 +30,14 @@ export class UsersController {
   @UseGuards(AdminGuard)
   async create(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(createUserDto)
+  }
+
+  @Patch(":id")
+  @UseGuards(AdminGuard)
+  async update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() updateUserDto: UpdateUserDto
+  ) {
+    return this.userService.updateUser(id, updateUserDto)
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -27,6 +27,12 @@ export class UsersController {
     return this.userService.findAll()
   }
 
+  @Get("admin")
+  @UseGuards(AdminGuard)
+  findAllForAdmin() {
+    return this.userService.findAllForAdmin()
+  }
+
   @Get(":id")
   @Public()
   async findOne(@Param("id", ParseIntPipe) id: number) {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -126,6 +126,23 @@ export class UsersService {
     }
   }
 
+  async deleteUser(userId: number) {
+    try {
+      await this.prisma.user.delete({ where: { id: userId } })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === "P2025")
+          throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)
+
+        if (error.code === "P2003")
+          throw new ConflictError(
+            "팀의 리더를 맡고 있는 사용자는 삭제할 수 없습니다. 먼저 팀 리더를 변경해주세요."
+          )
+      }
+      throw error
+    }
+  }
+
   async findOneByEmail(email: string) {
     return this.prisma.user.findUnique({ where: { email } })
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -147,7 +147,13 @@ export class UsersService {
   }
 
   async findOneByEmail(email: string) {
-    return this.prisma.user.findUnique({ where: { email } })
+    return this.prisma.user.findUnique({
+      where: { email },
+      select: {
+        ...publicUserSelector,
+        password: true
+      }
+    })
   }
 
   async findOneById(id: number) {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -133,10 +133,14 @@ export class UsersService {
         if (error.code === "P2025")
           throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)
 
-        if (error.code === "P2003")
-          throw new ConflictError(
-            "팀의 리더를 맡고 있는 사용자는 삭제할 수 없습니다. 먼저 팀 리더를 변경해주세요."
-          )
+        if (error.code === "P2003") {
+          const constraint = error.meta?.constraint as string
+
+          if (constraint === "teams_leaderId_fkey")
+            throw new ConflictError(
+              "팀의 리더를 맡고 있는 사용자는 삭제할 수 없습니다. 먼저 팀 리더를 변경해주세요."
+            )
+        }
       }
       throw error
     }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from "@nestjs/common"
-import { ConflictError } from "@repo/api-client"
+import { ConflictError, NotFoundError } from "@repo/api-client"
 import { Prisma } from "@repo/database"
 import * as bcrypt from "bcrypt"
 import { PrismaService } from "../prisma/prisma.service"
 import { CreateUserDto } from "./dto/create-user.dto"
 import { publicUserSelector } from "@repo/shared-types"
+import { UpdateUserDto } from "./dto/update-user.dto"
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
@@ -61,6 +62,55 @@ export class UsersService {
       where: { id: userId },
       data: { hashedRefreshToken: hashedRefreshToken }
     })
+  }
+
+  async updateUser(userId: number, updateUserDto: UpdateUserDto) {
+    const userExists = await this.prisma.user.count({
+      where: { id: userId }
+    })
+
+    if (!userExists)
+      throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)
+
+    const {
+      sessions: sessionIds,
+      generationId,
+      password,
+      ...restOfDto
+    } = updateUserDto
+
+    const updateData: Prisma.UserUpdateInput = {
+      ...restOfDto
+    }
+
+    if (password) updateData.password = await bcrypt.hash(password, 10)
+
+    if (generationId) updateData.generation = { connect: { id: generationId } }
+
+    if (sessionIds !== undefined)
+      updateData.sessions = { set: sessionIds.map((id) => ({ id })) }
+
+    try {
+      await this.prisma.user.update({
+        where: {
+          id: userId
+        },
+        data: updateData
+      })
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        const target = (error.meta?.target as string[]) || []
+        if (target.includes("email"))
+          throw new ConflictError("이미 사용중인 이메일입니다.")
+        if (target.includes("nickname"))
+          throw new ConflictError("이미 사용중인 닉네임입니다.")
+      }
+
+      throw error
+    }
   }
 
   async findOneByEmail(email: string) {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -25,12 +25,11 @@ export class UsersService {
           sessions: {
             connect: sessionIds.map((id) => ({ id }))
           }
-        }
+        },
+        select: publicUserSelector
       })
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { password, ...result } = user
-      return result
+      return user
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -4,7 +4,7 @@ import { Prisma } from "@repo/database"
 import * as bcrypt from "bcrypt"
 import { PrismaService } from "../prisma/prisma.service"
 import { CreateUserDto } from "./dto/create-user.dto"
-import { publicUserSelector } from "@repo/shared-types"
+import { publicUserSelector, userForAdminSelector } from "@repo/shared-types"
 import { UpdateUserDto } from "./dto/update-user.dto"
 @Injectable()
 export class UsersService {
@@ -26,7 +26,7 @@ export class UsersService {
             connect: sessionIds.map((id) => ({ id }))
           }
         },
-        select: publicUserSelector
+        select: userForAdminSelector
       })
 
       return user
@@ -150,7 +150,7 @@ export class UsersService {
     return this.prisma.user.findUnique({
       where: { email },
       select: {
-        ...publicUserSelector,
+        ...userForAdminSelector,
         password: true
       }
     })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -53,6 +53,12 @@ export class UsersService {
     return users
   }
 
+  async findAllForAdmin() {
+    return this.prisma.user.findMany({
+      select: detailedUserSelector
+    })
+  }
+
   async findOne(userId: number) {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -54,6 +54,18 @@ export class UsersService {
     return users
   }
 
+  async findOne(userId: number) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: publicUserSelector
+    })
+
+    if (!user)
+      throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)
+
+    return user
+  }
+
   async updateRefreshToken(userId: number, refreshToken: string | null) {
     const hashedRefreshToken = refreshToken
       ? await bcrypt.hash(refreshToken, 10)
@@ -91,11 +103,12 @@ export class UsersService {
       updateData.sessions = { set: sessionIds.map((id) => ({ id })) }
 
     try {
-      await this.prisma.user.update({
+      return await this.prisma.user.update({
         where: {
           id: userId
         },
-        data: updateData
+        data: updateData,
+        select: publicUserSelector
       })
     } catch (error) {
       if (

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -4,7 +4,7 @@ import { Prisma } from "@repo/database"
 import * as bcrypt from "bcrypt"
 import { PrismaService } from "../prisma/prisma.service"
 import { CreateUserDto } from "./dto/create-user.dto"
-import { publicUserSelector, userForAdminSelector } from "@repo/shared-types"
+import { publicUserSelector, detailedUserSelector } from "@repo/shared-types"
 import { UpdateUserDto } from "./dto/update-user.dto"
 @Injectable()
 export class UsersService {
@@ -26,7 +26,7 @@ export class UsersService {
             connect: sessionIds.map((id) => ({ id }))
           }
         },
-        select: userForAdminSelector
+        select: detailedUserSelector
       })
 
       return user
@@ -150,7 +150,7 @@ export class UsersService {
     return this.prisma.user.findUnique({
       where: { email },
       select: {
-        ...userForAdminSelector,
+        ...detailedUserSelector,
         password: true
       }
     })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -113,7 +113,7 @@ export class UsersService {
           id: userId
         },
         data: updateData,
-        select: publicUserSelector
+        select: detailedUserSelector
       })
     } catch (error) {
       if (

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -807,6 +807,7 @@ export default class ApiClient {
    * 유저 생성 (관리자용 API)
    * @throws {ValidationError} 입력값이 올바르지 않은 경우
    * @throws {ForbiddenError} 유저 생성 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
+   * @throws {ConflictError} 이미 사용중인 이메일, 닉네임을 입력했을 때 발생합니다.
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public createUser() {
@@ -814,6 +815,40 @@ export default class ApiClient {
       publicUser,
       ValidationError | ForbiddenError | InternalServerError
     >(`/users`, "POST")
+  }
+
+  /**
+   * 유저 업데이트 (관리자용 API)
+   * @throws {ValidationError} 입력값이 올바르지 않은 경우
+   * @throws {ForbiddenError} 유저 수정 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
+   * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
+   * @throws {ConflictError} 이미 사용중인 이메일, 닉네임을 입력했을 때 발생합니다.
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public updateUser(id: number) {
+    return this._request<
+      publicUser,
+      ValidationError | ForbiddenError | InternalServerError
+    >(`/users/${id}`, "PATCH")
+  }
+
+  /**
+   * 유저 삭제 (관리자용 API)
+   * @throws {ValidationError} 입력값이 올바르지 않은 경우
+   * @throws {ForbiddenError} 유저 수정 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
+   * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
+   * @throws {ConflictError} 팀에서 리더를 맡고 있는 사용자를 삭제하려고 할 때 발생합니다.
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public deleteUser(id: number) {
+    return this._request<
+      null,
+      | ValidationError
+      | ForbiddenError
+      | NotFoundError
+      | ConflictError
+      | InternalServerError
+    >(`/users/${id}`, "DELETE")
   }
 
   /**

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -7,6 +7,8 @@ import {
   CreateSession,
   CreateTeam,
   CreateUser,
+  DetailedUser,
+  DetailedUserList,
   Equipment,
   EquipmentWithRentalLog,
   GenerationDetail,
@@ -793,6 +795,18 @@ export default class ApiClient {
   }
 
   /**
+   * 유저 목록 조회 (기존 유저 목록 조회 API 보다 상세한 정보를 포함하여 반환합니다.)
+   * @throws {ForbiddenError} 전체 유저 확인 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public getUsersForAdmin() {
+    return this._request<DetailedUserList, InternalServerError>(
+      `/users/admin`,
+      "GET"
+    )
+  }
+
+  /**
    * 특정 유저 조회
    * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
    * @throws {InternalServerError} 서버 오류 발생 시
@@ -813,7 +827,7 @@ export default class ApiClient {
    */
   public createUser(userData: CreateUser) {
     return this._request<
-      publicUser,
+      DetailedUser,
       ValidationError | ForbiddenError | InternalServerError
     >(`/users`, "POST", userData)
   }
@@ -828,7 +842,7 @@ export default class ApiClient {
    */
   public updateUser(id: number, userData: UpdateUser) {
     return this._request<
-      publicUser,
+      DetailedUser,
       ValidationError | ForbiddenError | InternalServerError
     >(`/users/${id}`, "PATCH", userData)
   }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -31,6 +31,7 @@ import {
   RentalList,
   UpdateSession,
   UpdateTeam,
+  publicUser,
   publicUserList,
   PresignedUrlRequest,
   PresignedUrlResponse
@@ -784,14 +785,35 @@ export default class ApiClient {
 
   /**
    * 유저 목록 조회
-   * @throws {AuthError} 로그인 하지 않은 경우
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public getUsers() {
+    return this._request<publicUserList, InternalServerError>(`/users`, "GET")
+  }
+
+  /**
+   * 특정 유저 조회
+   * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public getUserById(id: number) {
+    return this._request<publicUser, NotFoundError | InternalServerError>(
+      `/users/${id}`,
+      "GET"
+    )
+  }
+
+  /**
+   * 유저 생성 (관리자용 API)
+   * @throws {ValidationError} 입력값이 올바르지 않은 경우
+   * @throws {ForbiddenError} 유저 생성 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public createUser() {
     return this._request<
-      publicUserList,
-      AuthError | ForbiddenError | InternalServerError
-    >(`/users`, "GET")
+      publicUser,
+      ValidationError | ForbiddenError | InternalServerError
+    >(`/users`, "POST")
   }
 
   /**

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -27,6 +27,7 @@ import {
   UpdateGeneration,
   UpdatePerformance,
   UpdateRental,
+  UpdateUser,
   RentalDetail,
   RentalList,
   UpdateSession,
@@ -810,11 +811,11 @@ export default class ApiClient {
    * @throws {ConflictError} 이미 사용중인 이메일, 닉네임을 입력했을 때 발생합니다.
    * @throws {InternalServerError} 서버 오류 발생 시
    */
-  public createUser() {
+  public createUser(userData: CreateUser) {
     return this._request<
       publicUser,
       ValidationError | ForbiddenError | InternalServerError
-    >(`/users`, "POST")
+    >(`/users`, "POST", userData)
   }
 
   /**
@@ -825,11 +826,11 @@ export default class ApiClient {
    * @throws {ConflictError} 이미 사용중인 이메일, 닉네임을 입력했을 때 발생합니다.
    * @throws {InternalServerError} 서버 오류 발생 시
    */
-  public updateUser(id: number) {
+  public updateUser(id: number, userData: UpdateUser) {
     return this._request<
       publicUser,
       ValidationError | ForbiddenError | InternalServerError
-    >(`/users/${id}`, "PATCH")
+    >(`/users/${id}`, "PATCH", userData)
   }
 
   /**

--- a/packages/database/prisma/seeds/03-user.seed.ts
+++ b/packages/database/prisma/seeds/03-user.seed.ts
@@ -32,6 +32,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
     const email = `admin${userNumber}@g.skku.edu`
     const generation = getRandomItem(generations)
     const session = getRandomItem(sessions)
+    const image = `https://api.dicebear.com/9.x/notionists/svg?seed=${encodeURIComponent(email)}`
 
     return prisma.user.create({
       data: {
@@ -40,6 +41,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
         name: nickname,
         nickname: nickname,
         bio: `안녕하세요. 아망 ${generation.order / 2}기 ${nickname}입니다.`,
+        image,
         isAdmin: true,
         generation: {
           connect: {
@@ -66,6 +68,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
     const email = `user${userNumber}@g.skku.edu`
     const generation = getRandomItem(generations)
     const session = getRandomItem(sessions)
+    const image = `https://api.dicebear.com/9.x/notionists/svg?seed=${encodeURIComponent(email)}`
 
     return prisma.user.create({
       data: {
@@ -74,6 +77,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
         name: nickname,
         nickname: nickname,
         bio: `안녕하세요. 아망 ${generation.order / 2}기 ${nickname}입니다.`,
+        image,
         isAdmin: false,
         generation: {
           connect: {

--- a/packages/shared-types/src/auth/auth.types.ts
+++ b/packages/shared-types/src/auth/auth.types.ts
@@ -1,4 +1,4 @@
-import { publicUser } from "../user/user.types"
+import { DetailedUser } from "../user/user.types"
 
 /**
  * 인증 응답(RFC 6749 기준)
@@ -9,7 +9,7 @@ export type AuthResponse = {
   accessToken: string
   refreshToken: string
   expiresIn: number
-  user: publicUser // 비표준, 편의를 위해 추가된 필드
+  user: DetailedUser // 비표준, 편의를 위해 추가된 필드
 }
 
 export type RefreshTokenResponse = {

--- a/packages/shared-types/src/auth/auth.types.ts
+++ b/packages/shared-types/src/auth/auth.types.ts
@@ -1,6 +1,4 @@
-import { User } from "@repo/database"
-
-type AuthUser = Omit<User, "password" | "hashedRefreshToken">
+import { publicUser } from "../user/user.types"
 
 /**
  * 인증 응답(RFC 6749 기준)
@@ -11,7 +9,7 @@ export type AuthResponse = {
   accessToken: string
   refreshToken: string
   expiresIn: number
-  user: AuthUser // 비표준, 편의를 위해 추가된 필드
+  user: publicUser // 비표준, 편의를 위해 추가된 필드
 }
 
 export type RefreshTokenResponse = {

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -29,7 +29,7 @@ export type publicUser = Prisma.UserGetPayload<{
 }>
 export type publicUserList = publicUser[]
 
-export type userForAdmin = Prisma.UserGetPayload<{
+export type UserForAdmin = Prisma.UserGetPayload<{
   select: typeof userForAdminSelector
 }>
-export type userListForAdmin = userForAdmin[]
+export type UserListForAdmin = UserForAdmin[]

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -18,8 +18,18 @@ export const publicUserSelector = {
   }
 } satisfies Prisma.UserSelect
 
+export const fullUserSelector = {
+  ...publicUserSelector,
+  isAdmin: true,
+  email: true
+} satisfies Prisma.UserSelect
+
 export type publicUser = Prisma.UserGetPayload<{
   select: typeof publicUserSelector
 }>
-
 export type publicUserList = publicUser[]
+
+export type fullUser = Prisma.UserGetPayload<{
+  select: typeof fullUserSelector
+}>
+export type fullUserList = fullUser[]

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -18,7 +18,7 @@ export const publicUserSelector = {
   }
 } satisfies Prisma.UserSelect
 
-export const fullUserSelector = {
+export const userForAdminSelector = {
   ...publicUserSelector,
   isAdmin: true,
   email: true
@@ -29,7 +29,7 @@ export type publicUser = Prisma.UserGetPayload<{
 }>
 export type publicUserList = publicUser[]
 
-export type fullUser = Prisma.UserGetPayload<{
-  select: typeof fullUserSelector
+export type userForAdmin = Prisma.UserGetPayload<{
+  select: typeof userForAdminSelector
 }>
-export type fullUserList = fullUser[]
+export type userListForAdmin = userForAdmin[]

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -18,7 +18,7 @@ export const publicUserSelector = {
   }
 } satisfies Prisma.UserSelect
 
-export const userForAdminSelector = {
+export const detailedUserSelector = {
   ...publicUserSelector,
   isAdmin: true,
   email: true
@@ -29,7 +29,7 @@ export type publicUser = Prisma.UserGetPayload<{
 }>
 export type publicUserList = publicUser[]
 
-export type UserForAdmin = Prisma.UserGetPayload<{
-  select: typeof userForAdminSelector
+export type DetailedUser = Prisma.UserGetPayload<{
+  select: typeof detailedUserSelector
 }>
-export type UserListForAdmin = UserForAdmin[]
+export type DetailedUserList = DetailedUser[]

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -13,12 +13,14 @@ export const publicUserSelector = {
   ...basicUserSelector,
   nickname: true,
   bio: true,
+  isAdmin: true,
+  email: true,
   sessions: {
     select: { id: true, name: true }
   }
 } satisfies Prisma.UserSelect
 
-type publicUser = Prisma.UserGetPayload<{
+export type publicUser = Prisma.UserGetPayload<{
   select: typeof publicUserSelector
 }>
 

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -13,8 +13,6 @@ export const publicUserSelector = {
   ...basicUserSelector,
   nickname: true,
   bio: true,
-  isAdmin: true,
-  email: true,
   sessions: {
     select: { id: true, name: true }
   }


### PR DESCRIPTION
<!--
title 형식은 다음과 같이 conventional commits에 따라 작성해주세요:
(출처: https://www.conventionalcommits.org/ko/v1.0.0)
<타입>[적용 범위(선택 사항)]: <설명>

[본문(선택 사항)]

[꼬리말(선택 사항)]
-->

## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

## PR 작업 내역에 대한 간단한 설명입니다.

유저 처리를 위한 Admin API를 추가하였습니다. 

유저 전체 혹은 특정 유저에 대한 GET 요청의 경우 **@Public()** 데코레이터를 추가해 로그인 없이도 볼 수 있도록 하였습니다.
그 이외의 `POST`, `PATCH`, `DELETE` 요청의 경우 **AdminGuard**를 추가해 Admin 권한 검증 후 실행되도록 하였습니다.

**변경 사항**

1. Admin 패널에서 사용자 관리를 위한 Admin 전용 API (`POST`, `PATCH`, `DELETE`)를 구현하였습니다.

2. 추가된 API들에 대한 함수를 **ApiClient** 클래스에 추가하였습니다.

3. publicUserSelector에서 `isAdmin`, `email` 필드를 추가로 반환하는 `detailedUserSelector`를 별도로 구현하였습니다.
  https://github.com/skku-amang/main/blob/6fe9a466fd00388abf0ebf12ba2e7da69003f6bd/packages/shared-types/src/user/user.types.ts#L12-L21  기존 publicUserSelector에서 반환하는 정보로는 Admin API를 사용하기에 부족할 수 있다고 판단해 별도의 Selector를 추가 및 사용하도록 변경하였습니다.

4. 기존 JWT 서명 중 `expiresIn` 으로 인한 문제를 해결하기 위해 각 토큰의 만료 시간 처리를 변경하였습니다.

    **기존 코드**
  https://github.com/skku-amang/main/blob/60c5b14c49d0cccd3004a132f492e79552736243/apps/api/src/auth/auth.service.ts#L71-L73
  기존 코드에서는 단순히 .env 파일의 `ACCESS_TOKEN_EXPIRES_IN` 값을 가져와서 그대로 사용했습니다. 이 때, `env`에서 가져와 지는 값은 string으로 처리되고 해당 문자열이 JWT의 `expiresIn`에 들어가게 되면 초 단위가 아닌 ms 단위로 처리되는 문제가 발생합니다.
  
    예시) `ACCESS_TOKEN_EXPIRES_IN`이 "3600"이라면 토큰이 3.6초 이후에 만료되는 문제 발생
  
    **변경된 코드**
    https://github.com/skku-amang/main/blob/cdc78b4e0ab60ef3f640d955e22ed41c82e3ac2d/apps/api/src/auth/auth.service.ts#L70-L77
  기존 코드를 위와 같이 env에서 가져온 후, parseInt를 통해 `number` 형식으로 변경하면 위와 같이 ms 단위로 인식되는 것이 아닌 정상적으로 s 단위로 인식되도록 변경할 수 있습니다.
  

## 📸 스크린샷(선택)

> 작업 결과물을 확인할 수 있는 스크린샷을 첨부해주세요.  
> 스크린샷이 없는 경우, 생략해도 됩니다.  
> (예: 로그인 페이지 UI 개선 전/후 스크린샷)

## 🔗 관련 이슈

> 이 PR과 관련된 이슈 번호를 연결해주세요.
> Closes #313 

## 🙏 리뷰어에게

> 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.  
> (예: 새로 설치한 라이브러리의 사용법이 적절한지 봐주세요.)

## ✅ 체크리스트

- [X] conventional commits 형식을 따르는 title을 작성했습니다.
- [X] 적절한 label을 1개 이상 추가했습니다.
- [X] 관련 이슈가 연결되었습니다.
