### PR TITLE
fix(infra): seed Job을 ArgoCD 관리 대상에서 제외하여 반복 실행 방지

### DIFF
--- a/infra/k8s/api/base/kustomization.yaml
+++ b/infra/k8s/api/base/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - deployment.yaml
   - service.yaml
   - migrate-job.yaml
-  - seed-job.yaml

--- a/infra/k8s/api/overlays/production/kustomization.yaml
+++ b/infra/k8s/api/overlays/production/kustomization.yaml
@@ -24,10 +24,3 @@ patches:
     target:
       kind: ConfigMap
       name: api-config
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/env/0/value
-        value: "master"
-    target:
-      kind: Job
-      name: db-seed


### PR DESCRIPTION
## 🚀 작업 내용

프로덕션에서 장비 레코드가 수천 개 중복 생성되는 문제 수정.

**근본 원인:** seed Job의 `ttlSecondsAfterFinished: 300`으로 완료된 Job이 자동 삭제된 후,
ArgoCD auto-sync가 리소스 누락을 감지하여 Job을 재생성하는 무한 루프 발생.

**해결:** seed Job을 kustomization에서 제거하여 ArgoCD 관리 대상에서 제외.
시드는 첫 배포 시 수동 실행(`kubectl create -f`)만 필요하므로 GitOps 관리 대상이 아님.
YAML 파일은 레포에 유지하여 수동 실행 시 참조 가능.

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- 관련: #379 (seed 멱등성), #381 (seed 멱등성 PR)

## 🙏 리뷰어에게

- 이 PR 머지 후 프로덕션 DB에서 중복 장비 레코드 정리가 별도로 필요합니다.
- seed-job.yaml 파일 자체는 삭제하지 않았습니다 (수동 실행 템플릿 용도).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.