### PR TITLE
feat(web): 관리자 예약 관리 페이지 추가

### DIFF
--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  Calendar,
   LayoutDashboard,
   Menu,
   Music,
@@ -31,7 +32,8 @@ const NAV_ITEMS = [
   { href: ROUTES.ADMIN.GENERATIONS, label: "기수", icon: Hash },
   { href: ROUTES.ADMIN.PERFORMANCES, label: "공연", icon: Music },
   { href: ROUTES.ADMIN.TEAMS, label: "팀", icon: Mic },
-  { href: ROUTES.ADMIN.SESSIONS, label: "세션", icon: Guitar }
+  { href: ROUTES.ADMIN.SESSIONS, label: "세션", icon: Guitar },
+  { href: ROUTES.ADMIN.RENTALS, label: "예약", icon: Calendar }
 ]
 
 function NavLinks({ onNavigate }: { onNavigate?: () => void }) {

--- a/apps/web/app/(admin)/admin/rentals/_components/RentalFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/rentals/_components/RentalFormDialog.tsx
@@ -1,0 +1,259 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { useEquipments } from "@/hooks/api/useEquipment"
+import { useUsers } from "@/hooks/api/useUser"
+import { formatGenerationOrder } from "@/lib/utils"
+import {
+  CreateRental,
+  CreateRentalSchema,
+  RentalDetail
+} from "@repo/shared-types"
+
+interface RentalFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateRental) => void
+  editingRental?: RentalDetail | null
+  isPending?: boolean
+}
+
+function formatDatetimeLocal(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+export function RentalFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  editingRental,
+  isPending = false
+}: RentalFormDialogProps) {
+  const { data: equipments } = useEquipments()
+  const { data: users } = useUsers()
+  const isEditing = !!editingRental
+
+  const form = useForm<CreateRental>({
+    resolver: zodResolver(CreateRentalSchema),
+    defaultValues: {
+      title: "",
+      equipmentId: undefined,
+      startAt: undefined,
+      endAt: undefined,
+      userIds: []
+    }
+  })
+
+  useEffect(() => {
+    if (open && editingRental) {
+      form.reset({
+        title: editingRental.title,
+        equipmentId: editingRental.equipmentId,
+        startAt: editingRental.startAt,
+        endAt: editingRental.endAt,
+        userIds: editingRental.users.map((u) => u.id)
+      })
+    } else if (open) {
+      form.reset({
+        title: "",
+        equipmentId: undefined,
+        startAt: undefined,
+        endAt: undefined,
+        userIds: []
+      })
+    }
+  }, [open, editingRental, form])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? "예약 수정" : "예약 생성"}</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>예약명</FormLabel>
+                  <FormControl>
+                    <Input placeholder="예약명을 입력하세요" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="equipmentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>장비</FormLabel>
+                  <Select
+                    value={field.value?.toString() ?? ""}
+                    onValueChange={(v) => field.onChange(parseInt(v))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="장비를 선택하세요" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {equipments?.map((equipment) => (
+                        <SelectItem
+                          key={equipment.id}
+                          value={equipment.id.toString()}
+                        >
+                          {equipment.brand} {equipment.model}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="startAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>시작 시간</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="datetime-local"
+                      value={
+                        field.value instanceof Date
+                          ? formatDatetimeLocal(field.value)
+                          : (field.value ?? "")
+                      }
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? new Date(e.target.value) : undefined
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="endAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>종료 시간</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="datetime-local"
+                      value={
+                        field.value instanceof Date
+                          ? formatDatetimeLocal(field.value)
+                          : (field.value ?? "")
+                      }
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? new Date(e.target.value) : undefined
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="userIds"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>참여자</FormLabel>
+                  <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-3">
+                    {users?.map((user) => (
+                      <div key={user.id} className="flex items-center gap-2">
+                        <Checkbox
+                          id={`user-${user.id}`}
+                          checked={field.value?.includes(user.id) ?? false}
+                          onCheckedChange={(checked) => {
+                            const current = field.value ?? []
+                            if (checked) {
+                              field.onChange([...current, user.id])
+                            } else {
+                              field.onChange(
+                                current.filter((id) => id !== user.id)
+                              )
+                            }
+                          }}
+                        />
+                        <label
+                          htmlFor={`user-${user.id}`}
+                          className="cursor-pointer text-sm"
+                        >
+                          {user.name} ({user.nickname}){" "}
+                          {user.generation?.order !== undefined
+                            ? formatGenerationOrder(user.generation.order)
+                            : ""}
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "저장 중..." : isEditing ? "수정" : "생성"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
@@ -3,10 +3,12 @@
 import { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
 import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
+import { UserCell } from "@/app/(admin)/_components/data-table/UserCell"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -14,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
+import ROUTES from "@/constants/routes"
 import { RentalDetail } from "@repo/shared-types"
 
 interface ColumnActions {
@@ -52,37 +55,75 @@ export function getColumns(actions: ColumnActions): ColumnDef<RentalDetail>[] {
         <DataTableColumnHeader column={column} title="장비" />
       ),
       meta: { label: "장비" },
-      cell: ({ row }) =>
-        row.original.equipment
-          ? `${row.original.equipment.brand} ${row.original.equipment.model}`
-          : "-"
+      cell: ({ row }) => {
+        const eq = row.original.equipment
+        if (!eq) return "-"
+        const label = `${eq.brand} ${eq.model}`
+        return (
+          <Link
+            href={`${ROUTES.ADMIN.EQUIPMENTS}?rowId=${eq.id}`}
+            className="text-blue-600 hover:underline"
+          >
+            {label}
+          </Link>
+        )
+      }
     },
     {
       accessorKey: "startAt",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="시작 시간" />
       ),
-      meta: { label: "시작 시간" },
-      cell: ({ row }) =>
-        format(new Date(row.original.startAt), "yyyy-MM-dd HH:mm")
+      meta: { label: "시작 시간", editable: { type: "date" as const } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            ctx.row.original.startAt
+              ? format(new Date(ctx.row.original.startAt), "yyyy-MM-dd HH:mm")
+              : "-"
+          }
+        />
+      )
     },
     {
       accessorKey: "endAt",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="종료 시간" />
       ),
-      meta: { label: "종료 시간" },
-      cell: ({ row }) =>
-        format(new Date(row.original.endAt), "yyyy-MM-dd HH:mm")
+      meta: { label: "종료 시간", editable: { type: "date" as const } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            ctx.row.original.endAt
+              ? format(new Date(ctx.row.original.endAt), "yyyy-MM-dd HH:mm")
+              : "-"
+          }
+        />
+      )
     },
     {
-      id: "participantCount",
+      id: "participants",
       accessorFn: (row) => row.users.length,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="참여자 수" />
+        <DataTableColumnHeader column={column} title="참여자" />
       ),
-      meta: { label: "참여자 수" },
-      cell: ({ row }) => `${row.original.users.length}명`
+      meta: { label: "참여자" },
+      cell: ({ row }) => {
+        const users = row.original.users
+        if (!users || users.length === 0) return "-"
+        const first = users[0]
+        if (users.length === 1) return <UserCell user={first} />
+        return (
+          <span className="flex items-center gap-1">
+            <UserCell user={first} />
+            <span className="text-muted-foreground">
+              외 {users.length - 1}명
+            </span>
+          </span>
+        )
+      }
     },
     {
       accessorKey: "createdAt",

--- a/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { format } from "date-fns"
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react"
+
+import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { RentalDetail } from "@repo/shared-types"
+
+interface ColumnActions {
+  onEdit: (rental: RentalDetail) => void
+  onDelete: (rental: RentalDetail) => void
+}
+
+export function getColumns(actions: ColumnActions): ColumnDef<RentalDetail>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60,
+      enableHiding: false
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="예약명" />
+      ),
+      meta: {
+        label: "예약명",
+        editable: { type: "text" }
+      },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.row.original.title}
+        />
+      )
+    },
+    {
+      id: "equipment",
+      accessorFn: (row) => row.equipment?.name ?? "",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="장비" />
+      ),
+      meta: { label: "장비" },
+      cell: ({ row }) => row.original.equipment?.name ?? "-"
+    },
+    {
+      accessorKey: "startAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="시작 시간" />
+      ),
+      meta: { label: "시작 시간" },
+      cell: ({ row }) =>
+        format(new Date(row.original.startAt), "yyyy-MM-dd HH:mm")
+    },
+    {
+      accessorKey: "endAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="종료 시간" />
+      ),
+      meta: { label: "종료 시간" },
+      cell: ({ row }) =>
+        format(new Date(row.original.endAt), "yyyy-MM-dd HH:mm")
+    },
+    {
+      id: "participantCount",
+      accessorFn: (row) => row.users.length,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="참여자 수" />
+      ),
+      meta: { label: "참여자 수" },
+      cell: ({ row }) => `${row.original.users.length}명`
+    },
+    {
+      accessorKey: "createdAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="생성일" />
+      ),
+      meta: { label: "생성일" },
+      cell: ({ row }) =>
+        format(new Date(row.original.createdAt), "yyyy-MM-dd")
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <CopyRowLinkItem rowId={row.original.id} />
+            <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50,
+      enableHiding: false
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/rentals/_components/columns.tsx
@@ -41,20 +41,21 @@ export function getColumns(actions: ColumnActions): ColumnDef<RentalDetail>[] {
         editable: { type: "text" }
       },
       cell: (ctx) => (
-        <EditableCell
-          cellContext={ctx}
-          displayValue={ctx.row.original.title}
-        />
+        <EditableCell cellContext={ctx} displayValue={ctx.row.original.title} />
       )
     },
     {
       id: "equipment",
-      accessorFn: (row) => row.equipment?.name ?? "",
+      accessorFn: (row) =>
+        row.equipment ? `${row.equipment.brand} ${row.equipment.model}` : "",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="장비" />
       ),
       meta: { label: "장비" },
-      cell: ({ row }) => row.original.equipment?.name ?? "-"
+      cell: ({ row }) =>
+        row.original.equipment
+          ? `${row.original.equipment.brand} ${row.original.equipment.model}`
+          : "-"
     },
     {
       accessorKey: "startAt",
@@ -89,8 +90,7 @@ export function getColumns(actions: ColumnActions): ColumnDef<RentalDetail>[] {
         <DataTableColumnHeader column={column} title="생성일" />
       ),
       meta: { label: "생성일" },
-      cell: ({ row }) =>
-        format(new Date(row.original.createdAt), "yyyy-MM-dd")
+      cell: ({ row }) => format(new Date(row.original.createdAt), "yyyy-MM-dd")
     },
     {
       id: "actions",

--- a/apps/web/app/(admin)/admin/rentals/page.tsx
+++ b/apps/web/app/(admin)/admin/rentals/page.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useCallback, useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import {
+  useCreateRental,
+  useDeleteRental,
+  useRentals,
+  useUpdateRental
+} from "@/hooks/api/useRental"
+import { CreateRental, RentalDetail } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+import { RentalFormDialog } from "./_components/RentalFormDialog"
+
+export default function RentalsAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: rentals, isLoading } = useRentals()
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editing, setEditing] = useState<RentalDetail | null>(null)
+  const [deleting, setDeleting] = useState<RentalDetail | null>(null)
+
+  const createMutation = useCreateRental()
+  const updateMutation = useUpdateRental()
+  const deleteMutation = useDeleteRental()
+
+  const handleCellUpdate = useCallback(
+    async (rowId: number, columnId: string, value: unknown) => {
+      const payload: Record<string, unknown> = {}
+      payload[columnId] = value
+      try {
+        await updateMutation.mutateAsync([rowId, payload])
+        toast({ title: "예약이 수정되었습니다." })
+        queryClient.invalidateQueries({ queryKey: ["rentals"] })
+      } catch (error) {
+        toast({
+          title: "수정에 실패했습니다.",
+          description: (error as Error).message,
+          variant: "destructive"
+        })
+        throw error
+      }
+    },
+    [updateMutation, toast, queryClient]
+  )
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onEdit: (rental) => {
+          setEditing(rental)
+          setFormOpen(true)
+        },
+        onDelete: (rental) => {
+          setDeleting(rental)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleSubmit = (data: CreateRental) => {
+    const mutation = editing
+      ? updateMutation.mutateAsync([editing.id, data])
+      : createMutation.mutateAsync([data])
+
+    mutation
+      .then(() => {
+        toast({
+          title: editing ? "예약이 수정되었습니다." : "예약이 생성되었습니다."
+        })
+        queryClient.invalidateQueries({ queryKey: ["rentals"] })
+        setFormOpen(false)
+        setEditing(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "오류가 발생했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({
+          title: `${deleting.title} 예약이 삭제되었습니다.`
+        })
+        queryClient.invalidateQueries({ queryKey: ["rentals"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">예약 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={rentals ?? []}
+        isLoading={isLoading}
+        initialSorting={[{ id: "startAt", desc: true }]}
+        searchColumn="title"
+        searchPlaceholder="예약 검색..."
+        onCreateClick={() => {
+          setEditing(null)
+          setFormOpen(true)
+        }}
+        createLabel="예약 생성"
+        onUpdateCell={handleCellUpdate}
+        onBulkDelete={async (rows) => {
+          const results = await Promise.allSettled(
+            rows.map((r) =>
+              deleteMutation.mutateAsync([(r as RentalDetail).id])
+            )
+          )
+          const failed = results.filter((r) => r.status === "rejected").length
+          if (failed > 0) {
+            toast({
+              title: `${rows.length - failed}개 삭제, ${failed}개 실패`,
+              variant: "destructive"
+            })
+          } else {
+            toast({ title: `${rows.length}개 예약이 삭제되었습니다.` })
+          }
+          queryClient.invalidateQueries({ queryKey: ["rentals"] })
+        }}
+      />
+
+      <RentalFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          setFormOpen(open)
+          if (!open) setEditing(null)
+        }}
+        onSubmit={handleSubmit}
+        editingRental={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${deleting.title} 예약을 삭제하시겠습니까?`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -12,7 +12,8 @@ const ROUTES = {
     TEAMS: "/admin/teams",
     TEAM_DETAIL: (teamId: number) => `/admin/teams/${teamId}`,
     SESSIONS: "/admin/sessions",
-    RENTALS: "/admin/rentals"
+    RENTALS: "/admin/rentals",
+    EQUIPMENTS: "/admin/equipments"
   },
   NOTICE: {
     CREATE: "/notices/create",

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -11,7 +11,8 @@ const ROUTES = {
     PERFORMANCES: "/admin/performances",
     TEAMS: "/admin/teams",
     TEAM_DETAIL: (teamId: number) => `/admin/teams/${teamId}`,
-    SESSIONS: "/admin/sessions"
+    SESSIONS: "/admin/sessions",
+    RENTALS: "/admin/rentals"
   },
   NOTICE: {
     CREATE: "/notices/create",


### PR DESCRIPTION
## Summary

관리자 페이지에 **예약 관리 패널**을 추가합니다.

- 예약 CRUD (생성/조회/수정/삭제) — 기존 admin DataTable 패턴 동일
- 시작/종료 시간 **인라인 편집** 지원 (공연 페이지 패턴 차용)
- 장비 컬럼에 장비 패널 링크 연결 (`/admin/equipments?rowId=`)
- 참여자 컬럼: `UserCell` 재활용, "첫 번째 유저 외 n명" 표시
- 사이드바에 "예약" 메뉴 추가 (Calendar 아이콘)
- `ROUTES.ADMIN.RENTALS` / `ROUTES.ADMIN.EQUIPMENTS` 경로 추가
- 예약 생성/편집 FormDialog (장비 선택, 시간, 참여자 multi-select)
- 벌크 삭제 지원

### 스크린샷

![Admin Rentals Table](https://github.com/skku-amang/main/releases/download/admin-rentals-screenshot/admin-rentals-table.png)

## Test plan

- [x] `/admin/rentals` 페이지 접근 — 2746개 예약 정상 표시
- [x] 예약명 인라인 편집 — 편집 아이콘 정상
- [x] 시작/종료 시간 인라인 편집 — 편집 아이콘 정상
- [x] 장비 링크 클릭 → `/admin/equipments?rowId=` 정상 연결
- [x] 참여자 표시 — "사용자20 35기 외 2명" 형식 정상
- [x] 사이드바 "예약" 메뉴 활성 상태

🤖 Generated with [Claude Code](https://claude.com/claude-code)