### PR TITLE
fix(api): production 환경에서 Prisma query 이벤트 로그 비활성화

### DIFF
--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -12,14 +12,18 @@ export class PrismaService
   implements OnModuleInit, OnModuleDestroy
 {
   private readonly logger = new Logger(PrismaService.name)
+  private static readonly isProduction =
+    process.env.NODE_ENV === "production"
 
   constructor() {
     super({
       log: [
-        { emit: "event", level: "query" },
         { emit: "event", level: "error" },
+        { emit: "event", level: "warn" },
         { emit: "event", level: "info" },
-        { emit: "event", level: "warn" }
+        ...(PrismaService.isProduction
+          ? []
+          : [{ emit: "event" as const, level: "query" as const }])
       ]
     })
   }
@@ -31,12 +35,16 @@ export class PrismaService
     this.$on("warn", (event) => {
       this.logger.warn(event)
     })
+
     this.$on("info", (event) => {
       this.logger.log(event)
     })
-    this.$on("query", (event) => {
-      this.logger.debug(event, "SQL Query")
-    })
+
+    if (!PrismaService.isProduction) {
+      this.$on("query", (event) => {
+        this.logger.debug(event, "SQL Query")
+      })
+    }
 
     await this.$connect()
   }


### PR DESCRIPTION
## 🚀 작업 내용

Production 환경에서 Prisma query 이벤트 로그를 비활성화하여 헬스체크 ping 등으로 인한 불필요한 로그 노이즈 제거.

- `PrismaService`에서 `NODE_ENV`에 따라 query 이벤트 등록을 분기
- Production: `error`, `warn`, `info` 이벤트만 등록
- Staging(development): 기존과 동일하게 `query` 포함 전체 이벤트 등록

## 📸 스크린샷(선택)

해당 없음

## 🔗 관련 이슈

없음

## 🙏 리뷰어에게

기존에 HTTP 레벨(`pino-http`)과 Sentry에서는 `/health` 필터링이 되어 있었지만, Prisma query 이벤트 레벨에서는 필터링이 없어 production에서도 헬스체크 쿼리 로그가 계속 발생하고 있었습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)