### PR TITLE
fix(infra): MCP 서버 VSCode 세션 타임아웃 해결 및 플러그인 전환

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -5,8 +5,5 @@
 # Notion: https://www.notion.so/profile/integrations 에서 아망 워크스페이스 Internal Integration 생성
 export NOTION_TOKEN=ntn_xxx
 
-# Figma: https://www.figma.com/developers/api#access-tokens 에서 Personal Access Token 생성
-export FIGMA_API_KEY=figd_xxx
-
 # Slack: 팀 공용 봇 토큰 — 장수에게 문의
 export SLACK_BOT_TOKEN=xoxb-xxx

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,45 +1,23 @@
 {
   "mcpServers": {
     "notion": {
-      "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
-      "env": {
-        "NOTION_TOKEN": "${NOTION_TOKEN}"
-      }
-    },
-    "figma": {
-      "command": "npx",
-      "args": ["-y", "figma-developer-mcp", "--stdio"],
-      "env": {
-        "FIGMA_API_KEY": "${FIGMA_API_KEY}"
-      }
+      "command": "direnv",
+      "args": ["exec", ".", "notion-mcp-server"]
     },
     "slack": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-slack"],
+      "command": "direnv",
+      "args": ["exec", ".", "mcp-server-slack"],
       "env": {
-        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
         "SLACK_TEAM_ID": "T07LTTU4WSZ"
       }
     },
-    "vercel": {
-      "type": "http",
-      "url": "https://mcp.vercel.com"
-    },
     "kubernetes": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-kubernetes"],
-      "env": {
-        "KUBECONFIG": "${KUBECONFIG}"
-      }
+      "command": "direnv",
+      "args": ["exec", ".", "mcp-server-kubernetes"]
     },
     "postgres": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-postgres", "${DATABASE_URL}"]
-    },
-    "sentry": {
-      "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
+      "command": "direnv",
+      "args": ["exec", ".", "sh", "-c", "mcp-server-postgres $DATABASE_URL"]
     }
   }
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,6 +51,16 @@ else
   HAS_DIRENV=true
 fi
 
+# Claude Code (선택)
+HAS_CLAUDE=false
+if command -v claude &>/dev/null; then
+  ok "Claude Code $(claude --version 2>/dev/null || echo '')"
+  HAS_CLAUDE=true
+else
+  warn "Claude Code가 설치되어 있지 않습니다. AI 도구 연동 시 필요합니다."
+  warn "설치: https://docs.anthropic.com/en/docs/claude-code"
+fi
+
 echo ""
 
 # ─── 2. pnpm 활성화 ───
@@ -133,7 +143,21 @@ ok "시드 완료"
 
 echo ""
 
-# ─── 8. 완료 ───
+# ─── 8. Claude Code 플러그인 (선택) ───
+if [ "$HAS_CLAUDE" = true ]; then
+  echo -en "${CYAN}[INFO]${NC} Claude Code 플러그인을 설치하시겠습니까? (Figma 등 MCP 도구 연동) [Y/n] "
+  read -r REPLY
+  if [[ -z "$REPLY" || "$REPLY" =~ ^[Yy]$ ]]; then
+    info "Claude Code 플러그인 설치 중..."
+    claude plugins install figma 2>/dev/null && ok "figma 플러그인 설치 완료" || warn "figma 플러그인 설치 실패"
+    echo ""
+  else
+    info "Claude Code 플러그인 설치를 건너뜁니다."
+    echo ""
+  fi
+fi
+
+# ─── 9. 완료 ───
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}  셋업 완료!${NC}"
 echo -e "${GREEN}========================================${NC}"


### PR DESCRIPTION
## 🚀 작업 내용

VSCode에서 Claude Code 세션 시작 시 MCP 서버 5개가 30초 타임아웃으로 연결 실패하는 문제 해결.

**원인:**
1. VSCode 확장이 direnv를 거치지 않아 환경변수 미주입 → 서버 초기화 실패
2. `npx -y`가 매번 registry 확인으로 ~20초 소요 → 동시 실행 시 타임아웃 초과

**변경:**
- `.mcp.json`: `npx -y` → `direnv exec . <글로벌 바이너리>`로 변경 (20초 → 1초)
- `.mcp.json`: 플러그인으로 대체 가능한 서버(figma, vercel, sentry) 제거
- `.envrc.local.example`: `FIGMA_API_KEY` 항목 제거 (플러그인 OAuth로 대체)
- `scripts/setup.sh`: Claude Code 감지 및 플러그인 설치 [Y/n] 옵션 추가

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #396

## 🙏 리뷰어에게

- MCP 서버를 글로벌 바이너리로 실행하므로, 팀원은 해당 패키지를 글로벌 설치해야 합니다:
  ```bash
  pnpm add -g @notionhq/notion-mcp-server @modelcontextprotocol/server-slack mcp-server-kubernetes @modelcontextprotocol/server-postgres
  ```
- Figma는 `claude plugins install figma` 플러그인(OAuth)으로 대체되어 API 키 갱신이 불필요합니다.
- Vercel, Sentry는 동일한 HTTP URL의 플러그인이 이미 설치되어 있어 중복 제거했습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.