### PR TITLE
fix(web): 공연 목록 페이지 로그인 리다이렉트 버그 수정

### DIFF
--- a/apps/web/lib/providers/index.tsx
+++ b/apps/web/lib/providers/index.tsx
@@ -9,14 +9,39 @@ import { useEffect } from "react"
 import { ApiClientProvider } from "./api-client-provider"
 import ReactQueryProvider from "./react-query-provider"
 
+const MAX_REFRESH_RETRIES = 3
+
 function SessionGuard({ children }: { children: React.ReactNode }) {
-  const { data: session } = useSession()
+  const { data: session, update } = useSession()
 
   useEffect(() => {
-    if (session?.error === "RefreshAccessTokenError") {
-      signOut()
+    if (session?.error !== "RefreshAccessTokenError") return
+
+    let cancelled = false
+
+    const retryRefresh = async () => {
+      for (let attempt = 1; attempt <= MAX_REFRESH_RETRIES; attempt++) {
+        if (cancelled) return
+        console.warn(
+          `[SessionGuard] 토큰 갱신 재시도 ${attempt}/${MAX_REFRESH_RETRIES}`
+        )
+        const newSession = await update()
+        if (newSession && !newSession.error) return
+      }
+      if (!cancelled) {
+        console.error(
+          "[SessionGuard] 토큰 갱신 최대 재시도 초과, 로그아웃 처리"
+        )
+        signOut()
+      }
     }
-  }, [session?.error])
+
+    retryRefresh()
+
+    return () => {
+      cancelled = true
+    }
+  }, [session?.error, update])
 
   useEffect(() => {
     if (session?.user) {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -19,5 +19,5 @@ export async function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/admin", "/performances", "/profile", "/teams"] // 보호된 경로를 여기에 추가
+  matcher: ["/admin", "/profile"] // 보호된 경로를 여기에 추가
 }


### PR DESCRIPTION
## 🚀 작업 내용

공연 목록 페이지(`/performances`)에서 로그인된 상태에서도 간헐적으로 `/login`으로 리다이렉트되는 버그 수정.

**Root Cause:** `proxy.ts` matcher에 `/performances`, `/teams`가 포함되어 있어서, 서버사이드 `auth()` 호출 시 세션 체크 실패 시 공개 페이지임에도 `/login`으로 307 리다이렉트됨. Vercel 프로덕션 로그에서 `GET /performances → 307` 확인.

**변경 사항:**
- `proxy.ts` matcher에서 공개 경로(`/performances`, `/teams`) 제거 — 인증 필수 경로(`/admin`, `/profile`)만 유지
- `SessionGuard`에서 `RefreshAccessTokenError` 발생 시 즉시 `signOut()` 대신 최대 3회 `update()` 재시도 후 실패 시에만 로그아웃

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

N/A

## 🙏 리뷰어에게

- `proxy.ts`: 공개 페이지가 matcher에 포함되어 불필요하게 인증 게이트를 거치고 있었습니다. 향후 새 보호 경로 추가 시 matcher 업데이트 필요.
- `SessionGuard`: async loop로 재시도하며, cleanup 함수에서 `cancelled` 플래그로 언마운트 시 안전하게 중단합니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.