### PR TITLE
fix(web): 장비 예약 페이지 hydration error 수정

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/WeekCalendarField/index.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import dayjs, { Dayjs } from "dayjs"
 import { RentalDetail } from "@repo/shared-types"
 import WeekColumn from "./WeekColumn"
@@ -24,14 +27,20 @@ export default function WeekCalendarField({
   const slotCount = endHour - startHour + 1
   const totalMin = slotCount * 60
 
-  const currentTime = new Date()
-  const h = currentTime.getHours()
-  const m = currentTime.getMinutes()
-  const minutesSinceStart = (h - startHour) * 60 + m
-  const clampedMin = Math.max(0, Math.min(totalMin, minutesSinceStart))
-  const nowTopPx = (clampedMin * ROW_H) / 60 + 42
+  const [now, setNow] = useState<Date | null>(null)
+  useEffect(() => {
+    setNow(new Date())
+  }, [])
 
-  const timeLabel = currentTime.toLocaleTimeString("en-US", {
+  const nowTopPx = (() => {
+    if (!now) return 0
+    const minutesSinceStart =
+      (now.getHours() - startHour) * 60 + now.getMinutes()
+    const clampedMin = Math.max(0, Math.min(totalMin, minutesSinceStart))
+    return (clampedMin * ROW_H) / 60 + 42
+  })()
+
+  const timeLabel = now?.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
     hour12: true
@@ -69,16 +78,18 @@ export default function WeekCalendarField({
             key={i}
           />
         ))}
-        <div
-          className="w-full absolute bg-destructive h-[1px]"
-          style={{ top: `${nowTopPx}px` }}
-        >
-          <div className="w-full relative">
-            <div className="absolute w-11 flex items-center justify-center -translate-y-1/2 h-4 rounded-lg text-[10px] text-white bg-destructive -left-5">
-              {timeLabel}
+        {now && (
+          <div
+            className="w-full absolute bg-destructive h-[1px]"
+            style={{ top: `${nowTopPx}px` }}
+          >
+            <div className="w-full relative">
+              <div className="absolute w-11 flex items-center justify-center -translate-y-1/2 h-4 rounded-lg text-[10px] text-white bg-destructive -left-5">
+                {timeLabel}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
+++ b/apps/web/app/(general)/(light)/reservations/equipment/[id]/_components/EquipmentCalendarPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useQueryState, parseAsStringLiteral, parseAsString } from "nuqs"
 import { useParams } from "next/navigation"
 import Link from "next/link"
@@ -41,9 +41,18 @@ export default function EquipmentCalendarPage() {
   )
   const [selectedDateStr, setSelectedDateStr] = useQueryState(
     "date",
-    parseAsString.withDefault(dayjs().format("YYYY-MM-DD"))
+    parseAsString
   )
-  const [y, m, d] = selectedDateStr.split("-").map(Number)
+  const todayStr = dayjs().format("YYYY-MM-DD")
+  const dateStr = selectedDateStr || todayStr
+
+  useEffect(() => {
+    if (!selectedDateStr) {
+      setSelectedDateStr(todayStr)
+    }
+  }, [selectedDateStr, todayStr, setSelectedDateStr])
+
+  const [y, m, d] = dateStr.split("-").map(Number)
   const selectedDate = dayjs(new Date(y!, m! - 1, d!))
   const setSelectedDate = (date: Dayjs) =>
     setSelectedDateStr(date.format("YYYY-MM-DD"))


### PR DESCRIPTION
## 🚀 작업 내용

장비 예약 페이지(`/reservations/equipment/[id]`)에서 발생하던 hydration error를 수정합니다.

**원인**: 서버 렌더링과 클라이언트 hydration 간 현재 시간 불일치
- `WeekCalendarField`: `new Date()`로 계산한 현재 시간 라인 위치/레이블이 서버/클라이언트에서 다름
- `EquipmentCalendarPage`: `useQueryState`의 `withDefault(dayjs())`가 서버/클라이언트에서 다른 날짜를 반환 가능 (타임존 차이)

**수정**:
- `WeekCalendarField`: 현재 시간을 `useEffect`로 클라이언트 마운트 후에만 설정, 마운트 전에는 시간 라인 숨김
- `EquipmentCalendarPage`: `withDefault` 제거, 마운트 후 `useEffect`로 오늘 날짜 설정

## 📸 스크린샷(선택)

N/A — 로직 변경만 포함, UI 변경 없음

## 🔗 관련 이슈

Sentry [WEB-M](https://amang-23.sentry.io/issues/WEB-M) — Hydration Error on `/reservations/equipment/25392`

## 🙏 리뷰어에게

- `WeekCalendarField`에 `"use client"` 지시어를 추가했습니다 (기존에 없었으나 `useState`/`useEffect` 사용을 위해 필요)
- 현재 시간 라인은 마운트 전 잠깐 안 보이다가 나타나지만, 체감상 거의 인지 불가능합니다

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.