### PR TITLE
feat(web,infra): Vercel Analytics에서 개발자 트래픽 제외

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,10 +4,10 @@ import { Metadata } from "next"
 import localFont from "next/font/local"
 import React from "react"
 
-import { Analytics } from "@vercel/analytics/react"
 import { SpeedInsights } from "@vercel/speed-insights/react"
 
 import { Toaster } from "@/components/ui/toaster"
+import VercelAnalytics from "@/components/VercelAnalytics"
 import { SEO } from "@/constants/seo"
 import Providers from "@/lib/providers"
 import { cn } from "@/lib/utils"
@@ -80,7 +80,7 @@ export default function RootLayout({
         <Providers>
           {children}
           <Toaster />
-          <Analytics />
+          <VercelAnalytics />
           <SpeedInsights />
         </Providers>
       </body>

--- a/apps/web/components/VercelAnalytics.tsx
+++ b/apps/web/components/VercelAnalytics.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { Analytics } from "@vercel/analytics/react"
+import { useSession } from "next-auth/react"
+
+const developerEmails = new Set(
+  (process.env.NEXT_PUBLIC_DEVELOPER_EMAILS ?? "")
+    .split(",")
+    .map((e) => e.trim())
+    .filter(Boolean)
+)
+
+export default function VercelAnalytics() {
+  const { data: session } = useSession()
+
+  return (
+    <Analytics
+      beforeSend={(event) => {
+        if (session?.user?.email && developerEmails.has(session.user.email)) {
+          return null
+        }
+        return event
+      }}
+    />
+  )
+}

--- a/infra/terraform/vercel/main.tf
+++ b/infra/terraform/vercel/main.tf
@@ -103,6 +103,14 @@ resource "vercel_project_environment_variable" "site_url_preview" {
   target     = ["preview", "development"]
 }
 
+resource "vercel_project_environment_variable" "developer_emails" {
+  project_id = vercel_project.web.id
+  team_id    = var.vercel_team_id
+  key        = "NEXT_PUBLIC_DEVELOPER_EMAILS"
+  value      = var.developer_emails
+  target     = ["production", "preview"]
+}
+
 resource "vercel_project_environment_variable" "sentry_dsn" {
   project_id = vercel_project.web.id
   team_id    = var.vercel_team_id

--- a/infra/terraform/vercel/variables.tf
+++ b/infra/terraform/vercel/variables.tf
@@ -8,3 +8,9 @@ variable "vercel_team_id" {
   description = "Vercel team ID (slug or ID)"
   type        = string
 }
+
+variable "developer_emails" {
+  description = "Comma-separated developer emails to exclude from Vercel Analytics"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## 🚀 작업 내용

`NEXT_PUBLIC_DEVELOPER_EMAILS` 환경변수에 등록된 개발자 이메일로 로그인한 사용자의 트래픽을 Vercel Analytics에서 제외합니다.

- `<Analytics />` → `<VercelAnalytics />` Client Component로 교체, `beforeSend`에서 세션 이메일 체크
- Terraform으로 `NEXT_PUBLIC_DEVELOPER_EMAILS` 환경변수 선언적 관리

### 적용 방법
1. `terraform.tfvars`에 `developer_emails = "dev1@skku.edu,dev2@skku.edu"` 추가
2. `terraform plan` → `terraform apply`

## 📸 스크린샷(선택)

UI 변경 없음

## 🔗 관련 이슈

N/A

## 🙏 리뷰어에게

- `beforeSend`가 `null`을 반환하면 이벤트가 Vercel 서버로 전송되지 않아 대시보드 수치에 영향을 주지 않습니다.
- `NEXT_PUBLIC_` 접두사로 클라이언트에 이메일이 노출되지만, 동아리 멤버 이메일이라 민감하지 않다고 판단했습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
