### PR TITLE
fix: navbar 배경색 및 높이 변경

### DIFF
--- a/apps/web/components/Header/index.tsx
+++ b/apps/web/components/Header/index.tsx
@@ -50,7 +50,7 @@ const Header = ({
         position,
         "top-0 z-50 flex h-full w-full justify-center backdrop-blur-sm",
         {
-          "bg-primary md:bg-white": mode === "light",
+          "bg-primary md:bg-slate-50": mode === "light",
           "bg-primary": mode === "dark",
           "bg-transparent": mode === "transparent"
         }

--- a/apps/web/components/RootHeaderAndFooterWrapper.tsx
+++ b/apps/web/components/RootHeaderAndFooterWrapper.tsx
@@ -37,8 +37,8 @@ const RootHeaderAndFooterWrapper = ({
   useHeader = true,
   headerMode = useHeader ? "light" : undefined
 }: RootHeaderAndFooterWrapperProps) => {
-  const headerHeightPiexel = 82
-  const footerHeightPiexl = 120
+  const headerHeightPixel = 82
+  const footerHeightPixel = 120
 
   const toPixelString = (value: number) => `${value}px`
 
@@ -46,22 +46,22 @@ const RootHeaderAndFooterWrapper = ({
     <div className="h-screen">
       <Header
         position="fixed"
-        height={toPixelString(headerHeightPiexel)}
+        height={toPixelString(headerHeightPixel)}
         mode={headerMode}
       />
 
       <main
         className={cn("h-auto min-h-full", mainClassName)}
         style={{
-          paddingTop: toPixelString(headerHeightPiexel + paddingTopPixel),
-          paddingBottom: toPixelString(footerHeightPiexl + paddingBottomPixel),
+          paddingTop: toPixelString(headerHeightPixel + paddingTopPixel),
+          paddingBottom: toPixelString(footerHeightPixel + paddingBottomPixel),
           ...mainStyle
         }}
       >
         {children}
       </main>
 
-      <Footer height={toPixelString(footerHeightPiexl)} />
+      <Footer height={toPixelString(footerHeightPixel)} />
     </div>
   )
 }

--- a/apps/web/components/RootHeaderAndFooterWrapper.tsx
+++ b/apps/web/components/RootHeaderAndFooterWrapper.tsx
@@ -37,7 +37,7 @@ const RootHeaderAndFooterWrapper = ({
   useHeader = true,
   headerMode = useHeader ? "light" : undefined
 }: RootHeaderAndFooterWrapperProps) => {
-  const headerHeightPiexel = 48
+  const headerHeightPiexel = 82
   const footerHeightPiexl = 120
 
   const toPixelString = (value: number) => `${value}px`


### PR DESCRIPTION
## Summary
- Navbar 배경색: `bg-white` → `bg-slate-50` (데스크탑 light 모드)
- Navbar 높이: `48px` → `82px` (Header 컴포넌트 기본값은 이미 82px이었으나, RootHeaderAndFooterWrapper에서 48px로 override하고 있었음)

Closes #337

## Changes
- `apps/web/components/Header/index.tsx`: `md:bg-white` → `md:bg-slate-50`
- `apps/web/components/RootHeaderAndFooterWrapper.tsx`: `headerHeightPiexel = 48` → `82`

## Test plan
- [ ] 데스크탑에서 navbar 배경색이 slate-50인지 확인
- [ ] navbar 높이가 82px인지 확인
- [ ] 모바일 뷰에서 navbar가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)