### PR TITLE
fix(infra): Job 파드 라벨 충돌로 인한 502 해소

### DIFF
--- a/infra/k8s/api/base/migrate-job.yaml
+++ b/infra/k8s/api/base/migrate-job.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        app: api
+        app: api-job
         job-type: migrate
     spec:
       restartPolicy: Never

--- a/infra/k8s/api/base/seed-job.yaml
+++ b/infra/k8s/api/base/seed-job.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: api
+        app: api-job
         job-type: seed
     spec:
       restartPolicy: Never


### PR DESCRIPTION
## 🚀 작업 내용

#377 머지 후 staging/production에서 502 발생. seed/migrate Job 파드가 `app=api` 라벨을 가져 `api-server` Service 셀렉터에 매칭되어 트래픽이 Job 파드로 라우팅된 것이 원인.

- Job 파드 라벨을 `app: api` → `app: api-job`으로 변경하여 Service endpoint에서 제외

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

#377 후속 수정

## 🙏 리뷰어에게

502의 근본 원인은 기존 CronJob에서도 동일했으나, CronJob이 suspended 상태라 파드가 생성되지 않아 드러나지 않았던 문제입니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [ ] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)