### PR TITLE
fix(database,web): Prisma engine 번들 제외를 위한 enum entrypoint 분리

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Equipment } from "@repo/shared-types"
-import { EquipCategory } from "@repo/database"
+import { EquipCategory } from "@repo/database/enums"
 import { MoreVertical, ScanSearch, Search } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
-import { EquipCategory } from "@repo/database"
+import { EquipCategory } from "@repo/database/enums"
 import { Equipment } from "@repo/shared-types"
 import { useQueryClient } from "@tanstack/react-query"
 

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentListPage.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react"
 import { useSession } from "next-auth/react"
 import { useQueryClient } from "@tanstack/react-query"
-import { EquipCategory } from "@repo/database"
+import { EquipCategory } from "@repo/database/enums"
 import { Equipment } from "@repo/shared-types"
 import { Filter, Plus, Search, RefreshCw, PackageSearch } from "lucide-react"
 import {

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/FilterModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/FilterModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { EquipCategory } from "@repo/database"
+import { EquipCategory } from "@repo/database/enums"
 
 import {
   Dialog,

--- a/apps/web/constants/sessionimage.ts
+++ b/apps/web/constants/sessionimage.ts
@@ -1,4 +1,4 @@
-import { SessionName } from "../../../packages/database/generated/prisma"
+import { SessionName } from "@repo/database/enums"
 
 type SessionImageType = {
   UNPRESSED: Record<SessionName, string>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,7 +3,14 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./enums": {
+      "types": "./generated/prisma/index.d.ts",
+      "default": "./generated/prisma/index-browser.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared-types/src/equipment/create-equipment.schema.ts
+++ b/packages/shared-types/src/equipment/create-equipment.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { EquipCategory } from "@repo/database"
+import { EquipCategory } from "@repo/database/enums"
 import {
   ACCEPTED_IMAGE_TYPES,
   MAX_FILE_SIZE

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -1,4 +1,4 @@
-import { SessionName } from "@repo/database"
+import { SessionName } from "@repo/database/enums"
 import { z } from "zod"
 
 /**


### PR DESCRIPTION
## 🚀 작업 내용

Vercel 배포 시 `PrismaClientInitializationError: Could not locate the Query Engine for runtime "rhel-openssl-3.0.x"` 에러 해소.

- `@repo/database`에 `./enums` entrypoint 추가 (Prisma `index-browser.js` 활용, engine 미포함)
- web, shared-types의 enum import를 `@repo/database/enums`로 변경

## 📸 스크린샷(선택)

N/A (import 경로 변경)

## 🔗 관련 이슈

Sentry [WEB-8](https://amang-23.sentry.io/issues/WEB-8)

## 🙏 리뷰어에게

- Prisma는 `index.js`(engine 포함)와 `index-browser.js`(engine 미포함) 두 파일을 생성합니다. `./enums` entrypoint는 후자를 사용하여 enum 값과 타입만 제공합니다.
- API 쪽은 engine이 필요하므로 기존 `@repo/database` import 유지.
- 새 enum 추가 시 자동으로 `./enums`에서도 사용 가능 (Prisma generated 파일 직접 사용).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
