### PR TITLE
fix(api): pino logger userId anonymous 오기록 버그 수정

### DIFF
--- a/apps/api/src/common/logger/pino-logger.config.ts
+++ b/apps/api/src/common/logger/pino-logger.config.ts
@@ -4,6 +4,10 @@ import type { Params } from "nestjs-pino"
 import type { PrettyOptions } from "pino-pretty"
 import PinoPretty from "pino-pretty"
 import { format } from "sql-formatter"
+import { JwtService } from "@nestjs/jwt"
+import { JwtPayload } from "@repo/shared-types"
+
+const jwtService = new JwtService()
 
 const pinoPrettyOptions: PrettyOptions = {
   messageFormat: (log, messageKey) => {
@@ -38,7 +42,12 @@ export const pinoLoggerModuleOption: Params = {
       return mergeObject
     },
     customProps(req: any) {
-      return req.user ? { userId: req.user.sub } : { userId: "anonymous" }
+      const token = req.headers?.authorization?.split(" ")[1]
+      const payload = token ? jwtService.decode<JwtPayload>(token) : null
+
+      return payload
+        ? { userId: payload.sub, username: payload.name }
+        : { userId: "anonymous", username: "anonymous" }
     },
     genReqId(req, res) {
       const id = randomUUID()


### PR DESCRIPTION
## 🚀 작업 내용

pino logger에서 인증된 요청임에도 `userId`가 `anonymous`로 기록되는 버그를 수정합니다.

**근본 원인:**
pino-http의 `customProps`는 두 번 호출됩니다.
1. **요청 수신 시** (미들웨어 단계) — NestJS AuthGuard 실행 전이라 `req.user`가 없음 → `userId: "anonymous"` 바인딩
2. **응답 완료 시** — AuthGuard 이후라 `req.user`가 있음 → `userId: 94` 추가

결과적으로 JSON에 중복 키가 발생합니다: `"userId":"anonymous","userId":94`

Grafana(Loki)는 Go의 `encoding/json`을 사용하며, 중복 키 발생 시 **첫 번째 값**을 채택합니다. 따라서 Grafana에서는 인증된 요청도 항상 `userId: anonymous`로 집계되고 있었습니다.

**수정 방법:**
`JwtService.decode()`로 `Authorization` 헤더의 JWT를 서명 검증 없이 디코딩하여, 요청 시점부터 올바른 `userId`와 `username`을 기록합니다. 두 호출의 반환값이 동일해지므로 pino-http 내부의 중복 제거 로직이 정상 작동합니다.

```ts
// before
customProps(req: any) {
  return req.user ? { userId: req.user.sub } : { userId: "anonymous" }
}

// after
customProps(req: any) {
  const token = req.headers?.authorization?.split(" ")[1]
  const payload = token ? jwtService.decode<JwtPayload>(token) : null
  return payload
    ? { userId: payload.sub, username: payload.name }
    : { userId: "anonymous", username: "anonymous" }
}
```

## 🔗 관련 이슈

없음

## 🙏 리뷰어에게

- `JwtService.decode()`는 서명을 검증하지 않습니다. 변조된 토큰의 값이 로그에 기록될 수 있으나, 로깅 목적으로는 허용 가능하며 실제 인증/인가는 AuthGuard가 별도로 처리합니다.
- `username` 필드도 함께 추가했습니다 (JWT 페이로드의 `name` 필드).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.