### PR TITLE
chore: MCP 서버 이름에 amang- prefix 추가

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -30,14 +30,14 @@ argument-hint: "[이전 회의 노션 URL (생략 시 자동 탐색)]"
 
 `$ARGUMENTS`에 노션 URL이 있으면 해당 페이지 사용. 없으면:
 
-1. `mcp__notion__API-query-data-source`로 회의록 DB(`29a779af-a9b3-44a1-954a-bc780abc9cfc`)를 `일시` 내림차순으로 쿼리
+1. `mcp__amang-notion__API-query-data-source`로 회의록 DB(`29a779af-a9b3-44a1-954a-bc780abc9cfc`)를 `일시` 내림차순으로 쿼리
 2. 가장 최근 2개 페이지 가져오기 (직전 회의 = 두 번째, 현재 회의 = 첫 번째)
-3. `mcp__notion__API-retrieve-a-page`로 직전 회의의 `일시` 속성에서 날짜 추출 → 수집 시작일
+3. `mcp__amang-notion__API-retrieve-a-page`로 직전 회의의 `일시` 속성에서 날짜 추출 → 수집 시작일
 4. 직전 회의의 제목에서 차수(N차) 추출 → 이행 상황 표시에 사용
 
 ### 3단계: 직전 회의 작업 분배 파싱
 
-`mcp__notion__API-get-block-children`으로 직전 회의 페이지의 블록을 가져온다.
+`mcp__amang-notion__API-get-block-children`으로 직전 회의 페이지의 블록을 가져온다.
 `# 작업 분배` 섹션을 찾아 하위 블록을 파싱:
 - 호출자에게 분배된 작업 영역별(프론트, 백엔드, 인프라 등) 항목 추출
 - `has_children: true`인 블록은 재귀적으로 children 조회
@@ -74,7 +74,7 @@ gh pr list --repo skku-amang/main --state all \
 
 #### 에이전트 C: Sentry 에러
 
-`mcp__sentry__search_issues`로 web, api 프로젝트의 이슈 검색.
+`mcp__amang-sentry__search_issues`로 web, api 프로젝트의 이슈 검색.
 
 수집 필드: 이슈 ID, 에러 제목, 프로젝트(web/api), 이벤트 수, 상태(resolved/unresolved), 담당자
 해결된 이슈는 관련 PR 번호 매핑 시도 (커밋 메시지, PR 제목에서 Sentry 이슈 ID 검색)
@@ -116,7 +116,7 @@ GitHub 이슈/PR의 `scope:` 라벨로 영역을 판정한다. 라벨이 SSOT이
 
 사용자가 승인하면 Notion MCP 도구로 현재 회의 페이지에 작성:
 
-- `mcp__notion__API-patch-block-children`으로 블록 추가
+- `mcp__amang-notion__API-patch-block-children`으로 블록 추가
 - `heading_3`은 `is_toggleable: true` + children으로 항목 삽입
 - 이슈/PR 링크는 Notion rich text의 `link` 속성 사용
 - `@멘션`은 가능하면 Notion user mention 사용, 불가하면 plain text `@이름`
@@ -125,6 +125,6 @@ GitHub 이슈/PR의 `scope:` 라벨로 영역을 판정한다. 라벨이 SSOT이
 ## 주의사항
 
 - Notion MCP 서버가 연결 안 되면 환경변수 로드 확인 (`direnv allow`) 후 세션 재시작. 재시작 후에도 안 되면 사용자에게 알림
-- Notion API에서 `unsupported` 블록은 건너뛰고, `has_children: true`인 블록은 `mcp__notion__API-get-block-children`으로 재귀 탐색
+- Notion API에서 `unsupported` 블록은 건너뛰고, `has_children: true`인 블록은 `mcp__amang-notion__API-get-block-children`으로 재귀 탐색
 - Sentry MCP 도구 권한 오류 시 `search_issues`만으로 수집 가능
 - 회의록 DB에 현재 회의 페이지가 아직 없으면 사용자에게 생성 요청

--- a/.claude/skills/meeting-prep/reference.md
+++ b/.claude/skills/meeting-prep/reference.md
@@ -53,7 +53,7 @@ Notion API가 지원하지 않는 블록 타입 (예: synced_block, column_list 
 
 ### has_children 블록
 
-`has_children: true`인 블록은 `mcp__notion__API-get-block-children`으로 별도 조회해야 내용을 볼 수 있다.
+`has_children: true`인 블록은 `mcp__amang-notion__API-get-block-children`으로 별도 조회해야 내용을 볼 수 있다.
 - heading_3 토글의 실제 내용은 children에 있음
 - 재귀적으로 탐색 필요 (예: bullet 안에 sub-bullet)
 

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -7,3 +7,7 @@ export NOTION_TOKEN=ntn_xxx
 
 # Slack: 팀 공용 봇 토큰 — 장수에게 문의
 export SLACK_BOT_TOKEN=xoxb-xxx
+
+# Sentry: https://sentry.io/settings/account/api/auth-tokens/ 에서 User Auth Token 생성
+# scope: org:read, project:read, event:read, issue:read
+export SENTRY_ACCESS_TOKEN=sntryu_xxx

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,23 +1,27 @@
 {
   "mcpServers": {
-    "notion": {
+    "amang-notion": {
       "command": "direnv",
       "args": ["exec", ".", "notion-mcp-server"]
     },
-    "slack": {
+    "amang-slack": {
       "command": "direnv",
       "args": ["exec", ".", "mcp-server-slack"],
       "env": {
         "SLACK_TEAM_ID": "T07LTTU4WSZ"
       }
     },
-    "kubernetes": {
+    "amang-kubernetes": {
       "command": "direnv",
       "args": ["exec", ".", "mcp-server-kubernetes"]
     },
-    "postgres": {
+    "amang-postgres": {
       "command": "direnv",
       "args": ["exec", ".", "sh", "-c", "mcp-server-postgres $DATABASE_URL"]
+    },
+    "amang-sentry": {
+      "command": "direnv",
+      "args": ["exec", ".", "sentry-mcp"]
     }
   }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- `.mcp.json`의 모든 MCP 서버 이름에 `amang-` prefix 추가 (notion → amang-notion 등)
- Sentry MCP 서버 신규 추가 (`amang-sentry`, User Auth Token 방식)
- meeting-prep 스킬의 MCP 도구 참조명을 새 이름에 맞게 업데이트

**Why**: claude.ai 클라우드 커넥터(`mcp__claude_ai_Sentry__*` 등)와 로컬 MCP 서버 이름 충돌 방지

**Setup**: 새 Sentry MCP 서버 사용을 위해 `.envrc.local`에 추가 필요:
```bash
export SENTRY_ACCESS_TOKEN="sntryu_..."
```
토큰 발급: Sentry > Settings > Account > Auth Tokens (scope: org:read, project:read, event:read, issue:read)

## 📸 스크린샷(선택)

N/A (설정 파일 변경만 포함)

## 🔗 관련 이슈

없음 (인프라 개선)

## 🙏 리뷰어에게

- `.envrc.local.example`에 `SENTRY_ACCESS_TOKEN` 템플릿 추가는 후속 작업으로 처리 예정
- 재시작 후 `mcp__amang-*` 도구가 정상 로드되는지 확인 필요

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
