### PR TITLE
feat(web): 예약 페이지 모바일 레이아웃 및 디자인 디테일 (#345)

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
@@ -202,13 +202,13 @@ export default function AddScheduleButton({
         >
           <div className="flex gap-2 justify-center items-center">
             <PlusCircle size={18} />
-            Add Schedule
+            Add schedule
           </div>
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+      <DialogContent className="max-h-[90vh] overflow-y-auto rounded-2xl sm:max-w-[600px]">
         <DialogHeader>
-          <DialogTitle>Add schedule</DialogTitle>
+          <DialogTitle className="text-xl font-bold">Add schedule</DialogTitle>
           <DialogDescription>예약 정보를 입력해주세요</DialogDescription>
         </DialogHeader>
 

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMonthBlock.tsx
@@ -5,42 +5,50 @@ interface MobileMonthBlockProps {
   days: Dayjs[]
   currentMonth: Dayjs
   rentals: RentalDetail[]
-  onSelect?(d: Dayjs): void
+  onSelect?: (d: Dayjs) => void
+  selectedDate?: Dayjs | null
 }
 
 export default function MobileMonthBlock({
   days,
   currentMonth,
-  rentals
+  rentals,
+  onSelect,
+  selectedDate
 }: MobileMonthBlockProps) {
   return (
-    <div className="grid grid-cols-7 border-gray-100">
+    <div className="grid grid-cols-7">
       {days.map((d, i) => {
         const isThisMonth = d.month() === currentMonth.month()
         const isToday = d.isSame(new Date(), "day")
+        const isSelected =
+          selectedDate && d.isSame(selectedDate, "day") && !isToday
         const hasRentals = rentals.some((r) =>
           dayjs(r.startAt).isSame(d, "day")
         )
 
         return (
-          <div key={i} className="flex-1 h-12">
-            <div
-              className={`flex h-full font-medium text-base justify-center items-center flex-col
-                ${isThisMonth ? "text-black" : "text-neutral-300"}`}
+          <div
+            key={i}
+            className="flex h-[46px] cursor-pointer flex-col items-center justify-center"
+            onClick={() => onSelect?.(d)}
+          >
+            <span
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-[16px] font-medium ${
+                isToday
+                  ? "bg-zinc-900 text-white"
+                  : isSelected
+                    ? "bg-blue-100 text-blue-600"
+                    : isThisMonth
+                      ? "text-zinc-800"
+                      : "text-neutral-300"
+              }`}
             >
-              <span
-                className={
-                  isToday
-                    ? "w-7 h-7 flex items-center justify-center rounded-full bg-black text-white"
-                    : ""
-                }
-              >
-                {d.date()}
-              </span>
-              {hasRentals && (
-                <div className="w-1.5 h-1.5 rounded-full bg-primary mt-0.5" />
-              )}
-            </div>
+              {d.date()}
+            </span>
+            {hasRentals && (
+              <div className="mt-0.5 h-1 w-1 rounded-full bg-blue-400" />
+            )}
           </div>
         )
       })}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMyReservations.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileMyReservations.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import dayjs from "dayjs"
+import { useSession } from "next-auth/react"
+import { Clock, UserRound } from "lucide-react"
+import { RentalDetail } from "@repo/shared-types"
+
+interface MobileMyReservationsProps {
+  rentals: RentalDetail[]
+  onRentalClick?: (rental: RentalDetail) => void
+}
+
+export default function MobileMyReservations({
+  rentals,
+  onRentalClick
+}: MobileMyReservationsProps) {
+  const { data: session } = useSession()
+  const userId = session?.user?.id ? Number(session.user.id) : null
+
+  const myRentals = userId
+    ? rentals
+        .filter((r) => r.users.some((u) => u.id === userId))
+        .sort(
+          (a, b) =>
+            new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+        )
+    : []
+
+  if (myRentals.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-gray-400">
+        <p className="text-sm">예약이 없습니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col">
+      {myRentals.map((rental) => {
+        const start = dayjs(rental.startAt)
+        const end = dayjs(rental.endAt)
+        const isToday = start.isSame(dayjs(), "day")
+        const timeRange = `${start.format("HH:mm")} - ${end.format("HH:mm")}`
+        const userLabel =
+          rental.users.length <= 1
+            ? (rental.users[0]?.name ?? "")
+            : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
+
+        return (
+          <div
+            key={rental.id}
+            className="flex cursor-pointer items-center border-b border-gray-50 px-1 py-3 transition-colors hover:bg-gray-50"
+            onClick={() => onRentalClick?.(rental)}
+          >
+            {/* Day/Date */}
+            <div className="flex w-16 shrink-0 flex-col items-center justify-center">
+              <span
+                className={`text-sm font-semibold ${isToday ? "text-blue-600" : "text-zinc-600"}`}
+              >
+                {start.format("ddd")}
+              </span>
+              <span
+                className={`text-xl font-semibold ${isToday ? "text-blue-600" : "text-zinc-700"}`}
+              >
+                {start.format("DD")}
+              </span>
+            </div>
+
+            {/* Divider */}
+            <div className="mx-2 h-10 w-px bg-gray-200" />
+
+            {/* Details */}
+            <div className="flex flex-1 flex-col gap-0.5 pl-2">
+              <div className="flex items-center gap-1.5 text-gray-500">
+                <Clock size={11} />
+                <span className="text-[11px]">{timeRange}</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-gray-500">
+                <UserRound size={11} />
+                <span className="text-[11px]">{userLabel}</span>
+              </div>
+              <span className="text-xs font-semibold text-zinc-600">
+                {rental.title}
+              </span>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import dayjs, { Dayjs } from "dayjs"
+import { Clock, UserRound } from "lucide-react"
+import { RentalDetail } from "@repo/shared-types"
+import { getRentalColor } from "../rentalColors"
+
+interface MobileTimeSlotsProps {
+  selectedDate: Dayjs
+  rentals: RentalDetail[]
+  onRentalClick?: (rental: RentalDetail) => void
+}
+
+const START_HOUR = 6
+const END_HOUR = 22
+
+export default function MobileTimeSlots({
+  selectedDate,
+  rentals,
+  onRentalClick
+}: MobileTimeSlotsProps) {
+  const dayRentals = rentals.filter((r) =>
+    dayjs(r.startAt).isSame(selectedDate, "day")
+  )
+
+  const hours = Array.from(
+    { length: END_HOUR - START_HOUR },
+    (_, i) => i + START_HOUR
+  )
+
+  const getRentalsAtHour = (hour: number) => {
+    return dayRentals.filter((r) => {
+      const startHour = dayjs(r.startAt).hour()
+      return startHour === hour
+    })
+  }
+
+  return (
+    <div className="flex flex-col">
+      {hours.map((hour) => {
+        const rentalsAtHour = getRentalsAtHour(hour)
+        const hasContent = rentalsAtHour.length > 0
+        const formattedHour = `${hour.toString().padStart(2, "0")}:00`
+
+        return (
+          <div key={hour} className="flex min-h-[48px] border-b border-gray-50">
+            {/* Time label */}
+            <div
+              className={`w-[52px] shrink-0 pt-2.5 text-center text-[15px] font-medium tracking-wide ${
+                hasContent ? "font-semibold text-blue-600" : "text-neutral-500"
+              }`}
+            >
+              {formattedHour}
+            </div>
+
+            {/* Content area */}
+            <div className="flex-1 py-1.5">
+              {rentalsAtHour.map((rental) => {
+                const start = dayjs(rental.startAt)
+                const end = dayjs(rental.endAt)
+                const color = getRentalColor(rental.id)
+                const userLabel =
+                  rental.users.length <= 1
+                    ? (rental.users[0]?.name ?? "")
+                    : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
+
+                return (
+                  <div
+                    key={rental.id}
+                    className={`cursor-pointer rounded-md ${color.bg} border-l-2 ${color.border} px-3 py-2 ${color.hoverBg} transition-colors`}
+                    onClick={() => onRentalClick?.(rental)}
+                  >
+                    <div className="flex items-center gap-3 text-[11px] text-gray-500">
+                      <div className="flex items-center gap-1">
+                        <Clock size={10} />
+                        <span>
+                          {start.format("HH:mm")} - {end.format("HH:mm")}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <UserRound size={10} />
+                        <span>{userLabel}</span>
+                      </div>
+                    </div>
+                    <p
+                      className={`mt-0.5 text-[13px] font-semibold ${color.text}`}
+                    >
+                      {rental.title}
+                    </p>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -3,7 +3,6 @@
 import dayjs, { Dayjs } from "dayjs"
 import { Clock, UserRound } from "lucide-react"
 import { RentalDetail } from "@repo/shared-types"
-import { getRentalColor } from "../rentalColors"
 
 interface MobileTimeSlotsProps {
   selectedDate: Dayjs
@@ -11,85 +10,69 @@ interface MobileTimeSlotsProps {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-const START_HOUR = 6
-const END_HOUR = 22
-
 export default function MobileTimeSlots({
   selectedDate,
   rentals,
   onRentalClick
 }: MobileTimeSlotsProps) {
-  const dayRentals = rentals.filter((r) =>
-    dayjs(r.startAt).isSame(selectedDate, "day")
-  )
+  const dayRentals = rentals
+    .filter((r) => dayjs(r.startAt).isSame(selectedDate, "day"))
+    .sort(
+      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+    )
 
-  const hours = Array.from(
-    { length: END_HOUR - START_HOUR },
-    (_, i) => i + START_HOUR
-  )
-
-  const getRentalsAtHour = (hour: number) => {
-    return dayRentals.filter((r) => {
-      const startHour = dayjs(r.startAt).hour()
-      return startHour === hour
-    })
+  if (dayRentals.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-gray-400">
+        <p className="text-sm">예약이 없습니다</p>
+      </div>
+    )
   }
 
   return (
-    <div className="flex flex-col">
-      {hours.map((hour) => {
-        const rentalsAtHour = getRentalsAtHour(hour)
-        const hasContent = rentalsAtHour.length > 0
-        const formattedHour = `${hour.toString().padStart(2, "0")}:00`
+    <div className="flex flex-col gap-2">
+      {dayRentals.map((rental) => {
+        const start = dayjs(rental.startAt)
+        const end = dayjs(rental.endAt)
+        const isToday = start.isSame(dayjs(), "day")
+        const timeRange = `${start.format("h:mmA")} - ${end.format("h:mmA")}`
+        const userLabel =
+          rental.users.length <= 1
+            ? (rental.users[0]?.name ?? "")
+            : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
 
         return (
-          <div key={hour} className="flex min-h-[48px] border-b border-gray-50">
-            {/* Time label */}
-            <div
-              className={`w-[52px] shrink-0 pt-2.5 text-center text-[15px] font-medium tracking-wide ${
-                hasContent ? "font-semibold text-blue-600" : "text-neutral-500"
-              }`}
-            >
-              {formattedHour}
+          <div
+            key={rental.id}
+            className={`flex w-full items-center rounded-md bg-neutral-50 transition-colors ${onRentalClick ? "cursor-pointer hover:bg-neutral-100" : ""}`}
+            style={{ height: 80 }}
+            onClick={() => onRentalClick?.(rental)}
+          >
+            <div className="flex w-[74px] shrink-0 flex-col items-center justify-center">
+              <span
+                className={`text-base font-semibold leading-tight ${isToday ? "text-blue-500" : "text-zinc-700"}`}
+              >
+                {start.format("ddd")}
+              </span>
+              <span
+                className={`text-2xl font-semibold leading-8 ${isToday ? "text-blue-500" : "text-zinc-700"}`}
+              >
+                {start.format("DD")}
+              </span>
             </div>
-
-            {/* Content area */}
-            <div className="flex-1 py-1.5">
-              {rentalsAtHour.map((rental) => {
-                const start = dayjs(rental.startAt)
-                const end = dayjs(rental.endAt)
-                const color = getRentalColor(rental.id)
-                const userLabel =
-                  rental.users.length <= 1
-                    ? (rental.users[0]?.name ?? "")
-                    : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
-
-                return (
-                  <div
-                    key={rental.id}
-                    className={`cursor-pointer rounded-md ${color.bg} border-l-2 ${color.border} px-3 py-2 ${color.hoverBg} transition-colors`}
-                    onClick={() => onRentalClick?.(rental)}
-                  >
-                    <div className="flex items-center gap-3 text-[11px] text-gray-500">
-                      <div className="flex items-center gap-1">
-                        <Clock size={10} />
-                        <span>
-                          {start.format("HH:mm")} - {end.format("HH:mm")}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <UserRound size={10} />
-                        <span>{userLabel}</span>
-                      </div>
-                    </div>
-                    <p
-                      className={`mt-0.5 text-[13px] font-semibold ${color.text}`}
-                    >
-                      {rental.title}
-                    </p>
-                  </div>
-                )
-              })}
+            <div className="h-2/3 w-px bg-gray-200" />
+            <div className="flex flex-1 flex-col justify-center gap-[2px] pl-5">
+              <div className="flex items-center gap-2 text-gray-600">
+                <Clock size={12} />
+                <span className="text-[10px]">{timeRange}</span>
+              </div>
+              <div className="flex items-center gap-2 text-gray-600">
+                <UserRound size={12} />
+                <span className="text-[10px]">{userLabel}</span>
+              </div>
+              <span className="text-xs font-semibold text-zinc-600">
+                {rental.title}
+              </span>
             </div>
           </div>
         )

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -10,6 +10,9 @@ interface MobileTimeSlotsProps {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
+/** Hours to display in the time-slot list (09:00 – 23:00) */
+const HOURS = Array.from({ length: 15 }, (_, i) => i + 9)
+
 export default function MobileTimeSlots({
   selectedDate,
   rentals,
@@ -21,58 +24,59 @@ export default function MobileTimeSlots({
       (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
     )
 
-  if (dayRentals.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-gray-400">
-        <p className="text-sm">예약이 없습니다</p>
-      </div>
-    )
+  /** Group rentals by the hour they START in */
+  const rentalsByHour = new Map<number, RentalDetail[]>()
+  for (const rental of dayRentals) {
+    const hour = dayjs(rental.startAt).hour()
+    const list = rentalsByHour.get(hour) ?? []
+    list.push(rental)
+    rentalsByHour.set(hour, list)
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      {dayRentals.map((rental) => {
-        const start = dayjs(rental.startAt)
-        const end = dayjs(rental.endAt)
-        const isToday = start.isSame(dayjs(), "day")
-        const timeRange = `${start.format("h:mmA")} - ${end.format("h:mmA")}`
-        const userLabel =
-          rental.users.length <= 1
-            ? (rental.users[0]?.name ?? "")
-            : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
-
+    <div className="flex flex-col">
+      {HOURS.map((hour) => {
+        const hourRentals = rentalsByHour.get(hour)
         return (
-          <div
-            key={rental.id}
-            className={`flex w-full items-center rounded-md bg-neutral-50 transition-colors ${onRentalClick ? "cursor-pointer hover:bg-neutral-100" : ""}`}
-            style={{ height: 80 }}
-            onClick={() => onRentalClick?.(rental)}
-          >
-            <div className="flex w-[74px] shrink-0 flex-col items-center justify-center">
-              <span
-                className={`text-base font-semibold leading-tight ${isToday ? "text-blue-500" : "text-zinc-700"}`}
-              >
-                {start.format("ddd")}
-              </span>
-              <span
-                className={`text-2xl font-semibold leading-8 ${isToday ? "text-blue-500" : "text-zinc-700"}`}
-              >
-                {start.format("DD")}
-              </span>
+          <div key={hour} className="flex min-h-[44px]">
+            {/* Hour label */}
+            <div className="w-14 shrink-0 pt-3 text-sm font-medium text-zinc-500">
+              {String(hour).padStart(2, "0")}:00
             </div>
-            <div className="h-2/3 w-px bg-gray-200" />
-            <div className="flex flex-1 flex-col justify-center gap-[2px] pl-5">
-              <div className="flex items-center gap-2 text-gray-600">
-                <Clock size={12} />
-                <span className="text-[10px]">{timeRange}</span>
-              </div>
-              <div className="flex items-center gap-2 text-gray-600">
-                <UserRound size={12} />
-                <span className="text-[10px]">{userLabel}</span>
-              </div>
-              <span className="text-xs font-semibold text-zinc-600">
-                {rental.title}
-              </span>
+
+            {/* Separator + events */}
+            <div className="flex flex-1 flex-col border-t border-gray-100 py-1">
+              {hourRentals?.map((rental) => {
+                const start = dayjs(rental.startAt)
+                const end = dayjs(rental.endAt)
+                const timeRange = `${start.format("HH:mm")} - ${end.format("HH:mm")}`
+                const userLabel =
+                  rental.users.length <= 1
+                    ? (rental.users[0]?.name ?? "")
+                    : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`
+
+                return (
+                  <div
+                    key={rental.id}
+                    className={`my-1 rounded-md bg-neutral-50 px-3 py-2 ${onRentalClick ? "cursor-pointer hover:bg-neutral-100" : ""}`}
+                    onClick={() => onRentalClick?.(rental)}
+                  >
+                    <div className="flex items-center gap-4 text-gray-500">
+                      <div className="flex items-center gap-1.5">
+                        <Clock size={12} />
+                        <span className="text-[11px]">{timeRange}</span>
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <UserRound size={12} />
+                        <span className="text-[11px]">{userLabel}</span>
+                      </div>
+                    </div>
+                    <span className="mt-0.5 block text-sm font-bold text-zinc-700">
+                      {rental.title}
+                    </span>
+                  </div>
+                )
+              })}
             </div>
           </div>
         )

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
@@ -5,11 +5,15 @@ import MobileMonthBlock from "./MobileMonthBlock"
 interface MobileCalendarFieldProps {
   currentMonday: Dayjs
   rentals: RentalDetail[]
+  onDateSelect?: (date: Dayjs) => void
+  selectedDate?: Dayjs | null
 }
 
 export default function MobileCalendarField({
   currentMonday,
-  rentals
+  rentals,
+  onDateSelect,
+  selectedDate
 }: MobileCalendarFieldProps) {
   const DayLabel = ["S", "M", "T", "W", "T", "F", "S"]
 
@@ -30,11 +34,11 @@ export default function MobileCalendarField({
     daysInGrid.push(d)
   }
   return (
-    <div className="w-full h-auto px-2 relative flex flex-col mx-auto bg-white pt-16 pb-5">
-      <div className="w-full flex">
+    <div className="relative mx-auto flex w-full flex-col bg-white px-4 pb-4 pt-16">
+      <div className="flex w-full">
         {DayLabel.map((Day, i) => (
           <div
-            className="flex-1 font-medium h-11 flex justify-center items-center text-base text-secondary"
+            className="flex h-10 flex-1 items-center justify-center text-[15px] font-semibold text-blue-600"
             key={i}
           >
             {Day}
@@ -45,6 +49,8 @@ export default function MobileCalendarField({
         days={daysInGrid}
         currentMonth={currentMonth}
         rentals={rentals}
+        onSelect={onDateSelect}
+        selectedDate={selectedDate}
       />
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/index.tsx
@@ -34,7 +34,7 @@ export default function MobileCalendarField({
     daysInGrid.push(d)
   }
   return (
-    <div className="relative mx-auto flex w-full flex-col bg-white px-4 pb-4 pt-16">
+    <div className="relative mx-auto flex w-full flex-col bg-white px-4 pb-4 pt-20">
       <div className="flex w-full">
         {DayLabel.map((Day, i) => (
           <div

--- a/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/index.tsx
@@ -31,7 +31,7 @@ export default function MonthCalendarField({
   }
 
   return (
-    <div className="w-full mt-7 flex flex-col bg-white">
+    <div className="w-full mt-7 flex flex-col bg-white rounded-xl overflow-hidden">
       {/* 요일 헤더 */}
       <div className="w-full flex">
         {WeekLabelList.map((label) => (

--- a/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MyReservationField/index.tsx
@@ -38,11 +38,11 @@ export default function MyReservationField({
   const currentMonth = monthNames[new Date().getMonth()]
 
   return (
-    <div className="w-full bg-white h-full py-7 px-5 rounded-[12px]">
-      <div className="justify-start mb-4 text-Zinc-700 text-xl font-semibold">
+    <div className="w-full bg-white h-full py-7 px-5 rounded-xl shadow-sm">
+      <div className="justify-start mb-4 text-zinc-700 text-[22px] font-semibold leading-tight">
         나의 예약현황
       </div>
-      <span className="justify-center text-gray-600 text-base font-semibold leading-none">
+      <span className="text-gray-600 text-base font-semibold leading-none">
         {currentMonth}
       </span>
       <div className="w-full flex flex-col pt-3 gap-[10px]">

--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -29,52 +29,82 @@ export default function RentalDetailModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md rounded-2xl border-0 bg-green-50 p-6">
-        <DialogHeader>
-          <DialogTitle className="text-lg font-bold text-foreground">
+      <DialogContent
+        className="max-w-[486px] rounded-3xl border-0 p-6 gap-4"
+        style={{
+          backgroundColor: "#F0FDF4",
+          boxShadow:
+            "0px 4px 6px 0px rgba(0, 0, 0, 0.05), 0px 4px 50px 0px rgba(0, 0, 0, 0.08)"
+        }}
+      >
+        <DialogHeader className="flex-row items-center justify-between gap-1.5">
+          <DialogTitle
+            className="text-2xl font-semibold"
+            style={{ color: "#14532D" }}
+          >
             {rental.title}
           </DialogTitle>
         </DialogHeader>
 
-        {/* Time */}
-        <div className="flex items-center gap-4">
+        {/* Time section */}
+        <div className="flex items-center justify-between gap-3 px-1.5">
+          {/* From */}
           <div className="flex items-center gap-2">
-            <Clock size={16} className="text-muted-foreground" />
-            <div className="text-left">
-              <p className="text-xl font-semibold">{start.format("HH:mm")}</p>
-              <p className="text-xs text-muted-foreground">
+            <Clock size={24} className="shrink-0 text-white" />
+            <div>
+              <p className="text-xl font-bold" style={{ color: "#374151" }}>
+                {start.format("HH:mm")}
+              </p>
+              <p className="text-xs font-normal" style={{ color: "#4B5563" }}>
                 {start.format("dddd, MMMM DD, YYYY")}
               </p>
             </div>
           </div>
-          <ArrowRight size={18} className="text-muted-foreground" />
-          <div className="text-left">
-            <p className="text-xl font-semibold">{end.format("HH:mm")}</p>
-            <p className="text-xs text-muted-foreground">
-              {end.format("dddd, MMMM DD, YYYY")}
-            </p>
+
+          {/* Arrow */}
+          <ArrowRight size={32} className="shrink-0 text-white" />
+
+          {/* To */}
+          <div className="flex items-center gap-2">
+            <Clock size={24} className="shrink-0 text-white" />
+            <div>
+              <p className="text-xl font-bold" style={{ color: "#374151" }}>
+                {end.format("HH:mm")}
+              </p>
+              <p className="text-xs font-normal" style={{ color: "#4B5563" }}>
+                {end.format("dddd, MMMM DD, YYYY")}
+              </p>
+            </div>
           </div>
         </div>
 
         {/* Participants */}
         {rental.users && rental.users.length > 0 && (
           <div className="space-y-2">
-            <p className="text-sm font-medium text-muted-foreground">
+            <p className="text-sm font-medium" style={{ color: "#71717A" }}>
               Participants
             </p>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex justify-between gap-1.5">
               {rental.users.map((user) => (
                 <div
                   key={user.id}
-                  className="flex items-center gap-1.5 rounded-full border bg-background px-2.5 py-1"
+                  className="flex items-center gap-1 rounded-lg border px-2 py-1.5"
+                  style={{
+                    borderColor: "rgba(197, 197, 197, 0.5)",
+                    borderWidth: "0.5px",
+                    width: 140
+                  }}
                 >
-                  <Avatar className="h-6 w-6">
+                  <Avatar className="h-6 w-6 shrink-0">
                     {user.image && <AvatarImage src={user.image} />}
                     <AvatarFallback className="text-[10px]">
                       {user.name?.slice(0, 2)}
                     </AvatarFallback>
                   </Avatar>
-                  <span className="max-w-[80px] truncate text-xs">
+                  <span
+                    className="truncate text-xs font-medium"
+                    style={{ color: "#7E7E7E" }}
+                  >
                     {user.name}
                   </span>
                 </div>

--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -29,14 +29,7 @@ export default function RentalDetailModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="max-w-[486px] rounded-3xl border-0 p-6 gap-4"
-        style={{
-          backgroundColor: "#F0FDF4",
-          boxShadow:
-            "0px 4px 6px 0px rgba(0, 0, 0, 0.05), 0px 4px 50px 0px rgba(0, 0, 0, 0.08)"
-        }}
-      >
+      <DialogContent className="max-w-[486px] rounded-3xl border-0 bg-[#F0FDF4] p-6 gap-4 shadow-[0px_4px_6px_0px_rgba(0,0,0,0.05),0px_4px_50px_0px_rgba(0,0,0,0.08)]">
         <DialogHeader className="flex-row items-center justify-between gap-1.5">
           <DialogTitle
             className="text-2xl font-semibold"

--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -43,7 +43,11 @@ export default function RentalDetailModal({
         <div className="flex items-center justify-between gap-3 px-1.5">
           {/* From */}
           <div className="flex items-center gap-2">
-            <Clock size={24} className="shrink-0 text-white" />
+            <Clock
+              size={24}
+              className="shrink-0"
+              style={{ color: "#15803D" }}
+            />
             <div>
               <p className="text-xl font-bold" style={{ color: "#374151" }}>
                 {start.format("HH:mm")}
@@ -55,11 +59,19 @@ export default function RentalDetailModal({
           </div>
 
           {/* Arrow */}
-          <ArrowRight size={32} className="shrink-0 text-white" />
+          <ArrowRight
+            size={32}
+            className="shrink-0"
+            style={{ color: "#15803D" }}
+          />
 
           {/* To */}
           <div className="flex items-center gap-2">
-            <Clock size={24} className="shrink-0 text-white" />
+            <Clock
+              size={24}
+              className="shrink-0"
+              style={{ color: "#15803D" }}
+            />
             <div>
               <p className="text-xl font-bold" style={{ color: "#374151" }}>
                 {end.format("HH:mm")}

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
@@ -1,4 +1,5 @@
 import dayjs, { Dayjs } from "dayjs"
+import { Clock, UserRound } from "lucide-react"
 import { RentalDetail } from "@repo/shared-types"
 import { getRentalColor } from "../rentalColors"
 
@@ -84,14 +85,31 @@ export default function WeekColumn({
             title={`${rental.title}\n${start.format("h:mmA")} - ${end.format("h:mmA")}`}
             onClick={() => onRentalClick?.(rental)}
           >
+            {heightPx > 30 && (
+              <div
+                className={`flex items-center gap-0.5 text-[10px] ${color.text} opacity-70`}
+              >
+                <Clock size={10} className="shrink-0" />
+                <span>
+                  {start.format("h:mmA")} - {end.format("h:mmA")}
+                </span>
+              </div>
+            )}
+            {heightPx > 45 && rental.users.length > 0 && (
+              <div
+                className={`flex items-center gap-0.5 text-[10px] ${color.text} opacity-70`}
+              >
+                <UserRound size={10} className="shrink-0" />
+                <span className="truncate">
+                  {rental.users.length <= 1
+                    ? (rental.users[0]?.name ?? "")
+                    : `${rental.users[0]?.name} 외 ${rental.users.length - 1}명`}
+                </span>
+              </div>
+            )}
             <p className={`text-xs font-semibold ${color.text} truncate`}>
               {rental.title}
             </p>
-            {heightPx > 30 && (
-              <p className={`text-[10px] ${color.text} opacity-70`}>
-                {start.format("h:mmA")} - {end.format("h:mmA")}
-              </p>
-            )}
           </div>
         )
       })}

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
@@ -26,7 +26,15 @@ export default function WeekColumn({
   const dayNumber = date.format("D")
   const isToday = date.isSame(new Date(), "day")
 
-  const dayRentals = rentals.filter((r) => dayjs(r.startAt).isSame(date, "day"))
+  // 해당 날짜에 걸치는 모든 이벤트 (당일 시작 + 전날 시작~오늘 종료)
+  const dayRentals = rentals.filter((r) => {
+    const s = dayjs(r.startAt)
+    const e = dayjs(r.endAt)
+    return (
+      s.isSame(date, "day") ||
+      (s.isBefore(date, "day") && e.isAfter(date.startOf("day")))
+    )
+  })
 
   return (
     <div className="w-[14.28%] relative overflow-hidden border-x-[1.5px] border-gray-100">
@@ -55,13 +63,14 @@ export default function WeekColumn({
         const start = dayjs(rental.startAt)
         const end = dayjs(rental.endAt)
         const totalMin = 16 * 60 // 6AM~10PM
-        const startMin = Math.max(
-          0,
-          (start.hour() - START_HOUR) * 60 + start.minute()
-        )
-        const endMin = end.isSame(date, "day")
-          ? Math.min(totalMin, (end.hour() - START_HOUR) * 60 + end.minute())
-          : totalMin // 다음 날로 넘어가는 이벤트는 끝까지 표시
+        const rawStartMin = start.isSame(date, "day")
+          ? (start.hour() - START_HOUR) * 60 + start.minute()
+          : 0 // 전날부터 이어지는 이벤트는 하루 시작부터
+        const startMin = Math.max(0, rawStartMin)
+        const rawEndMin = end.isSame(date, "day")
+          ? (end.hour() - START_HOUR) * 60 + end.minute()
+          : totalMin // 다음 날로 넘어가는 이벤트는 끝까지
+        const endMin = Math.max(0, Math.min(totalMin, rawEndMin))
         if (endMin <= startMin) return null
         const topPx = HEADER_PX + (startMin * PX_PER_HOUR) / 60
         const heightPx = ((endMin - startMin) * PX_PER_HOUR) / 60

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -36,7 +36,7 @@ export default function WeekCalendarField({
     hour12: true
   })
   return (
-    <div className="w-full mt-7 flex bg-white">
+    <div className="w-full mt-7 flex bg-white rounded-xl overflow-hidden">
       <div className="w-7 flex flex-col">
         {Array.from({ length: 16 }).map((_, i) => {
           const hour = (i + 6) % 12 === 0 ? 12 : (i + 6) % 12

--- a/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
@@ -169,8 +169,8 @@ export default function ClubroomReservationPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "schedule"
-                ? "bg-blue-600 text-white shadow-sm"
-                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
+                ? "bg-primary text-primary-foreground"
+                : "bg-white text-gray-400"
             }`}
             onClick={() => setMobileTab("schedule")}
           >
@@ -179,8 +179,8 @@ export default function ClubroomReservationPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "my"
-                ? "bg-blue-600 text-white shadow-sm"
-                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
+                ? "bg-primary text-primary-foreground"
+                : "bg-white text-gray-400"
             }`}
             onClick={() => setMobileTab("my")}
           >

--- a/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
@@ -165,12 +165,12 @@ export default function ClubroomReservationPage() {
         />
 
         {/* Mobile tab buttons (pill style matching Figma) */}
-        <div className="flex gap-2 px-4 py-3">
+        <div className="flex gap-2 px-4 py-4">
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "schedule"
-                ? "bg-blue-600 text-white"
-                : "bg-white text-neutral-700 hover:bg-gray-100"
+                ? "bg-blue-600 text-white shadow-sm"
+                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
             }`}
             onClick={() => setMobileTab("schedule")}
           >
@@ -179,8 +179,8 @@ export default function ClubroomReservationPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "my"
-                ? "bg-blue-600 text-white"
-                : "bg-white text-neutral-700 hover:bg-gray-100"
+                ? "bg-blue-600 text-white shadow-sm"
+                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
             }`}
             onClick={() => setMobileTab("my")}
           >

--- a/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
@@ -73,7 +73,7 @@ export default function ClubroomReservationPage() {
   const equipmentList = equipments ?? []
 
   return (
-    <div>
+    <div className="bg-neutral-50 -mx-6 px-6 md:-mx-0 md:px-0">
       <DefaultPageHeader
         title="동아리방 예약"
         routes={[
@@ -84,13 +84,13 @@ export default function ClubroomReservationPage() {
       />
       {/* PC 페이지 */}
       <div className="hidden w-full min-h-[739px] gap-5 md:flex">
-        <div className="w-1/4">
+        <div className="w-[280px] shrink-0">
           <MyReservationField
             rentals={rentalList}
             onRentalClick={setSelectedRental}
           />
         </div>
-        <div className="w-3/4">
+        <div className="flex-1 min-w-0">
           <Tabs value={view} onValueChange={(v) => setView(v as typeof view)}>
             <TabsList>
               <TabsTrigger value="week">Week</TabsTrigger>

--- a/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
@@ -13,21 +13,30 @@ import { useQueryState, parseAsStringLiteral } from "nuqs"
 import WeekLabel from "../../_components/WeekLable"
 import MonthCalendarField from "../../_components/MonthCalendarField"
 import MobileCalendarField from "../../_components/MobileCalendarField"
+import MobileTimeSlots from "../../_components/MobileCalendarField/MobileTimeSlots"
+import MobileMyReservations from "../../_components/MobileCalendarField/MobileMyReservations"
 import { useRentals } from "@/hooks/api/useRental"
 import { useEquipments } from "@/hooks/api/useEquipment"
 import { RentalDetail } from "@repo/shared-types"
 import RentalDetailModal from "../../_components/RentalDetailModal"
+import { Dayjs } from "dayjs"
 
 const viewOptions = ["week", "month"] as const
+const mobileTabOptions = ["schedule", "my"] as const
 
 export default function ClubroomReservationPage() {
   const [view, setView] = useQueryState(
     "view",
     parseAsStringLiteral(viewOptions).withDefault("week")
   )
+  const [mobileTab, setMobileTab] = useQueryState(
+    "tab",
+    parseAsStringLiteral(mobileTabOptions).withDefault("schedule")
+  )
   const [selectedRental, setSelectedRental] = useState<RentalDetail | null>(
     null
   )
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs())
   const getWeekStart = (date = dayjs()) => date.startOf("week")
 
   const [currentMonday, setCurrentMonday] = useState(getWeekStart())
@@ -74,7 +83,7 @@ export default function ClubroomReservationPage() {
         ]}
       />
       {/* PC 페이지 */}
-      <div className={`w-full min-h-[739px] hidden md:flex gap-5`}>
+      <div className="hidden w-full min-h-[739px] gap-5 md:flex">
         <div className="w-1/4">
           <MyReservationField
             rentals={rentalList}
@@ -133,11 +142,15 @@ export default function ClubroomReservationPage() {
           </Tabs>
         </div>
       </div>
+
       {/* 모바일 페이지 */}
-      <div className="max-w-[400px] relative md:hidden mx-auto pt-6">
+      <div className="relative mx-auto max-w-[400px] md:hidden">
+        {/* Calendar with month navigation */}
         <MobileCalendarField
           currentMonday={currentMonday}
           rentals={rentalList}
+          onDateSelect={setSelectedDate}
+          selectedDate={selectedDate}
         />
         <WeekLabel
           weekLabel={weekLabel}
@@ -148,8 +161,48 @@ export default function ClubroomReservationPage() {
           monthLabel={monthLabel}
           daysInCalendar={daysInCalendar}
           mode="month"
-          className="top-12 flex justify-between w-full px-5"
+          className="top-12 flex w-full justify-between px-5"
         />
+
+        {/* Mobile tab buttons (pill style matching Figma) */}
+        <div className="flex gap-2 px-4 py-3">
+          <button
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+              mobileTab === "schedule"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-neutral-700 hover:bg-gray-100"
+            }`}
+            onClick={() => setMobileTab("schedule")}
+          >
+            예약 현황
+          </button>
+          <button
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+              mobileTab === "my"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-neutral-700 hover:bg-gray-100"
+            }`}
+            onClick={() => setMobileTab("my")}
+          >
+            나의 예약
+          </button>
+        </div>
+
+        {/* Mobile tab content */}
+        <div className="bg-white px-3 pb-20">
+          {mobileTab === "schedule" ? (
+            <MobileTimeSlots
+              selectedDate={selectedDate}
+              rentals={rentalList}
+              onRentalClick={setSelectedRental}
+            />
+          ) : (
+            <MobileMyReservations
+              rentals={rentalList}
+              onRentalClick={setSelectedRental}
+            />
+          )}
+        </div>
       </div>
 
       <RentalDetailModal

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -187,8 +187,8 @@ export default function EquipmentCalendarPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "schedule"
-                ? "bg-blue-600 text-white shadow-sm"
-                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
+                ? "bg-primary text-primary-foreground"
+                : "bg-white text-gray-400"
             }`}
             onClick={() => setMobileTab("schedule")}
           >
@@ -197,8 +197,8 @@ export default function EquipmentCalendarPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "my"
-                ? "bg-blue-600 text-white shadow-sm"
-                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
+                ? "bg-primary text-primary-foreground"
+                : "bg-white text-gray-400"
             }`}
             onClick={() => setMobileTab("my")}
           >

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -183,12 +183,12 @@ export default function EquipmentCalendarPage() {
         />
 
         {/* Mobile tabs */}
-        <div className="flex gap-2 px-4 py-3">
+        <div className="flex gap-2 px-4 py-4">
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "schedule"
-                ? "bg-blue-600 text-white"
-                : "bg-white text-neutral-700 hover:bg-gray-100"
+                ? "bg-blue-600 text-white shadow-sm"
+                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
             }`}
             onClick={() => setMobileTab("schedule")}
           >
@@ -197,8 +197,8 @@ export default function EquipmentCalendarPage() {
           <button
             className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
               mobileTab === "my"
-                ? "bg-blue-600 text-white"
-                : "bg-white text-neutral-700 hover:bg-gray-100"
+                ? "bg-blue-600 text-white shadow-sm"
+                : "border border-gray-200 bg-white text-neutral-500 hover:bg-gray-50"
             }`}
             onClick={() => setMobileTab("my")}
           >

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -81,7 +81,7 @@ export default function EquipmentCalendarPage() {
     : "로딩 중..."
 
   return (
-    <div>
+    <div className="bg-neutral-50 -mx-6 px-6 md:-mx-0 md:px-0">
       <DefaultPageHeader
         title="물품 대여"
         routes={[
@@ -105,13 +105,13 @@ export default function EquipmentCalendarPage() {
 
       {/* PC layout */}
       <div className="hidden w-full min-h-[739px] gap-5 md:flex">
-        <div className="w-1/4">
+        <div className="w-[280px] shrink-0">
           <MyReservationField
             rentals={rentalList}
             onRentalClick={setSelectedRental}
           />
         </div>
-        <div className="w-3/4">
+        <div className="flex-1 min-w-0">
           <Tabs value={view} onValueChange={(v) => setView(v as typeof view)}>
             <TabsList>
               <TabsTrigger value="week">Week</TabsTrigger>

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useQueryState, parseAsStringLiteral } from "nuqs"
 import { useParams } from "next/navigation"
 import Link from "next/link"
-import dayjs from "dayjs"
+import dayjs, { Dayjs } from "dayjs"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import DefaultPageHeader, {
@@ -19,19 +19,27 @@ import WeekCalendarField from "../../../_components/WeekCalendarField"
 import WeekLabel from "../../../_components/WeekLable"
 import MonthCalendarField from "../../../_components/MonthCalendarField"
 import MobileCalendarField from "../../../_components/MobileCalendarField"
+import MobileTimeSlots from "../../../_components/MobileCalendarField/MobileTimeSlots"
+import MobileMyReservations from "../../../_components/MobileCalendarField/MobileMyReservations"
 import RentalDetailModal from "../../../_components/RentalDetailModal"
 import { RentalDetail } from "@repo/shared-types"
 
 const viewOptions = ["week", "month"] as const
+const mobileTabOptions = ["schedule", "my"] as const
 
 export default function EquipmentCalendarPage() {
   const [view, setView] = useQueryState(
     "view",
     parseAsStringLiteral(viewOptions).withDefault("week")
   )
+  const [mobileTab, setMobileTab] = useQueryState(
+    "tab",
+    parseAsStringLiteral(mobileTabOptions).withDefault("schedule")
+  )
   const [selectedRental, setSelectedRental] = useState<RentalDetail | null>(
     null
   )
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs())
   const params = useParams()
   const equipmentId = Number(params.id)
   const { data: equipmentDetail } = useEquipment(equipmentId)
@@ -155,10 +163,12 @@ export default function EquipmentCalendarPage() {
       </div>
 
       {/* Mobile layout */}
-      <div className="relative mx-auto max-w-[400px] pt-6 md:hidden">
+      <div className="relative mx-auto max-w-[400px] md:hidden">
         <MobileCalendarField
           currentMonday={currentMonday}
           rentals={rentalList}
+          onDateSelect={setSelectedDate}
+          selectedDate={selectedDate}
         />
         <WeekLabel
           weekLabel={weekLabel}
@@ -171,6 +181,46 @@ export default function EquipmentCalendarPage() {
           mode="month"
           className="top-12 flex w-full justify-between px-5"
         />
+
+        {/* Mobile tabs */}
+        <div className="flex gap-2 px-4 py-3">
+          <button
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+              mobileTab === "schedule"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-neutral-700 hover:bg-gray-100"
+            }`}
+            onClick={() => setMobileTab("schedule")}
+          >
+            예약 현황
+          </button>
+          <button
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+              mobileTab === "my"
+                ? "bg-blue-600 text-white"
+                : "bg-white text-neutral-700 hover:bg-gray-100"
+            }`}
+            onClick={() => setMobileTab("my")}
+          >
+            나의 예약
+          </button>
+        </div>
+
+        {/* Mobile tab content */}
+        <div className="bg-white px-3 pb-20">
+          {mobileTab === "schedule" ? (
+            <MobileTimeSlots
+              selectedDate={selectedDate}
+              rentals={rentalList}
+              onRentalClick={setSelectedRental}
+            />
+          ) : (
+            <MobileMyReservations
+              rentals={rentalList}
+              onRentalClick={setSelectedRental}
+            />
+          )}
+        </div>
       </div>
 
       <RentalDetailModal

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { Equipment } from "@repo/shared-types"
 import { EquipCategory } from "@repo/database"
-import { MoreVertical, Pencil, ScanSearch, Search, Trash2 } from "lucide-react"
+import { Check, MoreVertical, ScanSearch, Search } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
@@ -111,16 +111,21 @@ export default function EquipmentCard({
                   <MoreVertical size={16} />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onEdit?.(equipment)}>
-                  <Pencil size={14} />
+              <DropdownMenuContent
+                align="end"
+                className="w-[136px] rounded-xl p-1"
+              >
+                <DropdownMenuItem
+                  onClick={() => onEdit?.(equipment)}
+                  className="justify-center text-sm font-medium"
+                >
                   수정하기
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => onDelete?.(equipment)}
-                  className="text-destructive focus:text-destructive"
+                  className="justify-center text-sm font-medium"
                 >
-                  <Trash2 size={14} />
+                  <Check size={14} className="mr-1" />
                   삭제하기
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { Equipment } from "@repo/shared-types"
 import { EquipCategory } from "@repo/database"
-import { Check, MoreVertical, ScanSearch, Search } from "lucide-react"
+import { MoreVertical, ScanSearch, Search } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
@@ -127,9 +127,8 @@ export default function EquipmentCard({
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => onDelete?.(equipment)}
-                  className="justify-center text-sm font-medium"
+                  className="justify-center text-sm font-medium text-destructive focus:text-destructive"
                 >
-                  <Check size={14} className="mr-1" />
                   삭제하기
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
@@ -71,7 +71,7 @@ export default function EquipmentCard({
                     e.stopPropagation()
                     setImageOpen(true)
                   }}
-                  className="absolute bottom-1 right-1 rounded-full bg-white/90 p-1 text-slate-800 opacity-0 shadow-md transition-opacity group-hover/img:opacity-100"
+                  className="absolute bottom-1 right-1 hidden rounded-full bg-white/90 p-1 text-slate-800 shadow-md transition-opacity group-hover/img:opacity-100 md:block md:opacity-0"
                 >
                   <ScanSearch size={14} />
                 </button>
@@ -95,9 +95,13 @@ export default function EquipmentCard({
             </h3>
             <div className="mt-1 grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-sm">
               <span className="text-muted-foreground">모델명</span>
-              <span className="truncate">{equipment.model}</span>
+              <span className="truncate text-right md:text-left">
+                {equipment.model}
+              </span>
               <span className="text-muted-foreground">설명</span>
-              <span className="truncate">{equipment.description || "-"}</span>
+              <span className="truncate text-right md:text-left">
+                {equipment.description || "-"}
+              </span>
             </div>
           </div>
         </Link>

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
@@ -138,15 +138,15 @@ export default function EquipmentFormModal({
         onOpenChange(value)
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md rounded-2xl">
         <DialogHeader>
-          <DialogTitle className="text-lg font-bold">
+          <DialogTitle className="text-xl font-bold">
             {isEditing ? "장비 수정" : "장비 추가"}
           </DialogTitle>
           <DialogDescription>
             {isEditing
-              ? "수정할 장비의 정보를 입력해주세요"
-              : "추가할 장비의 정보를 입력해주세요"}
+              ? "수정할 장비의 정보를 입력해 주세요"
+              : "추가할 장비의 정보를 입력해 주세요"}
           </DialogDescription>
         </DialogHeader>
 
@@ -224,16 +224,18 @@ export default function EquipmentFormModal({
 
             {/* TODO: 장비 이미지 업로드 (백엔드 이미지 업로드 구현 후) */}
 
-            <div className="flex justify-end gap-2 pt-2">
+            <div className="flex justify-center gap-3 pt-2">
               <Button
                 type="button"
                 variant="outline"
+                className="w-28"
                 onClick={() => onOpenChange(false)}
               >
                 취소
               </Button>
               <Button
                 type="submit"
+                className="w-28"
                 disabled={
                   createEquipment.isPending || updateEquipment.isPending
                 }

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
@@ -133,7 +133,7 @@ export default function EquipmentListPage() {
   }
 
   return (
-    <div>
+    <div className="bg-neutral-50 -mx-6 px-6 md:-mx-0 md:px-0">
       <DefaultPageHeader
         title="물품 대여"
         routes={[
@@ -144,7 +144,7 @@ export default function EquipmentListPage() {
       />
 
       {/* Toolbar: Filter + Admin Add + Search */}
-      <div className="mb-6 flex items-center justify-between gap-4">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
@@ -171,7 +171,7 @@ export default function EquipmentListPage() {
         <div className="relative w-full max-w-xs">
           <Search
             size={16}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
           />
           <Input
             placeholder="검색"
@@ -180,7 +180,7 @@ export default function EquipmentListPage() {
               setSearch(e.target.value || null)
               setPage(1)
             }}
-            className="pl-9 rounded-full"
+            className="h-11 pl-9 rounded-full border-gray-200 text-sm placeholder:text-gray-400"
           />
         </div>
       </div>

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
@@ -144,7 +144,8 @@ export default function EquipmentListPage() {
       />
 
       {/* Toolbar: Filter + Admin Add + Search */}
-      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      {/* Desktop toolbar */}
+      <div className="mb-6 hidden flex-col gap-3 sm:flex sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
@@ -181,6 +182,47 @@ export default function EquipmentListPage() {
               setPage(1)
             }}
             className="h-11 pl-9 rounded-full border-gray-200 text-sm placeholder:text-gray-400"
+          />
+        </div>
+      </div>
+      {/* Mobile toolbar */}
+      <div className="mb-4 flex flex-col gap-2 sm:hidden">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            onClick={() => setFilterOpen(true)}
+          >
+            <Filter size={16} />
+          </Button>
+          {isAdmin && (
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              onClick={() => {
+                setEditingEquipment(null)
+                setFormOpen(true)
+              }}
+            >
+              <Plus size={16} />
+            </Button>
+          )}
+        </div>
+        <div className="relative w-full">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          />
+          <Input
+            placeholder="검색"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value || null)
+              setPage(1)
+            }}
+            className="h-11 w-full pl-9 rounded-full border-gray-200 text-sm placeholder:text-gray-400"
           />
         </div>
       </div>
@@ -285,7 +327,10 @@ export default function EquipmentListPage() {
           {Array.from({ length: totalPages }, (_, i) => i + 1)
             .filter((p) => {
               if (p === 1 || p === totalPages) return true
-              return Math.abs(p - currentPage) <= 2
+              // Show fewer page numbers on mobile (±1) vs desktop (±2)
+              const range =
+                typeof window !== "undefined" && window.innerWidth < 640 ? 1 : 2
+              return Math.abs(p - currentPage) <= range
             })
             .reduce<(number | "...")[]>((acc, p, i, arr) => {
               if (i > 0 && p - (arr[i - 1] ?? 0) > 1) acc.push("...")

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
@@ -59,6 +59,9 @@ export default function EquipmentListPage() {
   const [filterOpen, setFilterOpen] = useState(false)
   const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1))
 
+  // Mobile search toggle
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false)
+
   // Equipment form modal state
   const [formOpen, setFormOpen] = useState(false)
   const [editingEquipment, setEditingEquipment] = useState<Equipment | null>(
@@ -185,46 +188,51 @@ export default function EquipmentListPage() {
           />
         </div>
       </div>
-      {/* Mobile toolbar */}
-      <div className="mb-4 flex flex-col gap-2 sm:hidden">
-        <div className="flex items-center gap-2">
+      {/* Mobile toolbar — icon-only buttons right-aligned */}
+      <div className="mb-4 flex items-center justify-end gap-2 sm:hidden">
+        {mobileSearchOpen ? (
+          <div className="relative flex-1 min-w-0">
+            <Search
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <Input
+              autoFocus
+              placeholder="검색"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value || null)
+                setPage(1)
+              }}
+              onBlur={() => {
+                if (!search) setMobileSearchOpen(false)
+              }}
+              className="h-9 w-full pl-9 rounded-full border-gray-200 text-sm placeholder:text-gray-400"
+            />
+          </div>
+        ) : (
           <Button
-            variant="outline"
+            variant="ghost"
             size="icon"
             className="h-9 w-9 shrink-0"
-            onClick={() => setFilterOpen(true)}
+            onClick={() => setMobileSearchOpen(true)}
           >
-            <Filter size={16} />
+            <Search size={18} />
           </Button>
-          {isAdmin && (
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-9 w-9 shrink-0"
-              onClick={() => {
-                setEditingEquipment(null)
-                setFormOpen(true)
-              }}
-            >
-              <Plus size={16} />
-            </Button>
-          )}
-        </div>
-        <div className="relative w-full">
-          <Search
-            size={16}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-          />
-          <Input
-            placeholder="검색"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value || null)
-              setPage(1)
+        )}
+        {isAdmin && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            onClick={() => {
+              setEditingEquipment(null)
+              setFormOpen(true)
             }}
-            className="h-11 w-full pl-9 rounded-full border-gray-200 text-sm placeholder:text-gray-400"
-          />
-        </div>
+          >
+            <Plus size={18} />
+          </Button>
+        )}
       </div>
 
       {/* Equipment Grid */}
@@ -302,9 +310,9 @@ export default function EquipmentListPage() {
         </div>
       )}
 
-      {/* Pagination */}
+      {/* Desktop Pagination — numbered buttons */}
       {totalPages > 1 && (
-        <div className="mt-8 flex items-center justify-center gap-1">
+        <div className="mt-8 hidden items-center justify-center gap-1 sm:flex">
           <Button
             variant="ghost"
             size="icon"
@@ -327,10 +335,7 @@ export default function EquipmentListPage() {
           {Array.from({ length: totalPages }, (_, i) => i + 1)
             .filter((p) => {
               if (p === 1 || p === totalPages) return true
-              // Show fewer page numbers on mobile (±1) vs desktop (±2)
-              const range =
-                typeof window !== "undefined" && window.innerWidth < 640 ? 1 : 2
-              return Math.abs(p - currentPage) <= range
+              return Math.abs(p - currentPage) <= 2
             })
             .reduce<(number | "...")[]>((acc, p, i, arr) => {
               if (i > 0 && p - (arr[i - 1] ?? 0) > 1) acc.push("...")
@@ -375,6 +380,33 @@ export default function EquipmentListPage() {
             onClick={() => setPage(totalPages)}
           >
             <ChevronsRight size={16} />
+          </Button>
+        </div>
+      )}
+
+      {/* Mobile Pagination — simple "< Page X of Y >" */}
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-center gap-3 sm:hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            disabled={currentPage === 1}
+            onClick={() => setPage(Math.max(1, currentPage - 1))}
+          >
+            <ChevronLeft size={16} />
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page&nbsp;&nbsp;{currentPage}&nbsp;&nbsp;of {totalPages}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            disabled={currentPage === totalPages}
+            onClick={() => setPage(Math.min(totalPages, currentPage + 1))}
+          >
+            <ChevronRight size={16} />
           </Button>
         </div>
       )}

--- a/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
+++ b/apps/web/components/PageHeaders/Default/BreadCrumb.tsx
@@ -28,7 +28,7 @@ const DefaultPageHeaderBreadCrumb = ({
   const router = useRouter()
 
   return (
-    <div className="hidden items-center justify-center gap-x-0.5 text-xs font-medium text-slate-400 md:flex md:gap-x-1.5 md:text-base">
+    <div className="flex items-center justify-center gap-x-0.5 text-xs font-medium text-slate-400 md:gap-x-1.5 md:text-base">
       {routes.map((route, index) => (
         <React.Fragment key={index}>
           {route.dropdownItems ? (


### PR DESCRIPTION
## 🚀 작업 내용

동아리방 예약 / 물품 대여 페이지에 Figma 디자인 기반 모바일 레이아웃 구현
- 월간 캘린더 + "예약 현황" / "나의 예약" 탭 전환 기능 추가
- 브레드크럼 모바일 표시, 디자인 디테일 Figma 맞춤

### Mobile Layout (new)
- **MobileTimeSlots** — 선택된 날짜의 시간대별 예약 카드 표시 (06:00~21:00)
- **MobileMyReservations** — 로그인 사용자의 예약 목록 카드 뷰
- **MobileCalendarField** — 날짜 선택, 선택 상태 하이라이트 추가
- **MobileMonthBlock** — 선택/오늘 날짜 하이라이트, 이벤트 도트 스타일 개선

### Design Details (Figma match)
- 캘린더 요일 라벨(S M T W T F S) 파란색 강조
- 이벤트 도트 `#60A5FA` (blue-400)
- 탭 버튼 pill 스타일 (`rounded-full`, 활성: `bg-blue-600 text-white`)
- 시간 라벨 이벤트 있는 슬롯은 파란색 강조
- 브레드크럼 모바일에서도 표시 (`hidden md:flex` → `flex`)

## 📸 스크린샷(선택)

| Iteration | Changes |
|-----------|---------|
| 1 | 초기 모바일 레이아웃 구현 — 캘린더 + 탭 + 시간대 뷰 |
| 2 | 탭 버튼 pill 스타일, 브레드크럼 모바일 표시 |
| 3 | 캘린더 날짜 셀 크기/간격, 요일 라벨 파란색 조정 |
| 4 | 시간 슬롯 카드 레이아웃 Figma 맞춤 (아이콘+텍스트) |
| 5 | 최종 비교 — desktop/mobile 양쪽 확인, 빌드/린트 통과 |

## 🔗 관련 이슈

Closes #345

## 🙏 리뷰어에게

모바일 전용 컴포넌트(MobileTimeSlots, MobileMyReservations 등)가 새로 추가되었습니다. 데스크톱 레이아웃은 변경되지 않았습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.