### PR TITLE
feat: 장비 이미지 업로드 기능 (presigned URL 방식)

### DIFF
--- a/apps/api/src/equipment/equipment.controller.ts
+++ b/apps/api/src/equipment/equipment.controller.ts
@@ -8,9 +8,7 @@ import {
   Delete,
   ParseIntPipe,
   UseGuards,
-  Query,
-  UseInterceptors,
-  UploadedFile
+  Query
 } from "@nestjs/common"
 import { EquipmentService } from "./equipment.service"
 import { CreateEquipmentDto } from "./dto/create-equipment.dto"
@@ -18,8 +16,6 @@ import { UpdateEquipmentDto } from "./dto/update-equipment.dto"
 import { AccessTokenGuard } from "../auth/guards/access-token.guard"
 import { AdminGuard } from "../auth/guards/admin.guard"
 import { Public } from "../auth/decorators/public.decorator"
-import { FileInterceptor } from "@nestjs/platform-express"
-import { optionalImageFileValidationPipe } from "../common/pipes/image-validation.pipe"
 
 @Controller("equipments")
 @UseGuards(AccessTokenGuard)
@@ -28,13 +24,8 @@ export class EquipmentController {
 
   @Post()
   @UseGuards(AdminGuard)
-  @UseInterceptors(FileInterceptor("image"))
-  create(
-    @Body() createEquipmentDto: CreateEquipmentDto,
-    @UploadedFile(optionalImageFileValidationPipe)
-    file?: Express.Multer.File
-  ) {
-    return this.equipmentService.create(createEquipmentDto, file)
+  create(@Body() createEquipmentDto: CreateEquipmentDto) {
+    return this.equipmentService.create(createEquipmentDto)
   }
 
   @Get()
@@ -51,14 +42,11 @@ export class EquipmentController {
 
   @Patch(":id")
   @UseGuards(AdminGuard)
-  @UseInterceptors(FileInterceptor("image"))
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body() updateEquipmentDto: UpdateEquipmentDto,
-    @UploadedFile(optionalImageFileValidationPipe)
-    file?: Express.Multer.File
+    @Body() updateEquipmentDto: UpdateEquipmentDto
   ) {
-    return this.equipmentService.update(id, updateEquipmentDto, file)
+    return this.equipmentService.update(id, updateEquipmentDto)
   }
 
   @Delete(":id")

--- a/apps/api/src/equipment/equipment.module.ts
+++ b/apps/api/src/equipment/equipment.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common"
 import { EquipmentService } from "./equipment.service"
 import { EquipmentController } from "./equipment.controller"
+import { ObjectStorageModule } from "../object-storage/object-storage.module"
 
 @Module({
+  imports: [ObjectStorageModule],
   controllers: [EquipmentController],
   providers: [EquipmentService]
 })

--- a/apps/api/src/equipment/equipment.service.spec.ts
+++ b/apps/api/src/equipment/equipment.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { EquipmentService } from "./equipment.service"
 import { PrismaService } from "../prisma/prisma.service"
+import { ObjectStorageService } from "../object-storage/object-storage.service"
 
 describe("EquipmentService", () => {
   let service: EquipmentService
@@ -17,6 +18,12 @@ describe("EquipmentService", () => {
             findUnique: jest.fn(),
             update: jest.fn(),
             delete: jest.fn()
+          }
+        },
+        {
+          provide: ObjectStorageService,
+          useValue: {
+            deleteObject: jest.fn()
           }
         }
       ]

--- a/apps/api/src/equipment/equipment.service.ts
+++ b/apps/api/src/equipment/equipment.service.ts
@@ -1,37 +1,25 @@
 import { PrismaService } from "./../prisma/prisma.service"
-import { Injectable } from "@nestjs/common"
+import { Injectable, Logger } from "@nestjs/common"
 import { CreateEquipmentDto } from "./dto/create-equipment.dto"
 import { UpdateEquipmentDto } from "./dto/update-equipment.dto"
 import { Prisma, EquipCategory } from "@repo/database"
-import { ConflictError, NotFoundError } from "@repo/api-client"
-import * as path from "node:path"
-import { randomUUID } from "node:crypto"
+import { NotFoundError } from "@repo/api-client"
+import { ObjectStorageService } from "../object-storage/object-storage.service"
 import { equipmentWithRentalLogInclude } from "@repo/shared-types"
 
 @Injectable()
 export class EquipmentService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(EquipmentService.name)
 
-  async create(
-    createEquipmentDto: CreateEquipmentDto,
-    file?: Express.Multer.File
-  ) {
-    const imageUrl: string | undefined = undefined
-    if (file) {
-      const fileExt = path.extname(file.originalname)
-      const fileName = `${randomUUID()}${fileExt}`
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly objectStorageService: ObjectStorageService
+  ) {}
 
-      // TODO: 파일 업로드 구현 필요
-      // await this.minioService.upload ?
-    }
-    const equipment = await this.prisma.equipment.create({
-      data: {
-        ...createEquipmentDto,
-        image: imageUrl
-      }
+  async create(createEquipmentDto: CreateEquipmentDto) {
+    return this.prisma.equipment.create({
+      data: createEquipmentDto
     })
-
-    return equipment
   }
 
   async findAll(type?: string) {
@@ -64,11 +52,7 @@ export class EquipmentService {
     return equipment
   }
 
-  async update(
-    id: number,
-    updateEquipmentDto: UpdateEquipmentDto,
-    file?: Express.Multer.File
-  ) {
+  async update(id: number, updateEquipmentDto: UpdateEquipmentDto) {
     try {
       const oldEquipment = await this.prisma.equipment.findUnique({
         where: { id },
@@ -77,35 +61,22 @@ export class EquipmentService {
       if (!oldEquipment)
         throw new NotFoundError(`ID가 ${id}인 장비를 찾을 수 없습니다.`)
 
-      const oldImageUrl = oldEquipment?.image
-      const imageUrl: string | undefined = undefined
+      if (
+        "image" in updateEquipmentDto &&
+        oldEquipment.image &&
+        oldEquipment.image !== updateEquipmentDto.image
+      ) {
+        this.deleteImageSafely(oldEquipment.image)
+      }
 
-      if (file) {
-        // 파일 업로드 필요.
-        const fileExt = path.extname(file.originalname)
-        const fileName = `${randomUUID()}${fileExt}`
-
-        // TODO: 파일 업로드 구현 필요
-        // imageUrl =
-      }
-      if (oldImageUrl && imageUrl) {
-        // TODO: oldImageUrl에 있는 기존 이미지 삭제 필요
-      }
-      const updateData: Prisma.EquipmentUpdateInput = {
-        ...updateEquipmentDto,
-        image: imageUrl
-      }
-      const equipment = await this.prisma.equipment.update({
+      return await this.prisma.equipment.update({
         where: { id },
-        data: updateData,
+        data: updateEquipmentDto,
         include: equipmentWithRentalLogInclude
       })
-
-      return equipment
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === "P2025")
-          // Race Condition 방지 처리
           throw new NotFoundError(`ID가 ${id}인 장비를 찾을 수 없습니다.`)
       }
       throw error
@@ -119,7 +90,7 @@ export class EquipmentService {
       })
 
       if (equipment.image) {
-        // TODO: 이미지 삭제 로직 구현 필요
+        this.deleteImageSafely(equipment.image)
       }
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -130,5 +101,11 @@ export class EquipmentService {
       }
       throw error
     }
+  }
+
+  private deleteImageSafely(imageUrl: string) {
+    this.objectStorageService.deleteObject(imageUrl).catch((error) => {
+      this.logger.warn(`S3 이미지 삭제 실패 (${imageUrl}):`, error)
+    })
   }
 }

--- a/apps/api/src/equipment/equipment.service.ts
+++ b/apps/api/src/equipment/equipment.service.ts
@@ -61,19 +61,23 @@ export class EquipmentService {
       if (!oldEquipment)
         throw new NotFoundError(`ID가 ${id}인 장비를 찾을 수 없습니다.`)
 
-      if (
-        "image" in updateEquipmentDto &&
-        oldEquipment.image &&
-        oldEquipment.image !== updateEquipmentDto.image
-      ) {
-        this.deleteImageSafely(oldEquipment.image)
-      }
+      const oldImageUrl = oldEquipment.image
 
-      return await this.prisma.equipment.update({
+      const updated = await this.prisma.equipment.update({
         where: { id },
         data: updateEquipmentDto,
         include: equipmentWithRentalLogInclude
       })
+
+      if (
+        "image" in updateEquipmentDto &&
+        oldImageUrl &&
+        oldImageUrl !== updateEquipmentDto.image
+      ) {
+        this.deleteImageSafely(oldImageUrl)
+      }
+
+      return updated
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === "P2025")

--- a/apps/api/src/equipment/equipment.service.ts
+++ b/apps/api/src/equipment/equipment.service.ts
@@ -1,5 +1,5 @@
 import { PrismaService } from "./../prisma/prisma.service"
-import { Injectable, Logger } from "@nestjs/common"
+import { Injectable } from "@nestjs/common"
 import { CreateEquipmentDto } from "./dto/create-equipment.dto"
 import { UpdateEquipmentDto } from "./dto/update-equipment.dto"
 import { Prisma, EquipCategory } from "@repo/database"
@@ -9,8 +9,6 @@ import { equipmentWithRentalLogInclude } from "@repo/shared-types"
 
 @Injectable()
 export class EquipmentService {
-  private readonly logger = new Logger(EquipmentService.name)
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly objectStorageService: ObjectStorageService
@@ -74,7 +72,7 @@ export class EquipmentService {
         oldImageUrl &&
         oldImageUrl !== updateEquipmentDto.image
       ) {
-        this.deleteImageSafely(oldImageUrl)
+        this.objectStorageService.deleteObjectSafely(oldImageUrl)
       }
 
       return updated
@@ -94,7 +92,7 @@ export class EquipmentService {
       })
 
       if (equipment.image) {
-        this.deleteImageSafely(equipment.image)
+        this.objectStorageService.deleteObjectSafely(equipment.image)
       }
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -105,11 +103,5 @@ export class EquipmentService {
       }
       throw error
     }
-  }
-
-  private deleteImageSafely(imageUrl: string) {
-    this.objectStorageService.deleteObject(imageUrl).catch((error) => {
-      this.logger.warn(`S3 이미지 삭제 실패 (${imageUrl}):`, error)
-    })
   }
 }

--- a/apps/api/src/object-storage/object-storage.service.ts
+++ b/apps/api/src/object-storage/object-storage.service.ts
@@ -82,20 +82,16 @@ export class ObjectStorageService implements OnModuleInit {
   }
 
   async deleteObject(url: string) {
-    try {
-      const key = this.extractKeyFromUrl(url)
+    const key = this.extractKeyFromUrl(url)
+    const command = new DeleteObjectCommand({ Bucket: this.bucket, Key: key })
+    await this.s3.send(command)
+    this.logger.log(`Object "${key}" deleted successfully`)
+  }
 
-      const command = new DeleteObjectCommand({
-        Bucket: this.bucket,
-        Key: key
-      })
-
-      await this.s3.send(command)
-      this.logger.log(`Object "${key}" deleted successfully`)
-    } catch (error) {
-      this.logger.error(`Failed to delete object "${url}":`, error)
-      throw error
-    }
+  deleteObjectSafely(url: string) {
+    this.deleteObject(url).catch((error) => {
+      this.logger.warn(`Failed to delete object "${url}":`, error)
+    })
   }
 
   private extractKeyFromUrl(url: string) {

--- a/apps/web/app/(admin)/admin/equipments/_components/EquipmentFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/equipments/_components/EquipmentFormDialog.tsx
@@ -6,7 +6,8 @@ import {
   CreateEquipmentSchema,
   Equipment
 } from "@repo/shared-types"
-import { useEffect } from "react"
+import { ImagePlus, Loader2, X } from "lucide-react"
+import { useEffect, useRef } from "react"
 import { useForm } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
@@ -35,6 +36,7 @@ import {
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { useImageUpload } from "@/hooks/useImageUpload"
 
 const CATEGORY_OPTIONS = [
   { value: "ROOM", label: "동아리방" },
@@ -51,8 +53,7 @@ const CATEGORY_OPTIONS = [
   { value: "ETC", label: "기타(기타)" }
 ] as const
 
-// Form schema without image (admin panel doesn't handle image upload yet)
-const FormSchema = CreateEquipmentSchema.omit({ image: true })
+const FormSchema = CreateEquipmentSchema
 
 interface EquipmentFormDialogProps {
   open: boolean
@@ -69,26 +70,43 @@ export function EquipmentFormDialog({
   editingEquipment,
   isPending
 }: EquipmentFormDialogProps) {
-  const form = useForm<Omit<CreateEquipment, "image">>({
+  const form = useForm<CreateEquipment>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       brand: "",
       model: "",
       category: "ETC" as const,
       isAvailable: true,
-      description: ""
+      description: "",
+      image: null
     }
   })
 
+  const imageUpload = useImageUpload({
+    onSuccess: (publicUrl) => {
+      form.setValue("image", publicUrl)
+    }
+  })
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const displayImage = imageUpload.preview ?? form.watch("image")
+
+  const handleRemoveImage = () => {
+    imageUpload.reset()
+    form.setValue("image", null)
+    if (fileInputRef.current) fileInputRef.current.value = ""
+  }
+
   useEffect(() => {
     if (open) {
+      imageUpload.reset()
       if (editingEquipment) {
         form.reset({
           brand: editingEquipment.brand,
           model: editingEquipment.model,
           category: editingEquipment.category,
           isAvailable: editingEquipment.isAvailable,
-          description: editingEquipment.description ?? ""
+          description: editingEquipment.description ?? "",
+          image: editingEquipment.image ?? null
         })
       } else {
         form.reset({
@@ -96,10 +114,12 @@ export function EquipmentFormDialog({
           model: "",
           category: "ETC" as const,
           isAvailable: true,
-          description: ""
+          description: "",
+          image: null
         })
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, editingEquipment, form])
 
   return (
@@ -111,12 +131,63 @@ export function EquipmentFormDialog({
           </DialogTitle>
         </DialogHeader>
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit((data) =>
-              onSubmit(data as CreateEquipment)
-            )}
-            className="space-y-4"
-          >
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {/* 이미지 업로드 */}
+            <FormItem>
+              <FormLabel>이미지</FormLabel>
+              <div className="flex items-center gap-3">
+                {displayImage ? (
+                  <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-md border">
+                    <img
+                      src={displayImage}
+                      alt="장비 이미지"
+                      className="h-full w-full object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleRemoveImage}
+                      className="absolute -right-1 -top-1 rounded-full bg-destructive p-0.5 text-destructive-foreground shadow-sm"
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex h-20 w-20 shrink-0 items-center justify-center rounded-md border-2 border-dashed text-muted-foreground hover:border-primary hover:text-primary"
+                  >
+                    <ImagePlus size={24} />
+                  </button>
+                )}
+                <div className="flex flex-col gap-1">
+                  {!displayImage && (
+                    <p className="text-sm text-muted-foreground">
+                      JPEG, PNG, WebP (최대 20MB)
+                    </p>
+                  )}
+                  {imageUpload.isUploading && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 size={14} className="animate-spin" />
+                      업로드 중... {imageUpload.progress}%
+                    </div>
+                  )}
+                  {imageUpload.error && (
+                    <p className="text-sm text-destructive">
+                      {imageUpload.error}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={imageUpload.selectAndUpload}
+              />
+            </FormItem>
+
             <FormField
               control={form.control}
               name="brand"
@@ -205,7 +276,10 @@ export function EquipmentFormDialog({
             />
 
             <DialogFooter>
-              <Button type="submit" disabled={isPending}>
+              <Button
+                type="submit"
+                disabled={isPending || imageUpload.isUploading}
+              >
                 {isPending ? "처리 중..." : editingEquipment ? "수정" : "생성"}
               </Button>
             </DialogFooter>

--- a/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/_components/EquipmentFormModal.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { ImagePlus, Loader2, X } from "lucide-react"
+import { useRef } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { EquipCategory } from "@repo/database/enums"
@@ -36,6 +38,7 @@ import {
   useCreateEquipment,
   useUpdateEquipment
 } from "@/hooks/api/useEquipment"
+import { useImageUpload } from "@/hooks/useImageUpload"
 
 const CATEGORY_OPTIONS: { value: EquipCategory; label: string }[] = [
   { value: EquipCategory.GUITAR, label: "기타" },
@@ -57,7 +60,8 @@ const formSchema = z.object({
   category: z.nativeEnum(EquipCategory, {
     required_error: "장비 카테고리는 필수입니다."
   }),
-  description: z.string().optional()
+  description: z.string().optional(),
+  image: z.string().url().nullable().optional()
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -79,6 +83,13 @@ export default function EquipmentFormModal({
   const updateEquipment = useUpdateEquipment()
   const isEditing = !!equipment
 
+  const imageUpload = useImageUpload({
+    onSuccess: (publicUrl) => {
+      form.setValue("image", publicUrl)
+    }
+  })
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: equipment
@@ -86,14 +97,24 @@ export default function EquipmentFormModal({
           brand: equipment.brand,
           model: equipment.model,
           category: equipment.category,
-          description: equipment.description ?? ""
+          description: equipment.description ?? "",
+          image: equipment.image ?? null
         }
       : {
           brand: "",
           model: "",
-          description: ""
+          description: "",
+          image: null
         }
   })
+
+  const displayImage = imageUpload.preview ?? form.watch("image")
+
+  const handleRemoveImage = () => {
+    imageUpload.reset()
+    form.setValue("image", null)
+    if (fileInputRef.current) fileInputRef.current.value = ""
+  }
 
   const onSubmit = (values: FormValues) => {
     if (isEditing) {
@@ -118,6 +139,7 @@ export default function EquipmentFormModal({
           queryClient.invalidateQueries({ queryKey: ["equipments"] })
           onOpenChange(false)
           form.reset()
+          imageUpload.reset()
         },
         onError: () => {
           toast({
@@ -134,7 +156,10 @@ export default function EquipmentFormModal({
     <Dialog
       open={open}
       onOpenChange={(value) => {
-        if (!value) form.reset()
+        if (!value) {
+          form.reset()
+          imageUpload.reset()
+        }
         onOpenChange(value)
       }}
     >
@@ -222,7 +247,61 @@ export default function EquipmentFormModal({
               )}
             />
 
-            {/* TODO: 장비 이미지 업로드 (백엔드 이미지 업로드 구현 후) */}
+            {/* 장비 이미지 */}
+            <div>
+              <SimpleLabel>장비 이미지</SimpleLabel>
+              <div className="mt-1 flex items-center gap-3">
+                {displayImage ? (
+                  <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-md border">
+                    <img
+                      src={displayImage}
+                      alt="장비 이미지"
+                      className="h-full w-full object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleRemoveImage}
+                      className="absolute -right-1 -top-1 rounded-full bg-destructive p-0.5 text-destructive-foreground shadow-sm"
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex h-20 w-20 shrink-0 items-center justify-center rounded-md border-2 border-dashed text-muted-foreground hover:border-primary hover:text-primary"
+                  >
+                    <ImagePlus size={24} />
+                  </button>
+                )}
+                <div className="flex flex-col gap-1">
+                  {!displayImage && (
+                    <p className="text-sm text-muted-foreground">
+                      JPEG, PNG, WebP (최대 20MB)
+                    </p>
+                  )}
+                  {imageUpload.isUploading && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 size={14} className="animate-spin" />
+                      업로드 중... {imageUpload.progress}%
+                    </div>
+                  )}
+                  {imageUpload.error && (
+                    <p className="text-sm text-destructive">
+                      {imageUpload.error}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={imageUpload.selectAndUpload}
+              />
+            </div>
 
             <div className="flex justify-center gap-3 pt-2">
               <Button
@@ -237,7 +316,9 @@ export default function EquipmentFormModal({
                 type="submit"
                 className="w-28"
                 disabled={
-                  createEquipment.isPending || updateEquipment.isPending
+                  createEquipment.isPending ||
+                  updateEquipment.isPending ||
+                  imageUpload.isUploading
                 }
               >
                 저장

--- a/packages/shared-types/src/equipment/create-equipment.schema.ts
+++ b/packages/shared-types/src/equipment/create-equipment.schema.ts
@@ -1,16 +1,6 @@
 import { z } from "zod"
 import { EquipCategory } from "@repo/database/enums"
-import {
-  ACCEPTED_IMAGE_TYPES,
-  MAX_FILE_SIZE
-} from "../constants/file-validation"
 
-/**
- * @description 장비 생성 원본 Zod 스키마
- *
- * 프론트엔드에서 폼(FormData)을 만들기 전,
- * 원본 데이터(React state 등)를 검증할 때 사용됩니다. (텍스트 + 파일 포함)
- */
 export const CreateEquipmentSchema = z.object({
   brand: z.string().min(1, "장비 브랜드 명은 필수입니다."),
   model: z.string().min(1, "장비 모델 명은 필수입니다."),
@@ -19,29 +9,13 @@ export const CreateEquipmentSchema = z.object({
   }),
   isAvailable: z.boolean().optional(),
   description: z.string().optional(),
-  image: z
-    .instanceof(File)
-    .refine((file) => file.size < MAX_FILE_SIZE, {
-      message: "File can't be larger than 20MB."
-    })
-    .refine((file) => ACCEPTED_IMAGE_TYPES.includes(file.type), {
-      message: `파일 확장자는 ${ACCEPTED_IMAGE_TYPES.map((t) => t.replace("image/", "")).join(", ")} 만 가능합니다.`
-    })
-    .nullable()
-    .optional()
+  image: z.string().url().nullable().optional()
 })
 
 /**
  * @description 백엔드 API 컨트롤러(DTO)용 Zod 스키마
- *
- * `FileInterceptor`에 의해 파일(`image`)이 분리된 후,
- * `req.body` (텍스트 필드)만을 검증하기 위해 사용됩니다.
+ * Presigned URL 방식이므로 image도 문자열로 포함
  */
-export const CreateEquipmentApiSchema = CreateEquipmentSchema.omit({
-  image: true
-})
+export const CreateEquipmentApiSchema = CreateEquipmentSchema
 
-/**
- * @description 장비 생성 타입 (프론트엔드용)
- */
 export type CreateEquipment = z.infer<typeof CreateEquipmentSchema>

--- a/packages/shared-types/src/equipment/update-equipment.schema.ts
+++ b/packages/shared-types/src/equipment/update-equipment.schema.ts
@@ -1,25 +1,12 @@
 import { z } from "zod"
 import { CreateEquipmentSchema } from "./create-equipment.schema"
 
-/**
- * @description 장비 업데이트 Zod 스키마
- *
- * `CreateEquipmentSchema`의 모든 필드를 '선택적(optional)'으로 만듭니다.
- * 프론트엔드에서 '수정 폼'의 원본 데이터를 검증할 때 사용됩니다.
- */
 export const UpdateEquipmentSchema = CreateEquipmentSchema.partial()
 
 /**
  * @description 백엔드 API 컨트롤러(DTO)용 장비 업데이트 스키마
- *
- * `UpdateEquipmentSchema`에서 `image` 필드를 제외합니다.
- * 백엔드 `PATCH` 요청의 `req.body` (텍스트 필드)만을 검증하기 위해 사용됩니다.
+ * Presigned URL 방식이므로 image도 문자열로 포함
  */
-export const UpdateEquipmentApiSchema = UpdateEquipmentSchema.omit({
-  image: true
-})
+export const UpdateEquipmentApiSchema = UpdateEquipmentSchema
 
-/**
- * @description 장비 업데이트 타입 (프론트엔드용)
- */
 export type UpdateEquipment = z.infer<typeof UpdateEquipmentSchema>


### PR DESCRIPTION
## 🚀 작업 내용

FileInterceptor 멀티파트 업로드 방식을 제거하고, **presigned URL 직접 업로드** 방식으로 전환하여 장비 이미지 업로드 기능을 완성합니다.

### 변경 요약

| 계층 | 변경 내용 |
|------|-----------|
| **shared-types** | `image` 필드를 `z.instanceof(File)` → `z.string().url()` 로 변경. API 스키마에서 image omit 제거 |
| **API 컨트롤러** | `FileInterceptor`, `@UploadedFile` 데코레이터 제거. JSON body로 image URL 수신 |
| **API 서비스** | `file` 파라미터 제거. `ObjectStorageService` 연동하여 이미지 변경/삭제 시 S3 cleanup |
| **Admin 폼** | `useImageUpload` 훅으로 이미지 업로드 UI 추가 (프리뷰, 진행률, 삭제) |
| **예약 폼 모달** | TODO 주석을 실제 이미지 업로드 UI로 교체 |

### 흐름

```
프론트: 파일 선택 → POST /uploads/presigned-url → S3에 직접 PUT
       → 반환된 publicUrl을 장비 create/update JSON body에 포함
백엔드: image URL 문자열을 DB에 저장, 이미지 교체/삭제 시 S3 객체 삭제
```

## 📸 스크린샷(선택)

<img width="499" height="221" alt="image" src="https://github.com/user-attachments/assets/ddc8fa10-5d91-40f0-a26f-7750e588e588" />

## 🔗 관련 이슈

Closes #346

## 🙏 리뷰어에게

- 기존 `FileInterceptor` 방식은 서비스 레이어에 TODO만 있고 실제 업로드 로직이 미구현이었습니다. presigned URL 방식으로 전환하면서 인프라(ObjectStorageService, useImageUpload 훅)를 그대로 활용합니다.
- `deleteImageSafely`는 fire-and-forget 패턴으로 S3 삭제 실패가 메인 요청을 블로킹하지 않습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)