### PR TITLE
feat(api): 사용자 승인 여부 추가

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -21,7 +21,11 @@ export class AuthController {
   @Post("signup")
   @HttpCode(HttpStatus.CREATED)
   async signup(@Body() createUserDto: CreateUserDto) {
-    return this.authService.signUp(createUserDto)
+    await this.authService.signUp(createUserDto)
+
+    return {
+      message: "회원가입이 완료되었습니다. 관리자 승인 후 로그인이 가능합니다."
+    }
   }
 
   @Post("login")

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from "@nestjs/common"
 import { ConfigService } from "@nestjs/config"
 import { JwtService } from "@nestjs/jwt"
-import { AuthError, ForbiddenError } from "@repo/api-client"
+import {
+  AuthError,
+  ForbiddenError,
+  UserNotApprovedError
+} from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
 import * as bcrypt from "bcrypt"
 import { CreateUserDto } from "../users/dto/create-user.dto"
@@ -16,15 +20,7 @@ export class AuthService {
   ) {}
 
   async signUp(createUserDto: CreateUserDto) {
-    const user = await this.usersService.create(createUserDto)
-    const tokens = await this.getTokens(
-      user.id,
-      user.email,
-      user.name,
-      user.isAdmin
-    )
-    await this.usersService.updateRefreshToken(user.id, tokens.refreshToken)
-    return { ...tokens, user }
+    await this.usersService.create(createUserDto)
   }
 
   async login(loginDto: LoginUserDto) {
@@ -32,9 +28,14 @@ export class AuthService {
     if (!user) {
       throw new AuthError("존재하지 않는 이메일입니다.")
     }
+
     const isMatch = await bcrypt.compare(loginDto.password, user.password)
     if (!isMatch) {
       throw new AuthError("비밀번호가 일치하지 않습니다.")
+    }
+
+    if (!user.isApproved) {
+      throw new UserNotApprovedError("아직 승인되지 않은 계정입니다.")
     }
 
     const tokens = await this.getTokens(
@@ -98,6 +99,10 @@ export class AuthService {
     const user = await this.usersService.findOneById(userId)
     if (!user || !user.hashedRefreshToken) {
       throw new ForbiddenError("Access Denied")
+    }
+
+    if (!user.isApproved) {
+      throw new UserNotApprovedError("아직 승인되지 않은 계정입니다.")
     }
 
     const refreshTokenMatches = await bcrypt.compare(

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -38,6 +38,12 @@ export class UsersController {
     return this.userService.findAllForAdmin()
   }
 
+  @Get("admin/pending")
+  @UseGuards(AdminGuard)
+  findPendingUsers() {
+    return this.userService.findPendingUsers()
+  }
+
   @Get(":id")
   @Public()
   async findOne(@Param("id", ParseIntPipe) id: number) {
@@ -79,6 +85,12 @@ export class UsersController {
     @Body() updateUserDto: UpdateUserDto
   ) {
     return this.userService.updateUser(id, updateUserDto)
+  }
+
+  @Patch(":id/approve")
+  @UseGuards(AdminGuard)
+  async approveUser(@Param("id", ParseIntPipe) id: number) {
+    return this.userService.approveUser(id)
   }
 
   @Delete(":id")

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -51,6 +51,7 @@ export class UsersService {
 
   async findAll() {
     const users = await this.prisma.user.findMany({
+      where: { isApproved: true },
       select: publicUserSelector
     })
 
@@ -65,7 +66,7 @@ export class UsersService {
 
   async findOne(userId: number) {
     const user = await this.prisma.user.findUnique({
-      where: { id: userId },
+      where: { id: userId, isApproved: true },
       select: publicUserSelector
     })
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -64,6 +64,15 @@ export class UsersService {
     })
   }
 
+  async findPendingUsers() {
+    return this.prisma.user.findMany({
+      where: {
+        isApproved: false
+      },
+      select: detailedUserSelector
+    })
+  }
+
   async findOne(userId: number) {
     const user = await this.prisma.user.findUnique({
       where: { id: userId, isApproved: true },
@@ -209,6 +218,19 @@ export class UsersService {
       data: {
         password: hashedPassword
       },
+      select: detailedUserSelector
+    })
+  }
+
+  async approveUser(userId: number) {
+    const user = this.prisma.user.findUnique({ where: { id: userId } })
+
+    if (!user)
+      throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { isApproved: true },
       select: detailedUserSelector
     })
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -223,7 +223,7 @@ export class UsersService {
   }
 
   async approveUser(userId: number) {
-    const user = this.prisma.user.findUnique({ where: { id: userId } })
+    const user = await this.prisma.user.findUnique({ where: { id: userId } })
 
     if (!user)
       throw new NotFoundError(`ID가 ${userId}인 사용자를 찾을 수 없습니다.`)

--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Menu,
   Music,
   Users,
+  UserCheck,
   Hash,
   Guitar,
   Mic,
@@ -30,6 +31,7 @@ const NAV_ITEMS = [
     exact: true
   },
   { href: ROUTES.ADMIN.USERS, label: "회원", icon: Users },
+  { href: ROUTES.ADMIN.PENDING_USERS, label: "승인 대기", icon: UserCheck },
   { href: ROUTES.ADMIN.GENERATIONS, label: "기수", icon: Hash },
   { href: ROUTES.ADMIN.PERFORMANCES, label: "공연", icon: Music },
   { href: ROUTES.ADMIN.TEAMS, label: "팀", icon: Mic },

--- a/apps/web/app/(admin)/admin/pending-users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/pending-users/_components/columns.tsx
@@ -2,11 +2,14 @@
 
 import { ColumnDef } from "@tanstack/react-table"
 import { Check, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import ROUTES from "@/constants/routes"
 import { getSessionDisplayName } from "@/constants/session"
 import { formatGenerationOrder } from "@/lib/utils"
 import { DetailedUser } from "@repo/shared-types"
@@ -45,28 +48,50 @@ export function getColumns({
       accessorKey: "name",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="이름" />
+      ),
+      meta: { label: "이름", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.getValue() as string}
+        />
       )
     },
     {
       accessorKey: "nickname",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="닉네임" />
+      ),
+      meta: { label: "닉네임", editable: { type: "text" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={ctx.getValue() as string}
+        />
       )
     },
     {
       accessorKey: "email",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="이메일" />
-      )
+      ),
+      meta: { label: "이메일" }
     },
     {
       id: "generation",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="기수" />
       ),
+      meta: { label: "기수" },
       accessorFn: (row) => row.generation.order,
-      cell: ({ row }) =>
-        `${formatGenerationOrder(row.original.generation.order)}기`,
+      cell: ({ row }) => (
+        <Link
+          href={`${ROUTES.ADMIN.GENERATIONS}?rowId=${row.original.generation.id}`}
+          className="text-blue-600 hover:underline"
+        >
+          {formatGenerationOrder(row.original.generation.order)}기
+        </Link>
+      ),
       filterFn: (row, _columnId, filterValue) =>
         String(row.original.generation.order) === filterValue
     },
@@ -75,14 +100,21 @@ export function getColumns({
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="세션" />
       ),
+      meta: { label: "세션" },
       accessorFn: (row) => row.sessions.map((s) => s.name).join(", "),
       cell: ({ row }) => (
         <div className="flex flex-wrap gap-1">
           {row.original.sessions.length > 0
             ? row.original.sessions.map((s) => (
-                <Badge key={s.id} variant="outline" className="text-xs">
-                  {getSessionDisplayName(s.name)}
-                </Badge>
+                <Link
+                  key={s.id}
+                  href={`${ROUTES.ADMIN.SESSIONS}?rowId=${s.id}`}
+                  className="hover:opacity-80"
+                >
+                  <Badge variant="outline" className="text-xs">
+                    {getSessionDisplayName(s.name)}
+                  </Badge>
+                </Link>
               ))
             : "-"}
         </div>

--- a/apps/web/app/(admin)/admin/pending-users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/pending-users/_components/columns.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { Check, Trash2 } from "lucide-react"
+
+import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { getSessionDisplayName } from "@/constants/session"
+import { formatGenerationOrder } from "@/lib/utils"
+import { DetailedUser } from "@repo/shared-types"
+
+interface ColumnCallbacks {
+  onApprove: (user: DetailedUser) => void
+  onDelete: (user: DetailedUser) => void
+}
+
+export function getColumns({
+  onApprove,
+  onDelete
+}: ColumnCallbacks): ColumnDef<DetailedUser>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ID" />
+      ),
+      size: 60,
+      enableHiding: false
+    },
+    {
+      id: "avatar",
+      header: "프로필",
+      cell: ({ row }) => (
+        <Avatar className="h-8 w-8">
+          <AvatarImage src={row.original.image ?? undefined} />
+          <AvatarFallback>{row.original.name[0]}</AvatarFallback>
+        </Avatar>
+      ),
+      size: 40,
+      enableHiding: false
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="이름" />
+      )
+    },
+    {
+      accessorKey: "nickname",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="닉네임" />
+      )
+    },
+    {
+      accessorKey: "email",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="이메일" />
+      )
+    },
+    {
+      id: "generation",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="기수" />
+      ),
+      accessorFn: (row) => row.generation.order,
+      cell: ({ row }) =>
+        `${formatGenerationOrder(row.original.generation.order)}기`,
+      filterFn: (row, _columnId, filterValue) =>
+        String(row.original.generation.order) === filterValue
+    },
+    {
+      id: "sessions",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="세션" />
+      ),
+      accessorFn: (row) => row.sessions.map((s) => s.name).join(", "),
+      cell: ({ row }) => (
+        <div className="flex flex-wrap gap-1">
+          {row.original.sessions.length > 0
+            ? row.original.sessions.map((s) => (
+                <Badge key={s.id} variant="outline" className="text-xs">
+                  {getSessionDisplayName(s.name)}
+                </Badge>
+              ))
+            : "-"}
+        </div>
+      ),
+      filterFn: (row, _columnId, filterValue) =>
+        row.original.sessions.some((s) => s.name === filterValue)
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="default"
+            onClick={() => onApprove(row.original)}
+          >
+            <Check className="mr-1 h-4 w-4" />
+            승인
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => onDelete(row.original)}
+          >
+            <Trash2 className="mr-1 h-4 w-4" />
+            삭제
+          </Button>
+        </div>
+      ),
+      size: 180,
+      enableHiding: false
+    }
+  ]
+}

--- a/apps/web/app/(admin)/admin/pending-users/page.tsx
+++ b/apps/web/app/(admin)/admin/pending-users/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 
 import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
 import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
@@ -11,7 +11,8 @@ import { useSessions } from "@/hooks/api/useSession"
 import {
   useApproveUser,
   useDeleteUser,
-  usePendingUsers
+  usePendingUsers,
+  useUpdateUser
 } from "@/hooks/api/useUser"
 import { getSessionDisplayName } from "@/constants/session"
 import { formatGenerationOrder } from "@/lib/utils"
@@ -31,6 +32,7 @@ export default function PendingUsersAdminPage() {
   const [deleting, setDeleting] = useState<DetailedUser | null>(null)
 
   const approveMutation = useApproveUser()
+  const updateMutation = useUpdateUser()
   const deleteMutation = useDeleteUser()
 
   const generationFilters = useMemo(
@@ -51,6 +53,27 @@ export default function PendingUsersAdminPage() {
         value: s.name
       })) ?? [],
     [sessions]
+  )
+
+  const handleCellUpdate = useCallback(
+    async (rowId: number, columnId: string, value: unknown) => {
+      try {
+        await updateMutation.mutateAsync([rowId, { [columnId]: value }])
+        toast({ title: "회원 정보가 수정되었습니다." })
+        queryClient.invalidateQueries({ queryKey: ["pendingUsers"] })
+      } catch (error) {
+        toast({
+          title: "수정에 실패했습니다.",
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
+          variant: "destructive"
+        })
+        throw error
+      }
+    },
+    [updateMutation, toast, queryClient]
   )
 
   const handleApprove = (user: DetailedUser) => {
@@ -120,6 +143,7 @@ export default function PendingUsersAdminPage() {
         initialSorting={[{ id: "id", desc: false }]}
         enableGlobalSearch
         searchPlaceholder="이름으로 검색..."
+        onUpdateCell={handleCellUpdate}
         emptyMessage="승인 대기 중인 회원이 없습니다."
         filters={[
           {

--- a/apps/web/app/(admin)/admin/pending-users/page.tsx
+++ b/apps/web/app/(admin)/admin/pending-users/page.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+
+import { DataTable } from "@/app/(admin)/_components/data-table/DataTable"
+import { DeleteConfirmDialog } from "@/app/(admin)/_components/data-table/DeleteConfirmDialog"
+import { useToast } from "@/components/hooks/use-toast"
+import { useGenerations } from "@/hooks/api/useGeneration"
+import { useSessions } from "@/hooks/api/useSession"
+import {
+  useApproveUser,
+  useDeleteUser,
+  usePendingUsers
+} from "@/hooks/api/useUser"
+import { getSessionDisplayName } from "@/constants/session"
+import { formatGenerationOrder } from "@/lib/utils"
+import { ApiError } from "@repo/api-client"
+import { DetailedUser } from "@repo/shared-types"
+
+import { getColumns } from "./_components/columns"
+
+export default function PendingUsersAdminPage() {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const { data: pendingUsers, isLoading } = usePendingUsers()
+  const { data: generations } = useGenerations()
+  const { data: sessions } = useSessions()
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleting, setDeleting] = useState<DetailedUser | null>(null)
+
+  const approveMutation = useApproveUser()
+  const deleteMutation = useDeleteUser()
+
+  const generationFilters = useMemo(
+    () =>
+      generations
+        ?.sort((a, b) => b.order - a.order)
+        .map((g) => ({
+          label: `${formatGenerationOrder(g.order)}기`,
+          value: String(g.order)
+        })) ?? [],
+    [generations]
+  )
+
+  const sessionFilters = useMemo(
+    () =>
+      sessions?.map((s) => ({
+        label: getSessionDisplayName(s.name),
+        value: s.name
+      })) ?? [],
+    [sessions]
+  )
+
+  const handleApprove = (user: DetailedUser) => {
+    approveMutation
+      .mutateAsync([user.id])
+      .then(() => {
+        toast({ title: `${user.name} 회원이 승인되었습니다.` })
+        queryClient.invalidateQueries({ queryKey: ["pendingUsers"] })
+        queryClient.invalidateQueries({ queryKey: ["users"] })
+      })
+      .catch((error) => {
+        toast({
+          title: "승인에 실패했습니다.",
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const handleDelete = () => {
+    if (!deleting) return
+
+    deleteMutation
+      .mutateAsync([deleting.id])
+      .then(() => {
+        toast({ title: `${deleting.name} 회원이 삭제되었습니다.` })
+        queryClient.invalidateQueries({ queryKey: ["pendingUsers"] })
+        setDeleteOpen(false)
+        setDeleting(null)
+      })
+      .catch((error) => {
+        toast({
+          title: "삭제에 실패했습니다.",
+          description:
+            error instanceof ApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
+          variant: "destructive"
+        })
+      })
+  }
+
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onApprove: handleApprove,
+        onDelete: (user) => {
+          setDeleting(user)
+          setDeleteOpen(true)
+        }
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">승인 대기 회원</h1>
+
+      <DataTable
+        columns={columns}
+        data={pendingUsers ?? []}
+        isLoading={isLoading}
+        initialSorting={[{ id: "id", desc: false }]}
+        enableGlobalSearch
+        searchPlaceholder="이름으로 검색..."
+        emptyMessage="승인 대기 중인 회원이 없습니다."
+        filters={[
+          {
+            columnId: "generation",
+            label: "기수",
+            options: generationFilters
+          },
+          {
+            columnId: "sessions",
+            label: "세션",
+            options: sessionFilters
+          }
+        ]}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleting(null)
+        }}
+        onConfirm={handleDelete}
+        description={
+          deleting
+            ? `${deleting.name} 회원을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`
+            : undefined
+        }
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(general)/(light)/signup/_components/SignupForm.tsx
+++ b/apps/web/app/(general)/(light)/signup/_components/SignupForm.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { ConflictError, ValidationError } from "@repo/api-client"
 import { CreateUserSchema, passwordField } from "@repo/shared-types"
-import { signIn } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
@@ -32,10 +32,7 @@ import ROUTES from "@/constants/routes"
 import { getSessionDisplayName } from "@/constants/session"
 import { useGenerations } from "@/hooks/api/useGeneration"
 import { useSessions } from "@/hooks/api/useSession"
-import {
-  DuplicatedCredentialsErrorCode,
-  InvalidSignupCredentialsErrorCode
-} from "@/lib/auth/errors"
+import { apiClient } from "@/lib/apiClient"
 import { formatGenerationOrder } from "@/lib/utils"
 
 const confirmPasswordMergedCreateUserSchema = CreateUserSchema.merge(
@@ -61,23 +58,19 @@ const SignupForm = () => {
   async function onSubmit(
     formData: z.infer<typeof confirmPasswordMergedCreateUserSchema>
   ) {
-    const res = await signIn("credentials", {
-      name: formData.name,
-      nickname: formData.nickname,
-      email: formData.email,
-      password: formData.password,
-      sessions: formData.sessions,
-      generationId: formData.generationId,
-      redirect: false
-    })
-    if (!res?.error) return router.push(ROUTES.HOME)
-
-    const shouldBeUniqueFields = ["nickname", "email"]
-    const allFields = Object.keys(
-      confirmPasswordMergedCreateUserSchema._def.schema.shape
-    )
-    switch (res.code) {
-      case DuplicatedCredentialsErrorCode:
+    try {
+      await apiClient.signup({
+        name: formData.name,
+        nickname: formData.nickname,
+        email: formData.email,
+        password: formData.password,
+        sessions: formData.sessions,
+        generationId: formData.generationId
+      })
+      router.push(ROUTES.LOGIN + "?signup=success")
+    } catch (error) {
+      if (error instanceof ConflictError) {
+        const shouldBeUniqueFields = ["nickname", "email"]
         shouldBeUniqueFields.forEach((key) => {
           form.setError(
             key as keyof z.infer<typeof confirmPasswordMergedCreateUserSchema>,
@@ -92,31 +85,19 @@ const SignupForm = () => {
           description: "이미 가입된 회원 정보입니다.",
           variant: "destructive"
         })
-        break
-
-      case InvalidSignupCredentialsErrorCode:
-        allFields.forEach((key) => {
-          form.setError(
-            key as keyof z.infer<typeof confirmPasswordMergedCreateUserSchema>,
-            {
-              type: "manual",
-              message: "회원가입 정보가 올바르지 않습니다."
-            }
-          )
-        })
+      } else if (error instanceof ValidationError) {
         toast({
           title: "회원가입 실패",
           description: "회원가입 정보가 올바르지 않습니다.",
           variant: "destructive"
         })
-        break
-
-      default:
+      } else {
         toast({
           title: "회원가입 실패",
           description: "알 수 없는 에러 발생!",
           variant: "destructive"
         })
+      }
     }
   }
 

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -5,7 +5,7 @@ import { signIn } from "next-auth/react"
 import { Oleo_Script } from "next/font/google"
 import Image from "next/image"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
@@ -16,7 +16,8 @@ import { Label } from "@/components/ui/label"
 import ROUTES from "@/constants/routes"
 import {
   InvalidSigninCredentialsErrorCode,
-  InvalidSigninErrorCode
+  InvalidSigninErrorCode,
+  UserNotApprovedErrorCode
 } from "@/lib/auth/errors"
 import { cn } from "@/lib/utils"
 import { LoginUserSchema } from "@repo/shared-types"
@@ -25,6 +26,8 @@ const OleoScript = Oleo_Script({ subsets: ["latin"], weight: "400" })
 
 const Login = () => {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const signupSuccess = searchParams.get("signup") === "success"
   const { toast } = useToast()
 
   const {
@@ -50,6 +53,14 @@ const Login = () => {
         setError("password", {
           type: "manual",
           message: "이메일 또는 비밀번호가 일치하지 않습니다."
+        })
+        break
+
+      case UserNotApprovedErrorCode:
+        toast({
+          title: "로그인 실패",
+          description: "관리자 승인 후 로그인이 가능합니다.",
+          variant: "destructive"
         })
         break
 
@@ -102,6 +113,11 @@ const Login = () => {
           <h5 className="mb-8 text-sm font-normal text-slate-400">
             계속하려면 로그인해주세요
           </h5>
+          {signupSuccess && (
+            <div className="mb-6 w-full rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 lg:max-w-sm">
+              회원가입이 완료되었습니다. 관리자 승인 후 로그인이 가능합니다.
+            </div>
+          )}
           {/* 일반 로그인 */}
           <form
             className="flex w-full flex-col items-center"

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -6,6 +6,7 @@ import { Oleo_Script } from "next/font/google"
 import Image from "next/image"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
+import { Suspense } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
@@ -23,6 +24,14 @@ import { cn } from "@/lib/utils"
 import { LoginUserSchema } from "@repo/shared-types"
 
 const OleoScript = Oleo_Script({ subsets: ["latin"], weight: "400" })
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <Login />
+    </Suspense>
+  )
+}
 
 const Login = () => {
   const router = useRouter()
@@ -169,5 +178,3 @@ const Login = () => {
     </div>
   )
 }
-
-export default Login

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -2,21 +2,19 @@ import type { Session } from "next-auth"
 import NextAuth, { NextAuthConfig, User } from "next-auth"
 import Credentials from "next-auth/providers/credentials"
 
+import { UserNotApprovedError } from "@repo/api-client"
+import { LoginUser, LoginUserSchema } from "@repo/shared-types"
+
 import { apiClient } from "@/lib/apiClient"
-import { InvalidSigninCredentialsError } from "@/lib/auth/errors"
 import {
-  CreateUser,
-  CreateUserSchema,
-  LoginUser,
-  LoginUserSchema
-} from "@repo/shared-types"
+  InvalidSigninCredentialsError,
+  UserNotApprovedSigninError
+} from "@/lib/auth/errors"
 
 const authOptions: NextAuthConfig = {
   providers: [
     Credentials({
       credentials: {
-        name: { label: "Name", type: "text" },
-        nickname: { label: "Nickname", type: "text" },
         email: {
           label: "Email",
           type: "email",
@@ -27,48 +25,17 @@ const authOptions: NextAuthConfig = {
           label: "Password",
           type: "password",
           placeholder: "********"
-        },
-        sessions: { label: "Sessions", type: "text" },
-        generationId: { label: "Generation", type: "text" },
-        csrfToken: { label: "csrfToken", type: "hidden" },
-        callbackUrl: { label: "callbackUrl", type: "hidden" }
+        }
       },
       /**
-       * 로그인 또는 회원가입 시 호출되는 함수
+       * 로그인 시 호출되는 함수
        * @param credentials 유저가 입력한 로그인 정보
        * @returns `null`을 반환하면 로그인 실패, `object`를 반환하면 로그인 성공되어 `jwt` 콜백의 `user`으로 전달됨
        */
       authorize: async (credentials) => {
-        const { name, nickname, email, generationId, sessions, password } =
-          credentials as {
-            id?: string
-            name?: string
-            nickname?: string
-            email?: string
-            generationId?: string
-            sessions?: string
-            password?: string
-          }
-        let parsedGenerationId: number | undefined
-        let parsedSessions: number[] | undefined
-        if (generationId) {
-          parsedGenerationId = parseInt(generationId as string)
-        }
-        if (sessions) {
-          parsedSessions =
-            (sessions as string).split(",").map((s) => parseInt(s)) || []
-        }
-
-        if (name && nickname && sessions) {
-          const userInfo = await CreateUserSchema.parseAsync({
-            name,
-            nickname,
-            email,
-            password,
-            generationId: parsedGenerationId,
-            sessions: parsedSessions
-          })
-          return signup({ ...userInfo })
+        const { email, password } = credentials as {
+          email?: string
+          password?: string
         }
         const userInfo = await LoginUserSchema.parseAsync({
           email,
@@ -128,6 +95,9 @@ const authOptions: NextAuthConfig = {
         }
       } catch (error) {
         console.error("Error refreshing access token", error)
+        if (error instanceof UserNotApprovedError) {
+          return { ...token, error: "UserNotApprovedError" }
+        }
         return { ...token, error: "RefreshAccessTokenError" }
       }
     },
@@ -187,37 +157,10 @@ async function login({ email, password }: LoginUser) {
     } as User
   } catch (error) {
     console.error("[auth] login error:", error)
-    throw new InvalidSigninCredentialsError()
-  }
-}
-
-async function signup({
-  name,
-  nickname,
-  email,
-  password,
-  generationId,
-  sessions
-}: CreateUser) {
-  const { user, accessToken, expiresIn, refreshToken } = await apiClient.signup(
-    {
-      name,
-      nickname,
-      email,
-      password,
-      generationId,
-      sessions
+    if (error instanceof UserNotApprovedError) {
+      throw new UserNotApprovedSigninError()
     }
-  )
-  return {
-    id: user.id.toString(),
-    name: user.name,
-    nickname: user.nickname,
-    email: user.email,
-    isAdmin: user.isAdmin,
-    accessToken,
-    refreshToken,
-    expiresIn
+    throw new InvalidSigninCredentialsError()
   }
 }
 

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -7,6 +7,7 @@ const ROUTES = {
   ADMIN: {
     INDEX: "/admin",
     USERS: "/admin/users",
+    PENDING_USERS: "/admin/pending-users",
     GENERATIONS: "/admin/generations",
     PERFORMANCES: "/admin/performances",
     TEAMS: "/admin/teams",

--- a/apps/web/hooks/api/useUser.ts
+++ b/apps/web/hooks/api/useUser.ts
@@ -16,3 +16,12 @@ export const useUpdatePassword = createMutationHook(
 export const useUpdateUser = createMutationHook(ApiClient.prototype.updateUser)
 
 export const useDeleteUser = createMutationHook(ApiClient.prototype.deleteUser)
+
+export const usePendingUsers = createQueryHook(
+  ApiClient.prototype.getPendingUsers,
+  () => ["pendingUsers"]
+)
+
+export const useApproveUser = createMutationHook(
+  ApiClient.prototype.approveUser
+)

--- a/apps/web/lib/auth/errors.ts
+++ b/apps/web/lib/auth/errors.ts
@@ -27,3 +27,8 @@ export const InvalidSigninCredentialsErrorCode = "Signin/Unauthorized"
 export class InvalidSigninCredentialsError extends CredentialsSignin {
   code = InvalidSigninCredentialsErrorCode
 }
+
+export const UserNotApprovedErrorCode = "User/NotApproved"
+export class UserNotApprovedSigninError extends CredentialsSignin {
+  code = UserNotApprovedErrorCode
+}

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -260,6 +260,19 @@ export class InvalidPerformanceDateError extends ApiError {
 }
 
 // ----------------------------------
+// Approve Specific Errors
+// ----------------------------------
+export class UserNotApprovedError extends ApiError {
+  readonly type = "/errors/user/not-approved"
+  readonly status = 403
+  readonly title = "User Not Approved"
+
+  constructor(detail?: string, instance?: string) {
+    super("관리자 승인 후 로그인이 가능합니다.", detail, instance)
+  }
+}
+
+// ----------------------------------
 // Token Specific Errors
 // ----------------------------------
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -812,6 +812,18 @@ export default class ApiClient {
   }
 
   /**
+   * 승인 대기 중인 유저 목록 조회 (관리자용 API)
+   * @throws {ForbiddenError} 관리자 권한이 없는 경우
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public getPendingUsers() {
+    return this._request<
+      DetailedUserList,
+      ForbiddenError | InternalServerError
+    >(`/users/admin/pending`, "GET")
+  }
+
+  /**
    * 특정 유저 조회
    * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
    * @throws {InternalServerError} 서버 오류 발생 시
@@ -898,6 +910,19 @@ export default class ApiClient {
   }
 
   /**
+   * 유저 승인 (관리자용 API)
+   * @throws {ForbiddenError} 관리자 권한이 없는 경우
+   * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
+   * @throws {InternalServerError} 서버 오류 발생 시
+   */
+  public approveUser(id: number) {
+    return this._request<
+      DetailedUser,
+      ForbiddenError | NotFoundError | InternalServerError
+    >(`/users/${id}/approve`, "PATCH")
+  }
+
+  /**
    * 회원가입
    * @throws {ValidationError}
    * @throws {ConflictError}
@@ -917,6 +942,7 @@ export default class ApiClient {
   /**
    * 로그인
    * @throws {AuthError}
+   * @throws {UserNotApprovedError} 아직 승인되지 않은 계정인 경우
    * @throws {InternalServerError}
    */
   public login(loginUser: LoginUser) {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -946,11 +946,10 @@ export default class ApiClient {
    * @throws {InternalServerError}
    */
   public login(loginUser: LoginUser) {
-    return this._request<AuthResponse, AuthError | InternalServerError>(
-      "/auth/login",
-      "POST",
-      loginUser
-    )
+    return this._request<
+      AuthResponse,
+      AuthError | UserNotApprovedError | InternalServerError
+    >("/auth/login", "POST", loginUser)
   }
 
   /**
@@ -979,13 +978,15 @@ export default class ApiClient {
 
   /**
    * 토큰 갱신
+   * @throws {AuthError}
+   * @throws {UserNotApprovedError} 아직 승인되지 않은 계정인 경우
+   * @throws {InternalServerError}
    */
   public refreshToken(refreshToken: string) {
-    return this._request<RefreshTokenResponse, AuthError | InternalServerError>(
-      "/auth/refresh",
-      "POST",
-      { refreshToken }
-    )
+    return this._request<
+      RefreshTokenResponse,
+      AuthError | UserNotApprovedError | InternalServerError
+    >("/auth/refresh", "POST", { refreshToken })
   }
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -22,6 +22,7 @@ import {
   RefreshTokenResponse,
   SessionDetail,
   SessionList,
+  SignUpResponse,
   TeamApplication,
   TeamDetail,
   TeamList,
@@ -63,7 +64,8 @@ import {
   RefreshTokenExpiredError,
   SessionNotFoundError,
   UnprocessableEntityError,
-  ValidationError
+  ValidationError,
+  UserNotApprovedError
 } from "./errors"
 
 /**
@@ -108,6 +110,8 @@ function createErrorFromProblemDocument(problemDoc: ProblemDocument): ApiError {
       return new ReferencedEntityNotFoundError(detail, instance)
     case "/errors/performance/invalid-performance-date":
       return new InvalidPerformanceDateError(detail, instance)
+    case "/errors/user/not-approved":
+      return new UserNotApprovedError(detail, instance)
     case "/errors/token/refresh-token-expired":
       return new RefreshTokenExpiredError(detail, instance)
     case "/errors/token/access-token-expired":
@@ -902,7 +906,7 @@ export default class ApiClient {
    */
   public signup(userData: CreateUser) {
     return this._request<
-      AuthResponse,
+      SignUpResponse,
       | ValidationError
       | ConflictError
       | UnprocessableEntityError

--- a/packages/database/prisma/migrations/20260404101735_add_is_approved_into_user_model/migration.sql
+++ b/packages/database/prisma/migrations/20260404101735_add_is_approved_into_user_model/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "isApproved" BOOLEAN NOT NULL DEFAULT false;
+
+-- Approve all existing users
+UPDATE "users" SET "isApproved" = true;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   bio                String?
   image              String?
   isAdmin            Boolean  @default(false)
+  isApproved         Boolean  @default(false)
   hashedRefreshToken String?
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt

--- a/packages/database/prisma/seeds/03-user.seed.ts
+++ b/packages/database/prisma/seeds/03-user.seed.ts
@@ -43,6 +43,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
         bio: `안녕하세요. 아망 ${generation.order / 2}기 ${nickname}입니다.`,
         image,
         isAdmin: true,
+        isApproved: true,
         generation: {
           connect: {
             id: generation.id
@@ -79,6 +80,7 @@ export const seedUsers = async (prisma: PrismaClient) => {
         bio: `안녕하세요. 아망 ${generation.order / 2}기 ${nickname}입니다.`,
         image,
         isAdmin: false,
+        isApproved: true,
         generation: {
           connect: {
             id: generation.id

--- a/packages/shared-types/src/auth/auth.types.ts
+++ b/packages/shared-types/src/auth/auth.types.ts
@@ -20,3 +20,7 @@ export type RefreshTokenResponse = {
 export type LogoutResponse = {
   message: string
 }
+
+export type SignUpResponse = {
+  message: string
+}

--- a/packages/shared-types/src/user/user.types.ts
+++ b/packages/shared-types/src/user/user.types.ts
@@ -21,7 +21,8 @@ export const publicUserSelector = {
 export const detailedUserSelector = {
   ...publicUserSelector,
   isAdmin: true,
-  email: true
+  email: true,
+  isApproved: true
 } satisfies Prisma.UserSelect
 
 export type publicUser = Prisma.UserGetPayload<{


### PR DESCRIPTION
## 🚀 작업 내용

> 작업하신 내용을 간략하게 설명해주세요.  
> (예: 로그인 페이지 UI 개선)

`User` 모델에 `isApproved` 속성을 추가하였습니다.
`isApproved` 속성은 기본적으로는 `false` 값을 가지며, Admin이 `true`로 바꿔주기전 까지는 로그인 및 토큰 획득이 불가능합니다.

1. 우선 **users/** 라우터에 Admin 전용 라우터인 `admin/pending`, `:id/approve` 를 추가하였습니다.
  `admin/pending`의 경우 모든 유저 중 아직 `isApproved` 속성이 `false`인 사용자만을 보여주고, `:id/approve`의 경우 PATCH 요청으로 해당 사용자를 승인하는데 사용됩니다.

2. **/auth/signup**의 경우 이제 유저 정보가 아닌 `{message: string}`을 반환합니다.
  회원가입 시 해당 사용자를 즉시 로그인 상태로 바꾸면 안되므로 회원가입에 성공했다는 메시지를 반환합니다.

3. **/auth/refresh**와 **/auth/login**의 경우 이제 `UserNotApprovedError`에러를 반환합니다.
  승인되지 않은 사용자가 로그인 혹은 토큰 리프레쉬를 요구할 경우 우선 해당 사용자가 승인되었는지 여부를 먼저 확인하고, 만약 아직 승인되지 않은 사용자라면 `UserNotApprovedError`에러를 반환합니다.

## 📸 스크린샷(선택)

## 🔗 관련 이슈

Closes #364 

## 🙏 리뷰어에게

## ✅ 체크리스트

- [X] conventional commits 형식을 따르는 title을 작성했습니다.
- [X] 적절한 label을 1개 이상 추가했습니다.
- [X] 관련 이슈가 연결되었습니다.

---

## 🚀 작업 내용 (FE 대응)

위 API 변경사항에 맞춰 프론트엔드를 대응하였습니다.

1. **회원가입을 next-auth에서 분리**: `auth.ts`의 `authorize` 콜백에서 회원가입 분기를 제거하고, `SignupForm`에서 `apiClient.signup()`을 직접 호출하도록 변경하였습니다. 가입 성공 시 `/login?signup=success`로 리다이렉트하여 안내 배너를 표시합니다.

2. **미승인 계정 로그인 차단 UX**: `auth.ts`의 `login()` 함수에서 `UserNotApprovedError`를 식별하여 `UserNotApprovedSigninError`로 변환하고, 로그인 페이지에서 "관리자 승인 후 로그인이 가능합니다" toast를 표시합니다.

3. **토큰 갱신 시 처리**: JWT 콜백의 refresh 로직에서 `UserNotApprovedError` 발생 시 `"UserNotApprovedError"` 에러를 세션에 전파합니다.

4. **관리자 승인 대기 페이지**: `/admin/pending-users` 페이지를 추가하였습니다. `DataTable`로 미승인 유저 목록을 표시하며, 승인/삭제 액션과 인라인 수정(`EditableCell`)을 지원합니다.

5. **타입 안전성 수정**: `ApiClient`의 `login()`, `refreshToken()` 메서드의 `_request` 제네릭 에러 타입에 `UserNotApprovedError`가 누락되어 있어 추가하였습니다.

## 📸 스크린샷(선택)

> 스크린샷은 별도 코멘트로 첨부 예정

## 🙏 리뷰어에게

- `auth.ts`에서 `signup()` 함수를 완전히 제거하고 회원가입을 next-auth와 분리한 것이 가장 큰 구조 변경입니다.
- `login/page.tsx`에 `useSearchParams()` 추가로 빌드 시 프리렌더링 에러가 발생하여 `Suspense`로 감쌌습니다.

## ✅ 체크리스트

- [X] conventional commits 형식을 따르는 title을 작성했습니다.
- [X] 적절한 label을 1개 이상 추가했습니다.
- [X] 관련 이슈가 연결되었습니다.