### PR TITLE
refactor(web): SessionGuard 토큰 갱신 역할 분리

### DIFF
--- a/apps/web/lib/providers/index.tsx
+++ b/apps/web/lib/providers/index.tsx
@@ -11,44 +11,22 @@ import ReactQueryProvider from "./react-query-provider"
 
 import ROUTES from "@/constants/routes"
 
-const MAX_REFRESH_RETRIES = 3
-
 function SessionGuard({ children }: { children: React.ReactNode }) {
-  const { data: session, update } = useSession()
+  const { data: session } = useSession()
   const isSigningOut = useRef(false)
 
+  // 토큰 갱신은 ApiClientProvider의 onTokenExpired에서 담당.
+  // 여기서는 갱신 최종 실패(RefreshAccessTokenError) 시 signOut만 처리.
   useEffect(() => {
     if (session?.error !== "RefreshAccessTokenError") return
     if (isSigningOut.current) return
 
-    let cancelled = false
-
-    const retryRefresh = async () => {
-      for (let attempt = 1; attempt <= MAX_REFRESH_RETRIES; attempt++) {
-        if (cancelled) return
-        console.warn(
-          `[SessionGuard] 토큰 갱신 재시도 ${attempt}/${MAX_REFRESH_RETRIES}`
-        )
-        const newSession = await update()
-        if (newSession && !newSession.error) return
-      }
-      if (!cancelled) {
-        isSigningOut.current = true
-        console.error(
-          "[SessionGuard] 토큰 갱신 최대 재시도 초과, 로그아웃 처리"
-        )
-        signOut({
-          redirectTo: `${ROUTES.LOGIN}?callbackUrl=${window.location.pathname}`
-        })
-      }
-    }
-
-    retryRefresh()
-
-    return () => {
-      cancelled = true
-    }
-  }, [session?.error, update])
+    isSigningOut.current = true
+    console.error("[SessionGuard] 토큰 갱신 실패, 로그아웃 처리")
+    signOut({
+      redirectTo: `${ROUTES.LOGIN}?callbackUrl=${window.location.pathname}`
+    })
+  }, [session?.error])
 
   useEffect(() => {
     if (session?.user) {


### PR DESCRIPTION
## 🚀 작업 내용

SessionGuard의 토큰 갱신 재시도 로직(3회 `update()` 호출)을 제거하고, 역할을 명확히 분리.

**Before**: SessionGuard와 ApiClientProvider 두 곳에서 독립적으로 `update()` 호출 → 세션 요청 중복
**After**:
- **ApiClientProvider**: API 401 시 `onTokenExpired` → `update()` → 토큰 갱신 담당
- **SessionGuard**: `RefreshAccessTokenError` 감지 시 signOut만 담당 (갱신 시도 안 함)

### 변경 요약 (-22줄)

`SessionGuard`에서 제거:
- `MAX_REFRESH_RETRIES` 상수
- `update()` 재시도 루프
- `cancelled` 플래그
- `update` 의존성

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #408

## 🙏 리뷰어에게

- JWT 콜백에서 토큰 갱신 실패 시 `session.error = "RefreshAccessTokenError"`가 설정되는데, 이 시점에서 이미 서버사이드 refresh가 실패한 것이므로 클라이언트에서 재시도하는 것은 무의미
- ApiClient의 `onTokenExpired`는 `refreshPromise`를 공유하여 동시 요청 시에도 한 번만 갱신 시도

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
