### PR TITLE
fix(web): 장비 예약 생성 시 equipmentId 미설정 버그 수정

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useSession } from "next-auth/react"
 import { useQueryClient } from "@tanstack/react-query"
 import dayjs from "dayjs"
@@ -61,6 +61,13 @@ export default function AddScheduleButton({
   const [equipmentId, setEquipmentId] = useState<number | null>(
     equipments.length === 1 ? (equipments[0]?.id ?? null) : null
   )
+
+  // equipments prop이 비동기로 로딩될 때 equipmentId를 동기화
+  useEffect(() => {
+    if (equipments.length === 1 && equipmentId === null) {
+      setEquipmentId(equipments[0]?.id ?? null)
+    }
+  }, [equipments, equipmentId])
   const [title, setTitle] = useState("")
   const [startDate, setStartDate] = useState<Date | undefined>(undefined)
   const [endDate, setEndDate] = useState<Date | undefined>(undefined)
@@ -383,7 +390,7 @@ export default function AddScheduleButton({
 
             <div className="space-y-1.5">
               <label className="text-sm text-muted-foreground">Members</label>
-              <Select onValueChange={addUser} value="">
+              <Select onValueChange={addUser} value={undefined}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select" />
                 </SelectTrigger>


### PR DESCRIPTION
## 🚀 작업 내용

장비 상세 페이지(`/reservations/equipment/[id]`)에서 "Add schedule" 클릭 후 모든 필드를 채워도 예약이 생성되지 않는 버그 수정

**원인**: `equipments` prop이 비동기 로딩되면서 `useState(equipmentId)` 초기값이 `null`로 고정됨. 장비가 1개일 때 Select UI가 hidden이라 validation 에러도 사용자에게 보이지 않음 (silent fail)

**수정**:
- `useEffect`로 `equipments` prop 변경 시 `equipmentId` 동기화 추가
- Members Select `value=""` → `value={undefined}` (controlled/uncontrolled 전환 경고 수정)

## 📸 스크린샷(선택)

수정 후 장비 예약이 정상 생성되어 캘린더에 표시됨 (Playwright로 검증 완료)

## 🔗 관련 이슈

N/A

## 🙏 리뷰어에게

- `useEffect` deps에 `equipmentId`가 포함되어 있는데, 조건문 `equipmentId === null`이 있어 무한 루프는 발생하지 않습니다
- 동방 예약 페이지에서도 같은 `AddScheduleButton`을 공유하므로 동방 예약 생성도 함께 테스트했습니다

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.
