### PR TITLE
feat(web): 캘린더 기능 개선 (#419)

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { useSession } from "next-auth/react"
 import { useQueryClient } from "@tanstack/react-query"
+import { useRouter, usePathname } from "next/navigation"
 import dayjs from "dayjs"
 import { Clock, PlusCircle, UserRound, X } from "lucide-react"
 
@@ -36,8 +37,8 @@ import type { DateRange } from "react-day-picker"
 const HOURS = Array.from({ length: 24 }, (_, i) =>
   i.toString().padStart(2, "0")
 )
-const MINUTES = Array.from({ length: 12 }, (_, i) =>
-  (i * 5).toString().padStart(2, "0")
+const MINUTES = Array.from({ length: 4 }, (_, i) =>
+  (i * 15).toString().padStart(2, "0")
 )
 
 interface AddScheduleButtonProps {
@@ -59,6 +60,8 @@ export default function AddScheduleButton({
   const createRental = useCreateRental()
   const queryClient = useQueryClient()
   const { toast } = useToast()
+  const router = useRouter()
+  const pathname = usePathname()
 
   const currentUserId = session?.user?.id ? Number(session.user.id) : null
   const today = new Date()
@@ -212,6 +215,10 @@ export default function AddScheduleButton({
     <Dialog
       open={open}
       onOpenChange={(v) => {
+        if (v && !session) {
+          router.push(`/login?callbackUrl=${encodeURIComponent(pathname)}`)
+          return
+        }
         setOpen(v)
         if (!v) resetForm()
       }}
@@ -219,8 +226,11 @@ export default function AddScheduleButton({
       <DialogTrigger asChild>
         <Button
           className={cn(
-            "text-white text-base font-semibold bg-third",
-            iconOnly ? "h-14 w-14 rounded-full p-0" : "h-[45px] rounded-[10px]",
+            iconOnly
+              ? "h-14 w-14 rounded-full p-0 bg-primary text-gray-50"
+              : label
+                ? "text-white text-base font-semibold bg-third h-[45px] rounded-[10px]"
+                : "text-gray-50 text-sm font-medium bg-primary w-36 h-9",
             className
           )}
         >
@@ -341,7 +351,7 @@ export default function AddScheduleButton({
                 }
                 onSelect={(range: DateRange | undefined) => {
                   setStartDate(range?.from)
-                  setEndDate(range?.to)
+                  setEndDate(range?.to ?? range?.from)
                 }}
                 disabled={disablePastDates}
                 className="rounded-md border p-1 w-full"

--- a/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MobileCalendarField/MobileTimeSlots.tsx
@@ -38,10 +38,19 @@ export default function MobileTimeSlots({
   const rentalHours = Array.from(rentalsByHour.keys())
   const startHour = Math.min(DEFAULT_START, ...rentalHours)
   const endHour = Math.max(DEFAULT_END, ...rentalHours)
+
+  // 예약이 진행 중인 시간대 (시작 시간 제외, 종료 시간 이전)는 스킵 대상
+  const occupiedHours = new Set<number>()
+  for (const rental of dayRentals) {
+    const sH = dayjs(rental.startAt).hour()
+    const eH = dayjs(rental.endAt).hour()
+    for (let h = sH + 1; h < eH; h++) occupiedHours.add(h)
+  }
+
   const hours = Array.from(
     { length: endHour - startHour + 1 },
     (_, i) => i + startHour
-  )
+  ).filter((h) => !occupiedHours.has(h) || rentalsByHour.has(h))
 
   return (
     <div className="flex flex-col">

--- a/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/MonthBlock.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/MonthBlock.tsx
@@ -6,13 +6,14 @@ interface MonthBlockProps {
   days: Dayjs[]
   currentMonth: Dayjs
   rentals: RentalDetail[]
-  onSelect?(d: Dayjs): void
+  onRentalClick?: (rental: RentalDetail) => void
 }
 
 export default function MonthBlock({
   days,
   currentMonth,
-  rentals
+  rentals,
+  onRentalClick
 }: MonthBlockProps) {
   return (
     <div className="grid grid-cols-7 auto-rows-[120px] border-t border-l border-gray-100">
@@ -42,7 +43,8 @@ export default function MonthBlock({
               return (
                 <div
                   key={rental.id}
-                  className={`mt-1 text-[9px] leading-tight ${color.bg} ${color.text} rounded px-1 py-0.5 truncate`}
+                  className={`mt-1 text-[9px] leading-tight ${color.bg} ${color.text} rounded px-1 py-0.5 truncate cursor-pointer`}
+                  onClick={() => onRentalClick?.(rental)}
                 >
                   {rental.title}
                 </div>

--- a/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/MonthCalendarField/index.tsx
@@ -5,11 +5,13 @@ import MonthBlock from "./MonthBlock"
 interface MonthCalendarFieldProps {
   currentMonday: Dayjs
   rentals: RentalDetail[]
+  onRentalClick?: (rental: RentalDetail) => void
 }
 
 export default function MonthCalendarField({
   currentMonday,
-  rentals
+  rentals,
+  onRentalClick
 }: MonthCalendarFieldProps) {
   const WeekLabelList = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
@@ -49,6 +51,7 @@ export default function MonthCalendarField({
         days={daysInGrid}
         currentMonth={currentMonth}
         rentals={rentals}
+        onRentalClick={onRentalClick}
       />
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -1,15 +1,31 @@
 "use client"
 
+import { useState } from "react"
 import dayjs from "dayjs"
-import { ArrowRight, Clock } from "lucide-react"
+import { ArrowRight, Clock, Trash2 } from "lucide-react"
+import { useSession } from "next-auth/react"
+import { useQueryClient } from "@tanstack/react-query"
 import { RentalDetail } from "@repo/shared-types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { useToast } from "@/components/hooks/use-toast"
+import { useDeleteRental } from "@/hooks/api/useRental"
 
 interface RentalDetailModalProps {
   rental: RentalDetail | null
@@ -22,7 +38,36 @@ export default function RentalDetailModal({
   open,
   onOpenChange
 }: RentalDetailModalProps) {
+  const { data: session } = useSession()
+  const deleteRental = useDeleteRental()
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
   if (!rental) return null
+
+  const currentUserId = session?.user?.id ? Number(session.user.id) : null
+  const isOwner = rental.users.some((u) => u.id === currentUserId)
+
+  const handleDelete = () => {
+    deleteRental.mutate([rental.id], {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["rentals"] })
+        onOpenChange(false)
+        toast({ title: "예약이 삭제되었습니다." })
+      },
+      onError: (error) => {
+        toast({
+          variant: "destructive",
+          title: "삭제 실패",
+          description:
+            error instanceof Error
+              ? error.message
+              : "예약을 삭제하지 못했습니다."
+        })
+      }
+    })
+  }
 
   const start = dayjs(rental.startAt)
   const end = dayjs(rental.endAt)
@@ -117,7 +162,43 @@ export default function RentalDetailModal({
             </div>
           </div>
         )}
+        {/* Delete button */}
+        {isOwner && (
+          <div className="pt-2">
+            <Button
+              variant="destructive"
+              size="sm"
+              className="w-full"
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={deleteRental.isPending}
+            >
+              <Trash2 size={14} className="mr-1.5" />
+              {deleteRental.isPending ? "삭제 중..." : "예약 삭제"}
+            </Button>
+          </div>
+        )}
       </DialogContent>
+
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>예약을 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>
+              &ldquo;{rental.title}&rdquo; 예약이 영구적으로 삭제됩니다. 이
+              작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   )
 }

--- a/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/clubroom/_components/ClubroomReservationPage.tsx
@@ -8,7 +8,7 @@ import ROUTES from "@/constants/routes"
 import MyReservationField from "../../_components/MyReservationField"
 import AddScheduleButton from "../../_components/AddScheduleButton"
 import WeekCalendarField from "../../_components/WeekCalendarField"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { useQueryState, parseAsStringLiteral, parseAsString } from "nuqs"
 import WeekLabel from "../../_components/WeekLable"
 import MonthCalendarField from "../../_components/MonthCalendarField"
@@ -44,14 +44,24 @@ export default function ClubroomReservationPage() {
   const selectedDate = dayjs(new Date(y!, m! - 1, d!))
   const setSelectedDate = (date: Dayjs) =>
     setSelectedDateStr(date.format("YYYY-MM-DD"))
-  const getWeekStart = (date = dayjs()) => date.startOf("week")
 
-  const [currentMonday, setCurrentMonday] = useState(getWeekStart())
-  const [calendarViewMonth, setCalendarViewMonth] = useState(currentMonday)
+  // Google Calendar 방식: selectedDate에서 주/월 범위 파생
+  const currentMonday = selectedDate.startOf("week")
+  const calendarViewMonth = selectedDate.startOf("month")
 
-  useEffect(() => {
-    setCalendarViewMonth(currentMonday)
-  }, [currentMonday])
+  // WeekLabel 네비게이션용 래퍼
+  const setCurrentMonday = (mondayOrFn: Dayjs | ((prev: Dayjs) => Dayjs)) => {
+    const newMonday =
+      typeof mondayOrFn === "function" ? mondayOrFn(currentMonday) : mondayOrFn
+    setSelectedDate(newMonday)
+  }
+  const setCalendarViewMonth = (
+    monthOrFn: Dayjs | ((prev: Dayjs) => Dayjs)
+  ) => {
+    const newMonth =
+      typeof monthOrFn === "function" ? monthOrFn(calendarViewMonth) : monthOrFn
+    setSelectedDate(newMonth)
+  }
 
   // 데이터 조회 범위: 현재 보고 있는 달의 시작~끝 (+전후 1주)
   const queryRange = useMemo(() => {
@@ -130,6 +140,7 @@ export default function ClubroomReservationPage() {
               <MonthCalendarField
                 currentMonday={currentMonday}
                 rentals={rentalList}
+                onRentalClick={setSelectedRental}
               />
               <WeekLabel
                 weekLabel={weekLabel}

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { useQueryState, parseAsStringLiteral, parseAsString } from "nuqs"
 import { useParams } from "next/navigation"
 import Link from "next/link"
@@ -51,13 +51,21 @@ export default function EquipmentCalendarPage() {
   const equipmentId = Number(params.id)
   const { data: equipmentDetail } = useEquipment(equipmentId)
 
-  const getWeekStart = (date = dayjs()) => date.startOf("week")
-  const [currentMonday, setCurrentMonday] = useState(getWeekStart())
-  const [calendarViewMonth, setCalendarViewMonth] = useState(currentMonday)
+  const currentMonday = selectedDate.startOf("week")
+  const calendarViewMonth = selectedDate.startOf("month")
 
-  useEffect(() => {
-    setCalendarViewMonth(currentMonday)
-  }, [currentMonday])
+  const setCurrentMonday = (mondayOrFn: Dayjs | ((prev: Dayjs) => Dayjs)) => {
+    const newMonday =
+      typeof mondayOrFn === "function" ? mondayOrFn(currentMonday) : mondayOrFn
+    setSelectedDate(newMonday)
+  }
+  const setCalendarViewMonth = (
+    monthOrFn: Dayjs | ((prev: Dayjs) => Dayjs)
+  ) => {
+    const newMonth =
+      typeof monthOrFn === "function" ? monthOrFn(calendarViewMonth) : monthOrFn
+    setSelectedDate(newMonth)
+  }
 
   const queryRange = useMemo(() => {
     const monthStart = calendarViewMonth
@@ -149,6 +157,7 @@ export default function EquipmentCalendarPage() {
               <MonthCalendarField
                 currentMonday={currentMonday}
                 rentals={rentalList}
+                onRentalClick={setSelectedRental}
               />
               <WeekLabel
                 weekLabel={weekLabel}

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@fullcalendar/react": "^6.1.20",
     "@fullcalendar/timegrid": "^6.1.20",
     "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.72.0(react@19.2.4))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2469,6 +2472,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -10687,6 +10703,20 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## 🚀 작업 내용

예약 캘린더의 CRUD 완성도 및 UX 개선 (8개 항목):

1. **월간 이벤트 클릭 → 상세 모달**: MonthBlock에서 이벤트 클릭 시 RentalDetailModal 표시
2. **예약 삭제 버튼**: RentalDetailModal에 본인 예약 삭제 기능 추가 (AlertDialog 확인)
3. **데스크톱 Add Schedule 스타일 복구**: `bg-primary`, `h-9` (이전 스타일) — `label` prop 있으면 모바일 스타일 유지
4. **URL 동기화 (Google Calendar 방식)**: `currentMonday`/`calendarViewMonth`를 `selectedDate`에서 파생, 주간 이동 시 URL 자동 반영
5. **날짜 단일 선택 → 종료 자동**: range calendar에서 `to ?? from` 폴백
6. **시간 슬롯 생략**: 진행 중 예약의 빈 시간대 숨김 (occupied hours 스킵)
7. **비로그인 → 로그인 리다이렉트**: 예약 버튼 클릭 시 `/login?callbackUrl` 이동
8. **분 단위 15분**: 5분 → 15분으로 변경

## 📸 스크린샷(선택)

Vercel 프리뷰에서 확인

## 🔗 관련 이슈

Closes #419

## 🙏 리뷰어에게

- 편집 기능은 복잡도가 높아 이번 PR에서 제외, 삭제만 구현했습니다.
- URL 동기화: `setCurrentMonday`/`setCalendarViewMonth`를 함수 래퍼로 구현하여 기존 WeekLabel 컴포넌트 수정 없이 동작합니다.
- `useDeleteRental` 훅의 호출 시그니처가 `mutate([id], ...)`인지 확인 필요 (createMutationHook 패턴에 따라 다를 수 있음).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
