### PR TITLE
fix(api): 헬스체크 엔드포인트 Sentry 에러 캡처 제외

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -8,5 +8,14 @@ Sentry.init({
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
 
-  integrations: [nodeProfilingIntegration()]
+  integrations: [nodeProfilingIntegration()],
+
+  // 헬스체크 503은 Blackbox Exporter에서 모니터링하므로 Sentry 노이즈 방지 (API-4)
+  beforeSend(event) {
+    const url = event.request?.url ?? event.extra?.url
+    if (typeof url === "string" && url.endsWith("/health")) {
+      return null
+    }
+    return event
+  }
 })


### PR DESCRIPTION
## 🚀 작업 내용

`/health` 엔드포인트의 503 에러를 Sentry `beforeSend`에서 필터링하여 캡처 제외.
Blackbox Exporter가 이미 외부 프로빙으로 헬스체크를 모니터링 중이므로, Sentry 측 캡처는 노이즈만 발생시킴.

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- Sentry [API-4](https://amang-23.sentry.io/issues/API-4): `GET /health`에서 간헐적 ServiceUnavailableException 발생 → **resolved** (이 PR로 해결)

## 🙏 리뷰어에게

- `beforeSend`에서 `event.request?.url`과 `event.extra?.url` 두 경로를 모두 체크합니다. 전자는 `@sentry/nestjs` 자동 계측, 후자는 `AllErrorFilter`의 수동 `captureException`에서 설정되는 값입니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)