### PR TITLE
fix(web): 비로그인 상태에서 팀 지원 UI 숨김 처리

### DIFF
--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailClient.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailClient.tsx
@@ -16,6 +16,7 @@ import SessionBadge from "@/components/TeamBadges/SessionBadge"
 import { Button } from "@/components/ui/button"
 import ROUTES from "@/constants/routes"
 import { getSessionDisplayName } from "@/constants/session"
+import Link from "next/link"
 import { useTeam } from "@/hooks/api/useTeam"
 import { useTeamPermission } from "@/hooks/useTeamPermission"
 import { getMissingIndices } from "@/lib/team/teamSession"
@@ -166,81 +167,95 @@ const TeamDetailClient = () => {
             }
             className="col-span-2 bg-white shadow-[0_4px_30px_0_rgba(59,130,246,0.07)]"
           >
-            <ul className="mb-6 mt-[12px] w-full text-xs font-normal leading-5 text-gray-600 md:mt-[16px] md:w-[537px]">
-              <li className="mb-1 md:mb-[10px]">
-                ・아래 버튼을 눌러 해당 팀에 참여 신청을 할 수 있으며,
-                선착순으로 마감됩니다
-              </li>
-              <li>
-                <span className="md:hidden">
-                  ・아래 버튼을 다시 누르거나 마이페이지에 접속하여 신청을
-                  취소할 수 있습니다
-                </span>
-                <span className="hidden md:inline">
-                  ・해당 페이지 혹은 마이페이지를 통해 신청을 취소할 수 있습니다
-                </span>
-              </li>
-            </ul>
-
-            {/* 빈 자리 세션 버튼들 */}
-            <div className="grid grid-cols-2 gap-3 md:flex md:flex-wrap">
-              {team.teamSessions?.map((ts) => {
-                const missingIndices = getMissingIndices(ts)
-                return missingIndices.map((index) => {
-                  const selected = isSelected(ts.session.id, index)
-                  return (
-                    <ApplyButton
-                      key={`apply-${ts.session.id}-${index}`}
-                      sessionName={ts.session.name}
-                      sessionIndex={index}
-                      isSelected={selected}
-                      onToggle={() => {
-                        if (selected) {
-                          onRemoveSession(ts.session.id, index)
-                        } else {
-                          onAppendSession(ts.session.id, index)
-                        }
-                      }}
-                    />
-                  )
-                })
-              })}
-            </div>
-
-            {/* 지원하기 버튼 (모바일) */}
-            {selectedSessions.length > 0 && (
-              <Button
-                shape="round"
-                className="mt-6 w-full md:hidden"
-                onClick={onSubmit}
-              >
-                지원하기
-              </Button>
-            )}
-
-            {team.teamSessions?.every(
-              (ts) => getMissingIndices(ts).length === 0
-            ) && (
-              <div className="py-4 text-center text-sm text-gray-400">
-                모든 세션이 마감되었습니다.
+            {session.status === "unauthenticated" ? (
+              <div className="py-8 text-center">
+                <p className="mb-4 text-sm text-gray-500">
+                  로그인 후 세션에 지원할 수 있습니다.
+                </p>
+                <Button shape="round" asChild>
+                  <Link href={ROUTES.LOGIN}>로그인하기</Link>
+                </Button>
               </div>
-            )}
-
-            {/* 지원하기 버튼 (데스크탑) - 카드 안쪽 하단 우측 */}
-            {selectedSessions.length > 0 && (
+            ) : (
               <>
-                <div className="my-4 hidden h-px w-full bg-slate-200 md:block" />
-                <div className="hidden justify-end md:flex">
+                <ul className="mb-6 mt-[12px] w-full text-xs font-normal leading-5 text-gray-600 md:mt-[16px] md:w-[537px]">
+                  <li className="mb-1 md:mb-[10px]">
+                    ・아래 버튼을 눌러 해당 팀에 참여 신청을 할 수 있으며,
+                    선착순으로 마감됩니다
+                  </li>
+                  <li>
+                    <span className="md:hidden">
+                      ・아래 버튼을 다시 누르거나 마이페이지에 접속하여 신청을
+                      취소할 수 있습니다
+                    </span>
+                    <span className="hidden md:inline">
+                      ・해당 페이지 혹은 마이페이지를 통해 신청을 취소할 수
+                      있습니다
+                    </span>
+                  </li>
+                </ul>
+
+                {/* 빈 자리 세션 버튼들 */}
+                <div className="grid grid-cols-2 gap-3 md:flex md:flex-wrap">
+                  {team.teamSessions?.map((ts) => {
+                    const missingIndices = getMissingIndices(ts)
+                    return missingIndices.map((index) => {
+                      const selected = isSelected(ts.session.id, index)
+                      return (
+                        <ApplyButton
+                          key={`apply-${ts.session.id}-${index}`}
+                          sessionName={ts.session.name}
+                          sessionIndex={index}
+                          isSelected={selected}
+                          onToggle={() => {
+                            if (selected) {
+                              onRemoveSession(ts.session.id, index)
+                            } else {
+                              onAppendSession(ts.session.id, index)
+                            }
+                          }}
+                        />
+                      )
+                    })
+                  })}
+                </div>
+
+                {/* 지원하기 버튼 (모바일) */}
+                {selectedSessions.length > 0 && (
                   <Button
-                    variant="outlinePrimary"
                     shape="round"
-                    className="w-[120px] gap-2"
+                    className="mt-6 w-full md:hidden"
                     onClick={onSubmit}
                   >
                     지원하기
-                    <span aria-hidden="true">&gt;</span>
                   </Button>
-                </div>
+                )}
+
+                {team.teamSessions?.every(
+                  (ts) => getMissingIndices(ts).length === 0
+                ) && (
+                  <div className="py-4 text-center text-sm text-gray-400">
+                    모든 세션이 마감되었습니다.
+                  </div>
+                )}
+
+                {/* 지원하기 버튼 (데스크탑) - 카드 안쪽 하단 우측 */}
+                {selectedSessions.length > 0 && (
+                  <>
+                    <div className="my-4 hidden h-px w-full bg-slate-200 md:block" />
+                    <div className="hidden justify-end md:flex">
+                      <Button
+                        variant="outlinePrimary"
+                        shape="round"
+                        className="w-[120px] gap-2"
+                        onClick={onSubmit}
+                      >
+                        지원하기
+                        <span aria-hidden="true">&gt;</span>
+                      </Button>
+                    </div>
+                  </>
+                )}
               </>
             )}
           </SessionSetCard>


### PR DESCRIPTION
## 🚀 작업 내용

비로그인 유저에게 세션 지원 버튼이 노출되어 클릭 시 `AccessTokenNotFoundError`(401)가 발생하고 Sentry에 unhandled error로 보고되던 문제를 수정합니다.

**변경 사항:**
- 팀 상세 페이지에서 `session.status === "unauthenticated"`일 때 세션 지원 UI 대신 로그인 유도 메시지와 로그인 버튼을 표시

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #404

## 🙏 리뷰어에게

- 기존 `useSession()` 훅을 이미 사용하고 있어서 추가 의존성 없이 분기 처리만 추가했습니다.
- 탈퇴 버튼(`MemberSessionCard`)은 기존에 `authSession.data?.user.id` 비교로 본인만 노출되어 별도 처리 불필요합니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
