### PR TITLE
feat(web): 관리자 장비 관리 페이지 추가

### DIFF
--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -8,7 +8,8 @@ import {
   Users,
   Hash,
   Guitar,
-  Mic
+  Mic,
+  Package
 } from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -33,7 +34,8 @@ const NAV_ITEMS = [
   { href: ROUTES.ADMIN.PERFORMANCES, label: "공연", icon: Music },
   { href: ROUTES.ADMIN.TEAMS, label: "팀", icon: Mic },
   { href: ROUTES.ADMIN.SESSIONS, label: "세션", icon: Guitar },
-  { href: ROUTES.ADMIN.RENTALS, label: "예약", icon: Calendar }
+  { href: ROUTES.ADMIN.RENTALS, label: "예약", icon: Calendar },
+  { href: ROUTES.ADMIN.EQUIPMENTS, label: "장비", icon: Package }
 ]
 
 function NavLinks({ onNavigate }: { onNavigate?: () => void }) {

--- a/apps/web/app/(admin)/admin/equipments/_components/EquipmentFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/equipments/_components/EquipmentFormDialog.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  CreateEquipment,
+  CreateEquipmentSchema,
+  Equipment
+} from "@repo/shared-types"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+
+const CATEGORY_OPTIONS = [
+  { value: "ROOM", label: "동아리방" },
+  { value: "SYNTHESIZER", label: "신디사이저" },
+  { value: "MICROPHONE", label: "마이크" },
+  { value: "GUITAR", label: "기타" },
+  { value: "BASS", label: "베이스" },
+  { value: "DRUM", label: "드럼" },
+  { value: "AUDIO_INTERFACE", label: "오디오 인터페이스" },
+  { value: "CABLE", label: "케이블" },
+  { value: "AMPLIFIER", label: "앰프" },
+  { value: "SPEAKER", label: "스피커" },
+  { value: "MIXER", label: "믹서" },
+  { value: "ETC", label: "기타(기타)" }
+] as const
+
+// Form schema without image (admin panel doesn't handle image upload yet)
+const FormSchema = CreateEquipmentSchema.omit({ image: true })
+
+interface EquipmentFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateEquipment) => void
+  editingEquipment: Equipment | null
+  isPending: boolean
+}
+
+export function EquipmentFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  editingEquipment,
+  isPending
+}: EquipmentFormDialogProps) {
+  const form = useForm<Omit<CreateEquipment, "image">>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      brand: "",
+      model: "",
+      category: "ETC" as const,
+      isAvailable: true,
+      description: ""
+    }
+  })
+
+  useEffect(() => {
+    if (open) {
+      if (editingEquipment) {
+        form.reset({
+          brand: editingEquipment.brand,
+          model: editingEquipment.model,
+          category: editingEquipment.category,
+          isAvailable: editingEquipment.isAvailable,
+          description: editingEquipment.description ?? ""
+        })
+      } else {
+        form.reset({
+          brand: "",
+          model: "",
+          category: "ETC" as const,
+          isAvailable: true,
+          description: ""
+        })
+      }
+    }
+  }, [open, editingEquipment, form])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {editingEquipment ? "장비 수정" : "장비 생성"}
+          </DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((data) =>
+              onSubmit(data as CreateEquipment)
+            )}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="brand"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>브랜드</FormLabel>
+                  <FormControl>
+                    <Input placeholder="예: SHURE" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="model"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>모델</FormLabel>
+                  <FormControl>
+                    <Input placeholder="예: SM58" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="category"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>카테고리</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="카테고리 선택" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {CATEGORY_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isAvailable"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border p-3">
+                  <FormLabel className="cursor-pointer">사용 가능</FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>설명</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="장비 설명 (선택)"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "처리 중..." : editingEquipment ? "수정" : "생성"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
@@ -72,11 +72,26 @@ export function getColumns(actions: ColumnActions): ColumnDef<Equipment>[] {
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="카테고리" />
       ),
-      meta: { label: "카테고리" },
-      cell: ({ row }) => (
-        <Badge variant="outline">
-          {CATEGORY_LABELS[row.original.category] ?? row.original.category}
-        </Badge>
+      meta: {
+        label: "카테고리",
+        editable: {
+          type: "select",
+          options: Object.entries(CATEGORY_LABELS).map(([value, label]) => ({
+            value,
+            label
+          }))
+        }
+      },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            <Badge variant="outline">
+              {CATEGORY_LABELS[ctx.row.original.category] ??
+                ctx.row.original.category}
+            </Badge>
+          }
+        />
       ),
       filterFn: (row, _id, filterValue) => {
         if (!filterValue) return true

--- a/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { format } from "date-fns"
+import { Check, EllipsisVertical, Pencil, Trash2, X } from "lucide-react"
+
+import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { Equipment } from "@repo/shared-types"
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ROOM: "동아리방",
+  SYNTHESIZER: "신디사이저",
+  MICROPHONE: "마이크",
+  GUITAR: "기타",
+  BASS: "베이스",
+  DRUM: "드럼",
+  AUDIO_INTERFACE: "오디오 인터페이스",
+  CABLE: "케이블",
+  AMPLIFIER: "앰프",
+  SPEAKER: "스피커",
+  MIXER: "믹서",
+  ETC: "기타(기타)"
+}
+
+interface ColumnActions {
+  onEdit: (equipment: Equipment) => void
+  onDelete: (equipment: Equipment) => void
+}
+
+export function getColumns(actions: ColumnActions): ColumnDef<Equipment>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60,
+      enableHiding: false
+    },
+    {
+      accessorKey: "brand",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="브랜드" />
+      ),
+      meta: { label: "브랜드", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell cellContext={ctx} displayValue={ctx.row.original.brand} />
+      )
+    },
+    {
+      accessorKey: "model",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="모델" />
+      ),
+      meta: { label: "모델", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell cellContext={ctx} displayValue={ctx.row.original.model} />
+      )
+    },
+    {
+      accessorKey: "category",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="카테고리" />
+      ),
+      meta: { label: "카테고리" },
+      cell: ({ row }) => (
+        <Badge variant="outline">
+          {CATEGORY_LABELS[row.original.category] ?? row.original.category}
+        </Badge>
+      ),
+      filterFn: (row, _id, filterValue) => {
+        if (!filterValue) return true
+        return row.original.category === filterValue
+      }
+    },
+    {
+      accessorKey: "isAvailable",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="사용 가능" />
+      ),
+      meta: { label: "사용 가능" },
+      cell: ({ row }) =>
+        row.original.isAvailable ? (
+          <Check className="h-4 w-4 text-green-600" />
+        ) : (
+          <X className="h-4 w-4 text-red-500" />
+        ),
+      size: 80
+    },
+    {
+      accessorKey: "description",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="설명" />
+      ),
+      meta: { label: "설명", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            <span className="max-w-[200px] truncate">
+              {ctx.row.original.description || "-"}
+            </span>
+          }
+        />
+      )
+    },
+    {
+      accessorKey: "createdAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="생성일" />
+      ),
+      meta: { label: "생성일" },
+      cell: ({ row }) => format(new Date(row.original.createdAt), "yyyy-MM-dd")
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <CopyRowLinkItem rowId={row.original.id} />
+            <DropdownMenuItem onClick={() => actions.onEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              편집
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => actions.onDelete(row.original)}
+              className="text-red-600"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 50,
+      enableHiding: false
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/equipments/page.tsx
+++ b/apps/web/app/(admin)/admin/equipments/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useCallback, useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import {
+  useCreateEquipment,
+  useDeleteEquipment,
+  useEquipments,
+  useUpdateEquipment
+} from "@/hooks/api/useEquipment"
+import { CreateEquipment, Equipment } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+import { EquipmentFormDialog } from "./_components/EquipmentFormDialog"
+
+export default function EquipmentsAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: equipments, isLoading } = useEquipments()
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editing, setEditing] = useState<Equipment | null>(null)
+  const [deleting, setDeleting] = useState<Equipment | null>(null)
+
+  const createMutation = useCreateEquipment()
+  const updateMutation = useUpdateEquipment()
+  const deleteMutation = useDeleteEquipment()
+
+  const handleCellUpdate = useCallback(
+    async (rowId: number, columnId: string, value: unknown) => {
+      const payload: Record<string, unknown> = {}
+      payload[columnId] = value
+      try {
+        await updateMutation.mutateAsync([rowId, payload])
+        toast({ title: "장비가 수정되었습니다." })
+        queryClient.invalidateQueries({ queryKey: ["equipments"] })
+      } catch (error) {
+        toast({
+          title: "수정에 실패했습니다.",
+          description: (error as Error).message,
+          variant: "destructive"
+        })
+        throw error
+      }
+    },
+    [updateMutation, toast, queryClient]
+  )
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onEdit: (equipment) => {
+          setEditing(equipment)
+          setFormOpen(true)
+        },
+        onDelete: (equipment) => {
+          setDeleting(equipment)
+          setDeleteOpen(true)
+        }
+      }),
+    []
+  )
+
+  const handleSubmit = (data: CreateEquipment) => {
+    const mutation = editing
+      ? updateMutation.mutateAsync([editing.id, data])
+      : createMutation.mutateAsync([data])
+
+    mutation
+      .then(() => {
+        toast({
+          title: editing ? "장비가 수정되었습니다." : "장비가 생성되었습니다."
+        })
+        queryClient.invalidateQueries({ queryKey: ["equipments"] })
+        setFormOpen(false)
+        setEditing(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "오류가 발생했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({
+          title: `${deleting.brand} ${deleting.model} 장비가 삭제되었습니다.`
+        })
+        queryClient.invalidateQueries({ queryKey: ["equipments"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description: error.message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">장비 관리</h1>
+
+      <DataTable
+        columns={columns}
+        data={equipments ?? []}
+        isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: true }]}
+        searchColumn="model"
+        searchPlaceholder="장비 검색..."
+        onCreateClick={() => {
+          setEditing(null)
+          setFormOpen(true)
+        }}
+        createLabel="장비 생성"
+        onUpdateCell={handleCellUpdate}
+        onBulkDelete={async (rows) => {
+          const results = await Promise.allSettled(
+            rows.map((r) => deleteMutation.mutateAsync([(r as Equipment).id]))
+          )
+          const failed = results.filter((r) => r.status === "rejected").length
+          if (failed > 0) {
+            toast({
+              title: `${rows.length - failed}개 삭제, ${failed}개 실패`,
+              variant: "destructive"
+            })
+          } else {
+            toast({ title: `${rows.length}개 장비가 삭제되었습니다.` })
+          }
+          queryClient.invalidateQueries({ queryKey: ["equipments"] })
+        }}
+      />
+
+      <EquipmentFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          setFormOpen(open)
+          if (!open) setEditing(null)
+        }}
+        onSubmit={handleSubmit}
+        editingEquipment={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${deleting.brand} ${deleting.model} 장비를 삭제하시겠습니까?`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## 🚀 작업 내용

관리자 페이지에 **장비 관리 패널**을 추가합니다.

- 장비 CRUD (생성/조회/수정/삭제) — 기존 admin DataTable 패턴 동일
- 브랜드, 모델, 설명 **인라인 편집** 지원
- 카테고리 Badge 표시 (동아리방, 마이크, 기타 등 12종)
- 사용 가능 여부 아이콘 표시 (✓/✗)
- 사이드바에 "장비" 메뉴 추가 (Package 아이콘)
- EquipmentFormDialog (카테고리 select, 사용 가능 toggle, 설명 textarea)
- 벌크 삭제 지원
- 예약 패널의 장비 링크(`/admin/equipments?rowId=`)와 연결

## 📸 스크린샷(선택)

추후 추가 예정

## 🔗 관련 이슈

예약 패널 PR #353 후속 작업

## 🙏 리뷰어에게

- 예약 패널과 동일한 DataTable 패턴을 따릅니다
- 이미지 업로드는 백엔드 TODO 상태라 FormDialog에서 제외했습니다

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
