### PR TITLE
fix(web): 비로그인 사용자의 불필요한 /auth/refresh 요청 방지

### DIFF
--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -83,13 +83,18 @@ const authOptions: NextAuthConfig = {
         return token
       }
 
+      // refreshToken이 없으면 갱신 불가 (비로그인 상태)
+      if (!token.refreshToken) {
+        return token
+      }
+
       // 토큰 갱신 시도
       try {
         const {
           accessToken,
           refreshToken: newRefreshToken,
           expiresIn
-        } = await refreshAccessToken(token?.refreshToken as string)
+        } = await refreshAccessToken(token.refreshToken as string)
         return {
           ...token,
           accessToken,


### PR DESCRIPTION
## 🚀 작업 내용

비로그인 상태에서 JWT 콜백이 호출될 때 `refreshToken`이 `undefined`인 상태로 `/auth/refresh` API를 반복 호출하는 버그 수정.

**근본 원인:** `apps/web/auth.ts` JWT 콜백에서
1. `token.expiresIn`이 `undefined` → 만료 체크 guard 통과 (비로그인 = 만료로 판단)
2. `token.refreshToken`이 `undefined` → `as string` 캐스팅으로 타입 안전장치 우회
3. `apiClient.refreshToken(undefined)` → 백엔드에 무효한 요청 → 401 반복

**수정:** `refreshToken`이 없으면 갱신을 시도하지 않고 토큰을 그대로 반환.

**영향:** 오늘 하루 약 100건 이상의 불필요한 401 요청 발생 확인 (18:16에 ~30건, 18:53-54에 ~41건 집중).

## 📸 스크린샷(선택)

해당 없음 (로직 수정)

## 🔗 관련 이슈

승민 슬랙 리포트 (2026-04-10): 비로그인 상태에서 `/auth/refresh`로 요청 폭주

## 🙏 리뷰어에게

- 비로그인 상태에서 에러를 세팅하지 않는 이유: 비로그인은 "에러"가 아니므로 `SessionGuard`의 불필요한 signOut을 방지
- 변경 범위가 5줄로 매우 작아 사이드이펙트 낮음

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)