### PR TITLE
fix(web,api-client): 에러 메시지 사용자 친화적 개선 및 팀 지원/탈퇴 에러 표시

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -48,7 +48,10 @@ const MemberSessionCard = ({
     onError: (error) => {
       toast({
         title: "탈퇴 실패",
-        description: error.message,
+        description:
+          error instanceof Error
+            ? error.message
+            : "팀 탈퇴 중 오류가 발생했습니다.",
         variant: "destructive"
       })
     }

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/MemberSessionCard.tsx
@@ -45,10 +45,10 @@ const MemberSessionCard = ({
       })
       onUnapplySuccess(team)
     },
-    onError: () => {
+    onError: (error) => {
       toast({
         title: "탈퇴 실패",
-        description: "팀 탈퇴 중 오류가 발생했습니다.",
+        description: error.message,
         variant: "destructive"
       })
     }

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
@@ -25,10 +25,10 @@ const useTeamApplication = (teamId: number) => {
       })
       setSelectedSessions([])
     },
-    onError: () => {
+    onError: (error) => {
       toast({
         title: "지원 실패",
-        description: "팀 지원 중 오류가 발생했습니다.",
+        description: error.message,
         variant: "destructive"
       })
     }

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_hooks/useTeamApplication.ts
@@ -28,7 +28,10 @@ const useTeamApplication = (teamId: number) => {
     onError: (error) => {
       toast({
         title: "지원 실패",
-        description: error.message,
+        description:
+          error instanceof Error
+            ? error.message
+            : "팀 지원 중 오류가 발생했습니다.",
         variant: "destructive"
       })
     }

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -61,7 +61,7 @@ export class AuthError extends ApiError {
   readonly title = "Authentication Error"
 
   constructor(detail?: string, instance?: string) {
-    super("유효한 인증 정보가 필요합니다.", detail, instance)
+    super("로그인이 필요합니다.", detail, instance)
   }
 }
 
@@ -100,7 +100,7 @@ export class UnprocessableEntityError extends ApiError {
   readonly title = "Unprocessable Entity"
 
   constructor(detail?: string, instance?: string) {
-    super("처리할 수 없는 엔티티입니다", detail, instance)
+    super("요청을 처리할 수 없습니다.", detail, instance)
   }
 }
 
@@ -272,7 +272,7 @@ export class RefreshTokenExpiredError extends ApiError {
   readonly title = "Refresh Token Expired"
 
   constructor(detail?: string, instance?: string) {
-    super("리프레시 토큰이 만료되었습니다.", detail, instance)
+    super("로그인이 만료되었습니다. 다시 로그인해주세요.", detail, instance)
   }
 }
 
@@ -285,7 +285,7 @@ export class AccessTokenExpiredError extends ApiError {
   readonly title = "Access Token Expired"
 
   constructor(detail?: string, instance?: string) {
-    super("액세스 토큰이 만료되었습니다.", detail, instance)
+    super("로그인이 만료되었습니다. 다시 로그인해주세요.", detail, instance)
   }
 }
 
@@ -298,7 +298,7 @@ export class RefreshTokenNotFoundError extends ApiError {
   readonly title = "Refresh Token Not Found"
 
   constructor(detail?: string, instance?: string) {
-    super("리프레시 토큰이 존재하지 않습니다.", detail, instance)
+    super("로그인이 만료되었습니다. 다시 로그인해주세요.", detail, instance)
   }
 }
 
@@ -311,6 +311,6 @@ export class AccessTokenNotFoundError extends ApiError {
   readonly title = "Access Token Not Found"
 
   constructor(detail?: string, instance?: string) {
-    super("액세스 토큰이 존재하지 않습니다.", detail, instance)
+    super("로그인이 필요합니다.", detail, instance)
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -44,6 +44,7 @@ import {
 import { ApiResult } from "./api-result"
 import {
   AccessTokenExpiredError,
+  AccessTokenNotFoundError,
   ApiError,
   AuthError,
   ConflictError,
@@ -61,6 +62,7 @@ import {
   ProblemDocument,
   ReferencedEntityNotFoundError,
   RefreshTokenExpiredError,
+  RefreshTokenNotFoundError,
   SessionNotFoundError,
   UnprocessableEntityError,
   ValidationError
@@ -110,8 +112,12 @@ function createErrorFromProblemDocument(problemDoc: ProblemDocument): ApiError {
       return new InvalidPerformanceDateError(detail, instance)
     case "/errors/token/refresh-token-expired":
       return new RefreshTokenExpiredError(detail, instance)
+    case "/errors/token/refresh-token-not-found":
+      return new RefreshTokenNotFoundError(detail, instance)
     case "/errors/token/access-token-expired":
       return new AccessTokenExpiredError(detail, instance)
+    case "/errors/token/access-token-not-found":
+      return new AccessTokenNotFoundError(detail, instance)
     default:
       // API 서버에서 알 수 없는 에러가 전달될 경우
       // detail과 instance가 없을 수 있습니다.


### PR DESCRIPTION
## 🚀 작업 내용

### 1. 팀 지원/탈퇴 에러 메시지 표시 (#382)
`onError` 핸들러에서 에러 객체를 무시하고 하드코딩된 메시지만 보여주던 것을 `error.message` 사용으로 변경.

### 2. 에러 메시지 사용자 친화적 개선 (#384)
`@repo/api-client` 에러 클래스의 message를 기술적 표현에서 사용자 친화적으로 변경.

| 에러 | 변경 전 | 변경 후 |
|---|---|---|
| AuthError | 유효한 인증 정보가 필요합니다. | 로그인이 필요합니다. |
| AccessTokenNotFoundError | 액세스 토큰이 존재하지 않습니다. | 로그인이 필요합니다. |
| AccessTokenExpiredError | 액세스 토큰이 만료되었습니다. | 로그인이 만료되었습니다. 다시 로그인해주세요. |
| RefreshTokenNotFoundError | 리프레시 토큰이 존재하지 않습니다. | 로그인이 만료되었습니다. 다시 로그인해주세요. |
| RefreshTokenExpiredError | 리프레시 토큰이 만료되었습니다. | 로그인이 만료되었습니다. 다시 로그인해주세요. |
| UnprocessableEntityError | 처리할 수 없는 엔티티입니다 | 요청을 처리할 수 없습니다. |

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #382
Closes #384
Sentry [WEB-9](https://amang-23.sentry.io/issues/WEB-9)

## 🙏 리뷰어에게

- 도메인 에러(팀, 공연 관련)는 이미 사용자 친화적이라 변경 없음
- `detail` 필드(API에서 온 기술적 상세)는 그대로 유지, `message`만 변경

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
