### PR TITLE
fix(api,web): refresh token rotation이 작동하도록 bcrypt에서 SHA-256 전환

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from "@nestjs/common"
 import { ConfigService } from "@nestjs/config"
 import { JwtService } from "@nestjs/jwt"
-import { AuthError, UserNotApprovedError } from "@repo/api-client"
+import {
+  AuthError,
+  RefreshTokenExpiredError,
+  RefreshTokenNotFoundError,
+  UserNotApprovedError
+} from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
 import * as bcrypt from "bcrypt"
 import { createHash, timingSafeEqual } from "crypto"
@@ -95,7 +100,7 @@ export class AuthService {
   async refreshTokens(userId: number, refreshToken: string) {
     const user = await this.usersService.findOneById(userId)
     if (!user || !user.hashedRefreshToken) {
-      throw new AuthError("Access Denied")
+      throw new RefreshTokenNotFoundError("리프레시 토큰이 존재하지 않습니다.")
     }
 
     if (!user.isApproved) {
@@ -103,12 +108,18 @@ export class AuthService {
     }
 
     const incomingHash = createHash("sha256").update(refreshToken).digest("hex")
+
+    if (incomingHash.length !== user.hashedRefreshToken.length)
+      throw new RefreshTokenExpiredError("리프레시 토큰이 유효하지 않습니다.")
+
     const refreshTokenMatches = timingSafeEqual(
       Buffer.from(incomingHash),
       Buffer.from(user.hashedRefreshToken)
     )
     if (!refreshTokenMatches) {
-      throw new AuthError("Access Denied")
+      throw new RefreshTokenExpiredError(
+        "리프레시 토큰이 만료되었거나 존재하지 않습니다."
+      )
     }
 
     const tokens = await this.getTokens(

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,13 +1,10 @@
 import { Injectable } from "@nestjs/common"
 import { ConfigService } from "@nestjs/config"
 import { JwtService } from "@nestjs/jwt"
-import {
-  AuthError,
-  ForbiddenError,
-  UserNotApprovedError
-} from "@repo/api-client"
+import { AuthError, UserNotApprovedError } from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
 import * as bcrypt from "bcrypt"
+import { createHash, timingSafeEqual } from "crypto"
 import { CreateUserDto } from "../users/dto/create-user.dto"
 import { LoginUserDto } from "../users/dto/login-user.dto"
 import { UsersService } from "../users/users.service"
@@ -98,19 +95,20 @@ export class AuthService {
   async refreshTokens(userId: number, refreshToken: string) {
     const user = await this.usersService.findOneById(userId)
     if (!user || !user.hashedRefreshToken) {
-      throw new ForbiddenError("Access Denied")
+      throw new AuthError("Access Denied")
     }
 
     if (!user.isApproved) {
       throw new UserNotApprovedError("아직 승인되지 않은 계정입니다.")
     }
 
-    const refreshTokenMatches = await bcrypt.compare(
-      refreshToken,
-      user.hashedRefreshToken
+    const incomingHash = createHash("sha256").update(refreshToken).digest("hex")
+    const refreshTokenMatches = timingSafeEqual(
+      Buffer.from(incomingHash),
+      Buffer.from(user.hashedRefreshToken)
     )
     if (!refreshTokenMatches) {
-      throw new ForbiddenError("Access Denied")
+      throw new AuthError("Access Denied")
     }
 
     const tokens = await this.getTokens(

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common"
 import { ConflictError, NotFoundError, ValidationError } from "@repo/api-client"
 import { Prisma } from "@repo/database"
 import * as bcrypt from "bcrypt"
+import { createHash } from "crypto"
 import { PrismaService } from "../prisma/prisma.service"
 import { CreateUserDto } from "./dto/create-user.dto"
 import { publicUserSelector, detailedUserSelector } from "@repo/shared-types"
@@ -87,7 +88,7 @@ export class UsersService {
 
   async updateRefreshToken(userId: number, refreshToken: string | null) {
     const hashedRefreshToken = refreshToken
-      ? await bcrypt.hash(refreshToken, 10)
+      ? createHash("sha256").update(refreshToken).digest("hex")
       : null
     await this.prisma.user.update({
       where: { id: userId },

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -85,12 +85,15 @@ const authOptions: NextAuthConfig = {
 
       // 토큰 갱신 시도
       try {
-        const { accessToken, expiresIn } = await refreshAccessToken(
-          token?.refreshToken as string
-        )
+        const {
+          accessToken,
+          refreshToken: newRefreshToken,
+          expiresIn
+        } = await refreshAccessToken(token?.refreshToken as string)
         return {
           ...token,
           accessToken,
+          refreshToken: newRefreshToken,
           expiresIn: Date.now() + expiresIn * 1000
         }
       } catch (error) {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -984,14 +984,20 @@ export default class ApiClient {
 
   /**
    * 토큰 갱신
-   * @throws {AuthError}
+   * @throws {RefreshTokenExpiredError} 리프레시 토큰이 만료되었거나 유효하지 않은 경우
+   * @throws {RefreshTokenNotFoundError} 리프레시 토큰이 존재하지 않는 경우 (로그아웃 상태)
+   * @throws {AuthError} 토큰 형식이 올바르지 않은 경우
    * @throws {UserNotApprovedError} 아직 승인되지 않은 계정인 경우
-   * @throws {InternalServerError}
+   * @throws {InternalServerError} 서버 오류 발생 시
    */
   public refreshToken(refreshToken: string) {
     return this._request<
       RefreshTokenResponse,
-      AuthError | UserNotApprovedError | InternalServerError
+      | RefreshTokenExpiredError
+      | RefreshTokenNotFoundError
+      | AuthError
+      | UserNotApprovedError
+      | InternalServerError
     >("/auth/refresh", "POST", { refreshToken })
   }
 }

--- a/packages/shared-types/src/auth/auth.types.ts
+++ b/packages/shared-types/src/auth/auth.types.ts
@@ -14,6 +14,7 @@ export type AuthResponse = {
 
 export type RefreshTokenResponse = {
   accessToken: string
+  refreshToken: string
   expiresIn: number
 }
 


### PR DESCRIPTION
## 🚀 작업 내용

bcrypt 72-byte 절삭 문제로 refresh token rotation이 사실상 무력화되어 있던 보안 이슈 수정.

**버그 1 (백엔드):** bcrypt는 입력의 첫 72바이트만 해싱하는데, 같은 유저의 JWT refresh token은 header+payload 앞부분이 동일하여 첫 72바이트가 항상 같음. 이전 refresh token으로도 bcrypt.compare가 성공하여 rotation 무력화.

**버그 2 (프론트):** auth.ts JWT callback에서 refresh 응답의 새 refreshToken을 destructuring에서 누락하여 저장하지 않음. 이전 refresh token을 계속 재사용.

**두 버그가 서로를 은폐:** 프론트가 옛날 RT를 보내도 bcrypt가 통과시켜주므로, 프로젝트 처음부터 존재했지만 아무 문제 없는 것처럼 동작했음. 하나만 고치면 즉시 깨지므로 반드시 동시 수정 필요.

**변경 사항:**
- users.service.ts: refresh token 해싱을 bcrypt.hash()에서 SHA-256으로 변경 (전체 토큰 비교 가능)
- auth.service.ts: refresh token 비교를 bcrypt.compare()에서 timingSafeEqual로 변경 (timing attack 방지)
- RefreshTokenResponse 타입에 refreshToken 필드 추가 (백엔드가 이미 반환하고 있었으나 타입 누락)
- auth.ts JWT callback에서 새 refreshToken을 저장하도록 수정

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #392

## 🙏 리뷰어에게

- 배포 시 기존 유저의 DB hashedRefreshToken이 bcrypt 형식이므로, 배포 직후 첫 refresh는 실패하여 재로그인이 필요합니다. 이후부터는 SHA-256으로 정상 작동합니다.
- 비밀번호 해싱은 여전히 bcrypt를 사용합니다 (비밀번호는 짧으므로 72바이트 제한에 영향 없음).

## 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.