### PR TITLE
fix(web): 캘린더 시간대 표시 범위 0~23시 확장 (#418)

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -3,7 +3,6 @@
 import dayjs, { Dayjs } from "dayjs"
 import { Clock, UserRound } from "lucide-react"
 import { RentalDetail } from "@repo/shared-types"
-import { useEffect, useRef } from "react"
 
 interface MobileTimeSlotsProps {
   selectedDate: Dayjs
@@ -11,22 +10,14 @@ interface MobileTimeSlotsProps {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-const HOURS = Array.from({ length: 24 }, (_, i) => i)
-const SCROLL_TO_HOUR = 9
+const DEFAULT_START = 9
+const DEFAULT_END = 22
 
 export default function MobileTimeSlots({
   selectedDate,
   rentals,
   onRentalClick
 }: MobileTimeSlotsProps) {
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const target = containerRef.current?.querySelector(
-      `[data-hour="${SCROLL_TO_HOUR}"]`
-    )
-    target?.scrollIntoView({ block: "start", behavior: "instant" })
-  }, [])
   const selectedDay = selectedDate.format("YYYY-MM-DD")
   const dayRentals = rentals
     .filter((r) => dayjs(r.startAt).format("YYYY-MM-DD") === selectedDay)
@@ -43,12 +34,21 @@ export default function MobileTimeSlots({
     rentalsByHour.set(hour, list)
   }
 
+  // 기본 09~22시, 예약 있으면 동적 확장
+  const rentalHours = Array.from(rentalsByHour.keys())
+  const startHour = Math.min(DEFAULT_START, ...rentalHours)
+  const endHour = Math.max(DEFAULT_END, ...rentalHours)
+  const hours = Array.from(
+    { length: endHour - startHour + 1 },
+    (_, i) => i + startHour
+  )
+
   return (
-    <div ref={containerRef} className="flex flex-col">
-      {HOURS.map((hour) => {
+    <div className="flex flex-col">
+      {hours.map((hour) => {
         const hourRentals = rentalsByHour.get(hour)
         return (
-          <div key={hour} data-hour={hour} className="flex min-h-[44px]">
+          <div key={hour} className="flex min-h-[44px]">
             {/* Hour label */}
             <div className="w-14 shrink-0 pt-3 text-sm font-medium text-zinc-500">
               {String(hour).padStart(2, "0")}:00

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -3,6 +3,7 @@
 import dayjs, { Dayjs } from "dayjs"
 import { Clock, UserRound } from "lucide-react"
 import { RentalDetail } from "@repo/shared-types"
+import { useEffect, useRef } from "react"
 
 interface MobileTimeSlotsProps {
   selectedDate: Dayjs
@@ -10,14 +11,22 @@ interface MobileTimeSlotsProps {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-/** Hours to display in the time-slot list (09:00 – 23:00) */
-const HOURS = Array.from({ length: 15 }, (_, i) => i + 9)
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+const SCROLL_TO_HOUR = 9
 
 export default function MobileTimeSlots({
   selectedDate,
   rentals,
   onRentalClick
 }: MobileTimeSlotsProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const target = containerRef.current?.querySelector(
+      `[data-hour="${SCROLL_TO_HOUR}"]`
+    )
+    target?.scrollIntoView({ block: "start", behavior: "instant" })
+  }, [])
   const selectedDay = selectedDate.format("YYYY-MM-DD")
   const dayRentals = rentals
     .filter((r) => dayjs(r.startAt).format("YYYY-MM-DD") === selectedDay)
@@ -35,11 +44,11 @@ export default function MobileTimeSlots({
   }
 
   return (
-    <div className="flex flex-col">
+    <div ref={containerRef} className="flex flex-col">
       {HOURS.map((hour) => {
         const hourRentals = rentalsByHour.get(hour)
         return (
-          <div key={hour} className="flex min-h-[44px]">
+          <div key={hour} data-hour={hour} className="flex min-h-[44px]">
             {/* Hour label */}
             <div className="w-14 shrink-0 pt-3 text-sm font-medium text-zinc-500">
               {String(hour).padStart(2, "0")}:00

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
@@ -11,7 +11,7 @@ interface WeekColumnProp {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-const START_HOUR = 6
+const START_HOUR = 0
 const PX_PER_HOUR = 42
 const HEADER_PX = 42
 
@@ -52,7 +52,7 @@ export default function WeekColumn({
       </div>
 
       {/* 시간 구간 */}
-      {Array.from({ length: 16 }).map((_, i) => (
+      {Array.from({ length: 24 }).map((_, i) => (
         <div
           key={i}
           className="h-[42px] border-t-[1.5px] last:border-b-[1.5px] border-gray-100"
@@ -63,7 +63,7 @@ export default function WeekColumn({
       {dayRentals.map((rental) => {
         const start = dayjs(rental.startAt)
         const end = dayjs(rental.endAt)
-        const totalMin = 16 * 60 // 6AM~10PM
+        const totalMin = 24 * 60
         const rawStartMin = start.isSame(date, "day")
           ? (start.hour() - START_HOUR) * 60 + start.minute()
           : 0 // 전날부터 이어지는 이벤트는 하루 시작부터

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/WeekColumn.tsx
@@ -9,9 +9,10 @@ interface WeekColumnProp {
   nowTopPx: number
   rentals: RentalDetail[]
   onRentalClick?: (rental: RentalDetail) => void
+  startHour: number
+  slotCount: number
 }
 
-const START_HOUR = 0
 const PX_PER_HOUR = 42
 const HEADER_PX = 42
 
@@ -20,7 +21,9 @@ export default function WeekColumn({
   nowTopPx,
   offset,
   rentals,
-  onRentalClick
+  onRentalClick,
+  startHour,
+  slotCount
 }: WeekColumnProp) {
   const date = currentMonday.add(offset, "day")
   const dayName = date.format("ddd")
@@ -52,7 +55,7 @@ export default function WeekColumn({
       </div>
 
       {/* 시간 구간 */}
-      {Array.from({ length: 24 }).map((_, i) => (
+      {Array.from({ length: slotCount }).map((_, i) => (
         <div
           key={i}
           className="h-[42px] border-t-[1.5px] last:border-b-[1.5px] border-gray-100"
@@ -63,14 +66,14 @@ export default function WeekColumn({
       {dayRentals.map((rental) => {
         const start = dayjs(rental.startAt)
         const end = dayjs(rental.endAt)
-        const totalMin = 24 * 60
+        const totalMin = slotCount * 60
         const rawStartMin = start.isSame(date, "day")
-          ? (start.hour() - START_HOUR) * 60 + start.minute()
-          : 0 // 전날부터 이어지는 이벤트는 하루 시작부터
+          ? (start.hour() - startHour) * 60 + start.minute()
+          : 0
         const startMin = Math.max(0, rawStartMin)
         const rawEndMin = end.isSame(date, "day")
-          ? (end.hour() - START_HOUR) * 60 + end.minute()
-          : totalMin // 다음 날로 넘어가는 이벤트는 끝까지
+          ? (end.hour() - startHour) * 60 + end.minute()
+          : totalMin
         const endMin = Math.max(0, Math.min(totalMin, rawEndMin))
         if (endMin <= startMin) return null
         const topPx = HEADER_PX + (startMin * PX_PER_HOUR) / 60

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react"
 import { Dayjs } from "dayjs"
 import { RentalDetail } from "@repo/shared-types"
 import WeekColumn from "./WeekColumn"
@@ -8,40 +9,46 @@ interface WeekCalendarFieldProp {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
+const START_HOUR = 0
+const ROW_H = 42
+const TOTAL_MIN = 24 * 60
+const SCROLL_TO_HOUR = 6
+
 export default function WeekCalendarField({
   currentMonday,
   rentals,
   onRentalClick
 }: WeekCalendarFieldProp) {
-  // 현재 시간
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    containerRef.current.scrollTop = SCROLL_TO_HOUR * ROW_H
+  }, [])
+
   const currentTime = new Date()
-
-  // 현재 시간 표시용 계산 (06:00 시작, 16시간 표시)
-  const START_HOUR = 6
-  const ROW_H = 42 // px per hour
-  const TOTAL_MIN = 16 * 60
-
   const h = currentTime.getHours()
   const m = currentTime.getMinutes()
   const minutesSinceStart = (h - START_HOUR) * 60 + m
-
-  // 보이는 영역 밖으로 나가지 않게 clamp
   const clampedMin = Math.max(0, Math.min(TOTAL_MIN, minutesSinceStart))
   const nowTopPx = (clampedMin * ROW_H) / 60 + 42
 
-  // 말풍선 텍스트 (8:30 PM 형식)
   const timeLabel = currentTime.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
     hour12: true
   })
   return (
-    <div className="w-full mt-7 flex bg-white rounded-xl overflow-hidden">
-      <div className="w-7 flex flex-col">
+    <div
+      ref={containerRef}
+      className="w-full mt-7 flex bg-white rounded-xl overflow-y-auto"
+      style={{ maxHeight: `${16 * ROW_H + 42}px` }}
+    >
+      <div className="w-7 flex flex-col shrink-0">
         <div className="h-[42px]" />
-        {Array.from({ length: 16 }).map((_, i) => {
-          const hour = (i + 6) % 12 === 0 ? 12 : (i + 6) % 12
-          const isPM = i + 6 >= 12
+        {Array.from({ length: 24 }).map((_, i) => {
+          const hour = i % 12 === 0 ? 12 : i % 12
+          const isPM = i >= 12
 
           return (
             <div

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef } from "react"
-import { Dayjs } from "dayjs"
+import dayjs, { Dayjs } from "dayjs"
 import { RentalDetail } from "@repo/shared-types"
 import WeekColumn from "./WeekColumn"
 
@@ -9,28 +8,27 @@ interface WeekCalendarFieldProp {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-const START_HOUR = 0
+const DEFAULT_START = 6
+const DEFAULT_END = 22
 const ROW_H = 42
-const TOTAL_MIN = 24 * 60
-const SCROLL_TO_HOUR = 6
 
 export default function WeekCalendarField({
   currentMonday,
   rentals,
   onRentalClick
 }: WeekCalendarFieldProp) {
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!containerRef.current) return
-    containerRef.current.scrollTop = SCROLL_TO_HOUR * ROW_H
-  }, [])
+  // 주간 전체 rental의 시간 범위로 동적 확장
+  const rentalHours = rentals.map((r) => dayjs(r.startAt).hour())
+  const startHour = Math.min(DEFAULT_START, ...rentalHours)
+  const endHour = Math.max(DEFAULT_END, ...rentalHours)
+  const slotCount = endHour - startHour + 1
+  const totalMin = slotCount * 60
 
   const currentTime = new Date()
   const h = currentTime.getHours()
   const m = currentTime.getMinutes()
-  const minutesSinceStart = (h - START_HOUR) * 60 + m
-  const clampedMin = Math.max(0, Math.min(TOTAL_MIN, minutesSinceStart))
+  const minutesSinceStart = (h - startHour) * 60 + m
+  const clampedMin = Math.max(0, Math.min(totalMin, minutesSinceStart))
   const nowTopPx = (clampedMin * ROW_H) / 60 + 42
 
   const timeLabel = currentTime.toLocaleTimeString("en-US", {
@@ -39,16 +37,13 @@ export default function WeekCalendarField({
     hour12: true
   })
   return (
-    <div
-      ref={containerRef}
-      className="w-full mt-7 flex bg-white rounded-xl overflow-y-auto"
-      style={{ maxHeight: `${16 * ROW_H + 42}px` }}
-    >
+    <div className="w-full mt-7 flex bg-white rounded-xl overflow-hidden">
       <div className="w-7 flex flex-col shrink-0">
         <div className="h-[42px]" />
-        {Array.from({ length: 24 }).map((_, i) => {
-          const hour = i % 12 === 0 ? 12 : i % 12
-          const isPM = i >= 12
+        {Array.from({ length: slotCount }).map((_, i) => {
+          const absHour = i + startHour
+          const hour = absHour % 12 === 0 ? 12 : absHour % 12
+          const isPM = absHour >= 12
 
           return (
             <div
@@ -69,6 +64,8 @@ export default function WeekCalendarField({
             currentMonday={currentMonday}
             rentals={rentals}
             onRentalClick={onRentalClick}
+            startHour={startHour}
+            slotCount={slotCount}
             key={i}
           />
         ))}

--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -8,7 +8,7 @@ interface WeekCalendarFieldProp {
   onRentalClick?: (rental: RentalDetail) => void
 }
 
-const DEFAULT_START = 6
+const DEFAULT_START = 9
 const DEFAULT_END = 22
 const ROW_H = 42
 


### PR DESCRIPTION
## 🚀 작업 내용

모바일/데스크톱 예약 캘린더의 시간 슬롯을 0~23시 전체로 확장하여 모든 시간대의 예약이 표시되도록 수정.

**변경 사항:**
- `MobileTimeSlots`: HOURS 9~23 → 0~23, 09시로 자동 스크롤
- `WeekCalendarField`: START_HOUR 6 → 0, 06시로 자동 스크롤 (`overflow-y-auto` + `maxHeight`)
- `WeekColumn`: START_HOUR/totalMin 동기화

기존 뷰 시작 시점으로 자동 스크롤하여 사용자 체감은 동일하되, 위로 스크롤하면 새벽 시간대 예약도 확인 가능.

## 📸 스크린샷(선택)

Vercel 프리뷰에서 확인

## 🔗 관련 이슈

Closes #418

## 🙏 리뷰어에게

- `WeekCalendarField`에 `maxHeight`를 inline style로 설정했습니다 (`16 * ROW_H + 42`px). 기존과 동일한 보이는 높이를 유지하면서 24시간 콘텐츠를 스크롤합니다.
- 자동 스크롤은 `useEffect([], ...)`로 마운트 시 1회만 실행됩니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
