### PR TITLE
fix: increase team list table font size (#338)

### DIFF
--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -75,7 +75,7 @@ const ActionsCell = ({ row }: CellContext<TeamColumn, unknown>) => {
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
-          className="rounded-lg border border-slate-100 p-[5px] text-sm drop-shadow-[0_3px_6px_rgb(0,0,0,0.3)]"
+          className="rounded-lg border border-slate-100 p-[5px] text-base drop-shadow-[0_3px_6px_rgb(0,0,0,0.3)]"
         >
           <DropdownMenuItem className="p-0 selection:text-slate-700 hover:cursor-pointer">
             <Link

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/table.tsx
@@ -10,7 +10,7 @@ const Table = React.forwardRef<
     <table
       ref={ref}
       className={cn(
-        "w-full caption-bottom border-separate [border-spacing:0_16px] text-sm",
+        "w-full caption-bottom border-separate [border-spacing:0_16px] text-base",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- 팀 목록 테이블의 폰트 크기를 `text-sm` (0.875rem)에서 `text-base` (1rem)로 변경
- 테이블 본문(`<table>` 요소)과 액션 드롭다운 메뉴 모두 적용

Closes #338

## Changes
- `TeamListTable/table.tsx`: `<table>` 요소의 `text-sm` → `text-base`
- `TeamListTable/columns.tsx`: 액션 드롭다운 메뉴의 `text-sm` → `text-base`

## Test plan
- [ ] 팀 목록 페이지(`/performances/[id]/teams`)에서 테이블 텍스트가 1rem(16px)로 표시되는지 확인
- [ ] 액션 드롭다운 메뉴(편집/삭제) 텍스트도 동일하게 적용되었는지 확인
- [ ] 모바일 카드 뷰는 영향 없음을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)