### PR TITLE
fix(web): 헤더/어드민/캘린더 잔이슈 일괄 수정

### DIFF
--- a/apps/web/app/(admin)/_components/AdminSidebar.tsx
+++ b/apps/web/app/(admin)/_components/AdminSidebar.tsx
@@ -133,6 +133,21 @@ export function AdminSidebar() {
               <div className="flex-1 px-3 py-4">
                 <NavLinks onNavigate={() => setOpen(false)} />
               </div>
+              <div className="border-t border-neutral-200 px-3 py-4">
+                <Link
+                  href={ROUTES.HOME}
+                  onClick={(e) => {
+                    if (guardNavigation(ROUTES.HOME)) {
+                      e.preventDefault()
+                      return
+                    }
+                    setOpen(false)
+                  }}
+                  className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-neutral-500 transition-colors hover:text-neutral-900"
+                >
+                  사이트로 돌아가기
+                </Link>
+              </div>
             </div>
           </SheetContent>
         </Sheet>

--- a/apps/web/app/(admin)/_components/data-table/DataTable.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTable.tsx
@@ -27,6 +27,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   OnChangeFn,
+  PaginationState,
   RowSelectionState,
   SortingState,
   useReactTable,
@@ -241,6 +242,33 @@ function DataTableInner<TData, TValue>({
     [sorting, setSortId, setSortOrder]
   )
 
+  // URL-synced pagination state
+  const [urlPage, setUrlPage] = useQueryState(
+    "page",
+    parseAsInteger.withDefault(1).withOptions({ history: "replace" })
+  )
+  const [urlPageSize, setUrlPageSize] = useQueryState(
+    "pageSize",
+    parseAsInteger.withDefault(10).withOptions({ history: "replace" })
+  )
+
+  const pagination: PaginationState = useMemo(
+    () => ({ pageIndex: urlPage - 1, pageSize: urlPageSize }),
+    [urlPage, urlPageSize]
+  )
+
+  const handlePaginationChange: OnChangeFn<PaginationState> = useCallback(
+    (updaterOrValue) => {
+      const next =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(pagination)
+          : updaterOrValue
+      setUrlPage(next.pageIndex + 1)
+      setUrlPageSize(next.pageSize)
+    },
+    [pagination, setUrlPage, setUrlPageSize]
+  )
+
   // URL-synced filter state via nuqs
   const filterParsers = useMemo(
     () => Object.fromEntries(filters.map((f) => [f.columnId, parseAsString])),
@@ -352,6 +380,7 @@ function DataTableInner<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: handleSortingChange,
+    onPaginationChange: handlePaginationChange,
     onColumnFiltersChange: handleColumnFiltersChange,
     onColumnVisibilityChange: handleColumnVisibilityChange,
     onRowSelectionChange: setRowSelection,
@@ -361,6 +390,7 @@ function DataTableInner<TData, TValue>({
     onColumnOrderChange: setColumnOrder,
     state: {
       sorting,
+      pagination,
       columnFilters,
       columnVisibility,
       columnOrder,
@@ -392,9 +422,9 @@ function DataTableInner<TData, TValue>({
     const pageSize = t.getState().pagination.pageSize
     const targetPage = Math.floor(rowIndex / pageSize)
     if (t.getState().pagination.pageIndex !== targetPage) {
-      t.setPageIndex(targetPage)
+      setUrlPage(targetPage + 1)
     }
-  }, [highlightedRowId])
+  }, [highlightedRowId, setUrlPage])
 
   // Scroll highlighted row into view
   useEffect(() => {

--- a/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/equipments/_components/columns.tsx
@@ -4,6 +4,8 @@ import { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { Check, EllipsisVertical, Pencil, Trash2, X } from "lucide-react"
 
+import Link from "next/link"
+
 import { CopyRowLinkItem } from "@/app/(admin)/_components/data-table/CopyRowLinkItem"
 import { DataTableColumnHeader } from "@/app/(admin)/_components/data-table/DataTableColumnHeader"
 import { EditableCell } from "@/app/(admin)/_components/data-table/EditableCell"
@@ -15,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
+import ROUTES from "@/constants/routes"
 import { Equipment } from "@repo/shared-types"
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -44,8 +47,38 @@ export function getColumns(actions: ColumnActions): ColumnDef<Equipment>[] {
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="ID" />
       ),
+      cell: ({ row }) => (
+        <Link
+          href={ROUTES.RESERVATION.EQUIPMENT_DETAIL(row.original.id)}
+          className="text-blue-600 hover:underline"
+          target="_blank"
+        >
+          {row.original.id}
+        </Link>
+      ),
       size: 60,
       enableHiding: false
+    },
+    {
+      accessorKey: "image",
+      header: "이미지",
+      meta: { label: "이미지", editable: { type: "image" } },
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            ctx.row.original.image ? (
+              <img
+                src={ctx.row.original.image}
+                alt="장비"
+                className="h-10 w-10 rounded object-cover"
+              />
+            ) : (
+              "-"
+            )
+          }
+        />
+      )
     },
     {
       accessorKey: "brand",

--- a/apps/web/app/(admin)/layout.tsx
+++ b/apps/web/app/(admin)/layout.tsx
@@ -26,7 +26,7 @@ export default async function AdminLayout({
     <UnsavedChangesProvider>
       <div className="flex h-screen">
         <AdminSidebar />
-        <main className="flex-1 overflow-auto bg-neutral-50 p-6">
+        <main className="flex-1 overflow-auto bg-neutral-50 p-6 pt-16 md:pt-6">
           {children}
         </main>
       </div>

--- a/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/MonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/MonthBlock.tsx
@@ -19,9 +19,14 @@ export default function MonthBlock({
       {days.map((d, i) => {
         const isThisMonth = d.month() === currentMonth.month()
         const isToday = d.isSame(new Date(), "day")
-        const dayRentals = rentals.filter((r) =>
-          dayjs(r.startAt).isSame(d, "day")
-        )
+        const dayRentals = rentals.filter((r) => {
+          const s = dayjs(r.startAt)
+          const e = dayjs(r.endAt)
+          return (
+            s.isSame(d, "day") ||
+            (s.isBefore(d, "day") && e.isAfter(d.startOf("day")))
+          )
+        })
 
         return (
           <div key={i} className="border-r border-b border-gray-100 p-2">

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -38,6 +38,7 @@ export default function WeekCalendarField({
   return (
     <div className="w-full mt-7 flex bg-white rounded-xl overflow-hidden">
       <div className="w-7 flex flex-col">
+        <div className="h-[42px]" />
         {Array.from({ length: 16 }).map((_, i) => {
           const hour = (i + 6) % 12 === 0 ? 12 : (i + 6) % 12
           const isPM = i + 6 >= 12
@@ -45,7 +46,7 @@ export default function WeekCalendarField({
           return (
             <div
               key={i}
-              className="text-[8px] w-full h-[42px] text-center first:text-[0px] text-gray-400"
+              className="text-[8px] w-full h-[42px] text-center text-gray-400"
             >
               {hour}
               {isPM ? "PM" : "AM"}

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -94,7 +94,7 @@ export default function EquipmentCalendarPage() {
 
       {/* Selected equipment header */}
       <div className="mb-4 flex items-center gap-3">
-        <span className="text-lg font-semibold">선택된 물품</span>
+        <span className="text-lg font-semibold">{equipmentLabel}</span>
         <Link
           href={ROUTES.RESERVATION.EQUIPMENT}
           className="text-sm text-muted-foreground hover:underline"

--- a/apps/web/components/Header/_component/Sidebar/SheetInnerContent/index.tsx
+++ b/apps/web/components/Header/_component/Sidebar/SheetInnerContent/index.tsx
@@ -7,6 +7,7 @@ import {
   Instagram,
   LogIn,
   Package,
+  Settings,
   Users,
   Youtube
 } from "lucide-react"
@@ -72,6 +73,24 @@ const SheetInnerContent = ({
       </Link>
       <Separator />
       <div className="flex-auto ">
+        {/* Admin */}
+        {session?.user?.isAdmin && (
+          <>
+            <div className="my-6">
+              <NavLinkHeader className="mb-4">ADMIN</NavLinkHeader>
+              <div className="space-y-7">
+                <NavLink
+                  href={ROUTES.ADMIN.INDEX}
+                  icon={<Settings size={iconSize} className={iconcolor} />}
+                  onClick={() => setIsOpen(false)}
+                >
+                  관리자
+                </NavLink>
+              </div>
+            </div>
+            <Separator />
+          </>
+        )}
         {/* Main */}
         <div className="my-6">
           <NavLinkHeader className="mb-4">MAIN</NavLinkHeader>

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -46,7 +46,8 @@ const ROUTES = {
   },
   RESERVATION: {
     CLUBROOM: "/reservations/clubroom",
-    EQUIPMENT: "/reservations/equipment"
+    EQUIPMENT: "/reservations/equipment",
+    EQUIPMENT_DETAIL: (id: number) => `/reservations/equipment/${id}`
   }
 }
 


### PR DESCRIPTION
## 🚀 작업 내용

헤더, 어드민, 캘린더 관련 잔이슈 10건 일괄 수정.

### 네비게이션/레이아웃
- 모바일 어드민 사이드바에 **'사이트로 돌아가기'** 링크 추가 (데스크톱과 동일)
- 모바일 어드민 **햄버거 버튼이 패널 제목 가리는 문제** 수정 (`pt-16 md:pt-6`)
- 모바일 클라이언트 사이드바에 **어드민 네비게이션 메뉴** 추가 (admin 유저만)

### 캘린더 버그 수정
- **월간 캘린더** 다중 일수 렌탈이 시작일에만 표시되던 버그 수정 (startAt~endAt 범위 필터)
- **주간 캘린더** 현재 시간 표시선 1시간 오차 수정 (시간 라벨 컬럼에 헤더 spacer 누락)

### 장비 어드민 개선
- 장비 어드민 테이블에 **인라인 이미지 편집 컬럼** 추가
- 장비 **ID 클릭 시 캘린더 상세 페이지로 이동** (새 탭)

### 기타
- 물품 상세 페이지 '선택된 물품' → **장비명 동적 표시**
- 어드민 **DataTable 페이지네이션 URL 상태 저장** (`?page=&pageSize=`, nuqs)

## 📸 스크린샷(선택)

배포 후 시각 검증 필요

## 🔗 관련 이슈

Closes #346

## 🙏 리뷰어에게

- 어드민 DataTable 페이지네이션 URL 동기화는 모든 어드민 테이블에 영향을 미칩니다. 기존 sort/filter URL 상태와 충돌 없이 동작하는지 확인 부탁드립니다.
- 월간 캘린더 필터 로직은 주간 캘린더(`WeekColumn.tsx`)의 기존 패턴을 그대로 적용했습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.