### PR TITLE
fix: filter modal UI 수정

### DIFF
--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Desktop.tsx
@@ -15,7 +15,7 @@ const DesktopFilterCheckbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-500 data-[state=checked]:bg-sky-500 data-[state=checked]:text-primary-foreground",
+      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-blue-500 data-[state=checked]:bg-blue-500 data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}
@@ -49,7 +49,7 @@ const DesktopFilter = ({
         {onSelectAll && (
           <button
             onClick={onSelectAll}
-            className="text-xs text-sky-500 hover:text-sky-600"
+            className="text-xs text-blue-500 hover:text-blue-600"
           >
             모두 선택
           </button>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Mobile.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/Filter/Mobile.tsx
@@ -15,7 +15,7 @@ const MobileFilterCheckbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-sky-500 data-[state=checked]:bg-sky-500 data-[state=checked]:text-primary-foreground",
+      "data-[state=checked]:1 peer h-[18px] w-[18px] shrink-0 rounded border border-slate-300 ring-offset-background hover:shadow-checkbox focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-blue-500 data-[state=checked]:bg-blue-500 data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -220,12 +220,6 @@ export function TeamListDataTable<TValue>({
   const filterValues: Record<keyof State["filters"], FilterValue[]> = {
     필요세션: [
       {
-        label: "모두",
-        onChecked: () =>
-          dispatch({ type: "clearFilter", payload: { target: "필요세션" } }),
-        checked: state.filters.필요세션.size === 0
-      },
-      {
         label: "보컬",
         onChecked: (checked) =>
           dispatch({
@@ -290,15 +284,6 @@ export function TeamListDataTable<TValue>({
       }
     ],
     모집상태: [
-      {
-        label: "모두",
-        onChecked: () =>
-          dispatch({
-            type: "setFilter",
-            payload: { target: "모집상태", value: "all" }
-          }),
-        checked: state.filters.모집상태 === "all"
-      },
       {
         label: "Active",
         onChecked: (checked) =>
@@ -406,11 +391,11 @@ export function TeamListDataTable<TValue>({
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                className="w-[480px] rounded-[12px] p-0"
+                className="w-[526px] min-h-[408px] rounded-[12px] p-0"
               >
                 {/* 헤더 */}
-                <div className="flex items-center justify-between px-6 pb-3 pt-5">
-                  <div className="flex items-baseline gap-x-3">
+                <div className="flex items-center justify-between px-6 py-4">
+                  <div className="flex items-center gap-x-3">
                     <h3 className="text-xl font-bold">Filter</h3>
                     <button
                       onClick={() => {
@@ -423,13 +408,13 @@ export function TeamListDataTable<TValue>({
                           payload: { target: "모집상태", value: "all" }
                         })
                       }}
-                      className="text-xs text-sky-500 hover:text-sky-600"
+                      className="text-xs text-blue-500 hover:text-blue-600"
                     >
                       초기화
                     </button>
                   </div>
                   <button onClick={() => setFilterOpen(false)}>
-                    <X className="h-4 w-4 text-slate-400" />
+                    <X className="h-6 w-6 text-gray-500" />
                   </button>
                 </div>
 


### PR DESCRIPTION
Closes #336

## Summary
- **'모두' 체크박스 제거**: 필요세션, 모집상태 필터에서 '모두' 체크박스 삭제 ('모두 선택' 텍스트 버튼과 기능 중복)
- **색상 변경**: sky → blue (초기화 버튼, 체크박스 checked 상태)
- **닫기(X) 버튼**: `slate-400` → `gray-500`, 아이콘 크기 `w-4 h-4` → `w-6 h-6`
- **수직 정렬**: Filter 제목과 초기화 버튼 `items-baseline` → `items-center`
- **헤더 패딩**: `pt-5 pb-3` → `py-4` (상하 균일)
- **모달 크기**: `w-[480px]` → `w-[526px]`, `min-h-[408px]` 추가

## Changed files
- `apps/web/.../TeamListTable/data-table.tsx` — 모달 크기, 헤더 패딩, 정렬, 닫기 버튼, 초기화 색상, '모두' 체크박스 제거
- `apps/web/.../TeamListTable/Filter/Desktop.tsx` — 체크박스 sky→blue, 모두선택 sky→blue
- `apps/web/.../TeamListTable/Filter/Mobile.tsx` — 체크박스 sky→blue

## Test plan
- [ ] 데스크톱에서 팀 목록 페이지 Filter 버튼 클릭 → 모달 정상 표시
- [ ] '모두' 체크박스가 없는지 확인
- [ ] 초기화 버튼, 체크박스 색상이 blue인지 확인
- [ ] X 닫기 버튼 크기 및 색상 확인
- [ ] Filter 제목과 초기화 버튼이 수직 중앙 정렬인지 확인
- [ ] 모달 크기가 ~526x408px인지 확인
- [ ] 모바일 필터 Drawer에서 체크박스 색상 blue 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)