### PR TITLE
fix: OG 이미지 미표시 수정

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -46,10 +46,7 @@ export const metadata: Metadata = {
     ]
   },
   twitter: {
-    card: "summary_large_image",
-    title: SEO.SITE_NAME,
-    description: SEO.SITE_DESCRIPTION,
-    images: [SEO.DEFAULT_OG_IMAGE]
+    card: "summary_large_image"
   },
   robots: {
     index: true,

--- a/apps/web/constants/seo.ts
+++ b/apps/web/constants/seo.ts
@@ -1,7 +1,7 @@
 export const SEO = {
-  SITE_URL: "https://amang.skku.edu",
+  SITE_URL: process.env.NEXT_PUBLIC_SITE_URL ?? "https://amang.json-server.win",
   SITE_NAME: "AMANG - 성균관대학교 밴드 동아리",
   SITE_DESCRIPTION:
-    "성균관대학교 밴드 동아리 AMANG 공식 홈페이지. 공연 정보, 팀 모집, 세션 지원 등 동아리 활동의 모든 것을 만나보세요.",
+    "성균관대학교 밴드 동아리 AMANG 공식 홈페이지. 공연 정보, 팀 모집, 동방 예약 등 동아리 활동의 모든 것을 만나보세요.",
   DEFAULT_OG_IMAGE: "/Logo.png"
 } as const


### PR DESCRIPTION
## Summary
- `twitter:image`가 접근 불가능한 `amang.skku.edu/Logo.png`로 resolve되던 문제 수정
- root layout의 `twitter` 블록에서 중복 필드 제거 → Next.js `openGraph` 자동 fallback 활용
- `SITE_URL`을 `NEXT_PUBLIC_SITE_URL` 환경변수로 변경 (기본값: `amang.json-server.win`)

## 원인 분석
1. `seo.ts`의 `SITE_URL`이 `https://amang.skku.edu` (접근 불가) → `metadataBase` resolve 실패
2. `layout.tsx`에서 `twitter`를 명시적으로 설정 → 하위 페이지의 `openGraph` 값이 twitter에 전파되지 않음

## Test plan
- [ ] 배포 후 `curl` 로 `/performances/1/teams/4` OG 태그 확인
- [ ] `twitter:image`가 S3 URL로 표시되는지 확인
- [ ] 포스터 없는 팀에서 `/Logo.png` fallback 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)