### PR TITLE
chore: turbo 빌드 파이프라인 최적화

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -7,7 +7,7 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "prisma generate && tsc",
+    "build": "tsc",
     "dev": "tsc --watch",
     "check-types": "tsc --noEmit",
     "format": "prettier --check \"src/**/*.ts\"",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,6 @@
     }
   },
   "scripts": {
-    "build": "tsc",
     "dev": "tsc --watch",
     "check-types": "tsc --noEmit",
     "format": "prettier --check \"src/**/*.{ts,tsx}\"",

--- a/turbo.json
+++ b/turbo.json
@@ -3,10 +3,9 @@
   "ui": "tui",
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "^db:generate"],
+      "dependsOn": ["^build", "^db:generate", "db:generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": ["PORT", "NODE_ENV", "DATABASE_URL"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "format": {
       "dependsOn": ["^format"]
@@ -16,7 +15,6 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "persistent": true,
       "env": ["NODE_ENV"]
     },
     "check-types": {
@@ -39,7 +37,7 @@
     },
     "db:seed": {
       "cache": false,
-      "dependsOn": ["^db:generate", "^db:migrate"],
+      "dependsOn": ["db:generate", "db:migrate"],
       "env": ["DATABASE_URL", "SEED_DEFAULT_PASSWORD"]
     },
     "storybook": {


### PR DESCRIPTION
## 🚀 작업 내용

turbo 빌드 파이프라인에서 불필요한 작업과 잘못된 설정을 수정하여 빌드를 최적화합니다.

### 변경 사항
- **prisma generate 이중 실행 제거**: `database:build` 스크립트에서 `prisma generate`를 분리하고, turbo `dependsOn`에 `db:generate`를 추가하여 순서를 보장하면서 중복 실행 방지
- **미사용 `@repo/ui` build 태스크 제거**: 어디서도 import되지 않는 패키지의 불필요한 빌드 제거
- **`test` 태스크의 `persistent: true` 제거**: `jest`는 실행 후 종료되는 태스크이므로 잘못된 설정 제거
- **`db:seed` dependsOn `^` 접두사 수정**: `^db:generate`, `^db:migrate`는 의존 패키지의 태스크를 참조하지만 해당 태스크를 가진 의존 패키지가 없어 무효. `^` 제거하여 동일 패키지 내 태스크 참조로 수정
- **`build.env` 중복 선언 제거**: `PORT`, `NODE_ENV`, `DATABASE_URL`이 이미 `globalEnv`에 선언되어 있어 중복

### 결과
- 빌드 태스크 7개 → 6개로 감소
- `prisma generate` 1회만 실행

## 🙏 리뷰어에게

`turbo.json`의 `dependsOn`에서 `^` 유무 차이를 유의해주세요.
- `^db:generate`: **의존 패키지**의 `db:generate` 실행
- `db:generate`: **동일 패키지** 내 `db:generate` 실행

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.