### PR TITLE
feat: user profile frontend - edit, password change, admin CRUD

### DIFF
--- a/apps/web/app/(admin)/admin/users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/columns.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 
 import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
 import { formatGenerationOrder } from "@/lib/utils"
 import ROUTES from "@/constants/routes"
 import { getSessionDisplayName } from "@/constants/session"
@@ -55,25 +56,42 @@ export function getColumns({
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="이름" />
       ),
-      meta: { label: "이름" }
+      meta: { label: "이름", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.getValue() as string}
+        />
+      )
     },
     {
       accessorKey: "nickname",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="닉네임" />
       ),
-      meta: { label: "닉네임" }
+      meta: { label: "닉네임", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.getValue() as string}
+        />
+      )
     },
     {
       accessorKey: "bio",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="소개" />
       ),
-      meta: { label: "소개" },
-      cell: ({ row }) => (
-        <span className="max-w-[200px] truncate">
-          {row.original.bio ?? "-"}
-        </span>
+      meta: { label: "소개", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            <span className="max-w-[200px] truncate">
+              {ctx.row.original.bio ?? "-"}
+            </span>
+          }
+        />
       )
     },
     {

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -12,6 +12,7 @@ import { useDeleteUser, useUpdateUser, useUsers } from "@/hooks/api/useUser"
 import { formatGenerationOrder } from "@/lib/utils"
 import { getSessionDisplayName } from "@/constants/session"
 import { publicUser } from "@repo/shared-types"
+import { ApiError } from "@repo/api-client"
 
 import { getColumns } from "./_components/columns"
 import { UserFormDialog } from "./_components/UserFormDialog"
@@ -60,7 +61,10 @@ export default function UsersAdminPage() {
       } catch (error) {
         toast({
           title: "수정에 실패했습니다.",
-          description: (error as Error).message,
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
           variant: "destructive"
         })
         throw error
@@ -103,7 +107,10 @@ export default function UsersAdminPage() {
       .catch((error) => {
         toast({
           title: "수정에 실패했습니다.",
-          description: (error as Error).message,
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
           variant: "destructive"
         })
       })
@@ -123,7 +130,10 @@ export default function UsersAdminPage() {
       .catch((error) => {
         toast({
           title: "삭제에 실패했습니다.",
-          description: (error as Error).message,
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
           variant: "destructive"
         })
       })

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 
 import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
 import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
@@ -49,6 +49,24 @@ export default function UsersAdminPage() {
         value: s.name
       })) ?? [],
     [sessions]
+  )
+
+  const handleCellUpdate = useCallback(
+    async (rowId: number, columnId: string, value: unknown) => {
+      try {
+        await updateMutation.mutateAsync([rowId, { [columnId]: value }])
+        toast({ title: "회원 정보가 수정되었습니다." })
+        queryClient.invalidateQueries({ queryKey: ["users"] })
+      } catch (error) {
+        toast({
+          title: "수정에 실패했습니다.",
+          description: (error as Error).message,
+          variant: "destructive"
+        })
+        throw error
+      }
+    },
+    [updateMutation, toast, queryClient]
   )
 
   const columns = useMemo(
@@ -123,6 +141,7 @@ export default function UsersAdminPage() {
         initialColumnVisibility={{ bio: false }}
         enableGlobalSearch
         searchPlaceholder="이름으로 검색..."
+        onUpdateCell={handleCellUpdate}
         emptyMessage="등록된 회원이 없습니다."
         filters={[
           {

--- a/packages/shared-types/src/user/update-user.schema.ts
+++ b/packages/shared-types/src/user/update-user.schema.ts
@@ -1,5 +1,10 @@
 import z from "zod"
 import { CreateUserSchema } from "./create-user.schema"
 
-export const UpdateUserSchema = CreateUserSchema.partial()
+export const UpdateUserSchema = CreateUserSchema.extend({
+  bio: z
+    .string()
+    .max(100, { message: "자기소개는 100자 이내로 작성해 주세요." })
+    .optional()
+}).partial()
 export type UpdateUser = z.infer<typeof UpdateUserSchema>


### PR DESCRIPTION
## Summary
- 마이페이지 프로필/비밀번호 수정 폼을 `PATCH /users/me`, `PATCH /users/me/password` API에 연결
- 어드민 유저 대시보드에 편집/삭제 기능 구현 (다이얼로그 + 인라인 편집)
- `UpdateUserSchema`에 `bio` 필드 추가하여 어드민 유저 수정 시 bio 업데이트 가능
- 로그인 에러 메시지 개선 (generic toast → 구체적 에러 표시)
- 백엔드 `AllErrorFilter` 에러 로깅 개선 (`{}` → name/message/stack)

## Dependencies
- #319 (feat: add user update API) — base branch
- → #329 (fix: QA 피드백 반영) — 이 PR을 base로 하는 후속 PR

머지 순서: **#319 → #324 → #329**

## Changes
- `packages/api-client`: `updateProfile`, `updatePassword` 메서드 추가
- `packages/shared-types`: `UpdateUserSchema`에 `bio` 필드 추가
- `apps/web/hooks/api/useUser.ts`: mutation hooks 추가 (updateProfile, updatePassword, updateUser, deleteUser)
- `apps/web/app/(general)/(light)/profile/edit/page.tsx`: 프로필/비밀번호 수정 폼 API 연결
- `apps/web/app/(admin)/admin/users/`: UserFormDialog, 인라인 편집(name, nickname, bio), 삭제 기능

## Test plan
- [x] 마이페이지에서 프로필 (이름, 닉네임, 소개) 수정 확인
- [x] 마이페이지에서 비밀번호 변경 확인
- [x] 어드민 유저 테이블 인라인 편집 (이름, 닉네임, 소개) 확인
- [x] 어드민 유저 다이얼로그 편집 확인
- [x] 어드민 유저 삭제 확인
- [x] 잘못된 로그인 시 에러 메시지 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)