### PR TITLE
fix(api,db): RT 갱신 시 동시 요청 race condition 방지 (grace period)

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -13,6 +13,9 @@ import { createHash, timingSafeEqual } from "crypto"
 import { CreateUserDto } from "../users/dto/create-user.dto"
 import { LoginUserDto } from "../users/dto/login-user.dto"
 import { UsersService } from "../users/users.service"
+
+const REFRESH_TOKEN_GRACE_PERIOD_MS = 30_000
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -109,17 +112,33 @@ export class AuthService {
 
     const incomingHash = createHash("sha256").update(refreshToken).digest("hex")
 
-    if (incomingHash.length !== user.hashedRefreshToken.length)
-      throw new RefreshTokenExpiredError("리프레시 토큰이 유효하지 않습니다.")
-
-    const refreshTokenMatches = timingSafeEqual(
-      Buffer.from(incomingHash),
-      Buffer.from(user.hashedRefreshToken)
-    )
-    if (!refreshTokenMatches) {
-      throw new RefreshTokenExpiredError(
-        "리프레시 토큰이 만료되었거나 존재하지 않습니다."
+    const matchesCurrent =
+      incomingHash.length === user.hashedRefreshToken.length &&
+      timingSafeEqual(
+        Buffer.from(incomingHash),
+        Buffer.from(user.hashedRefreshToken)
       )
+
+    if (!matchesCurrent) {
+      const withinGracePeriod =
+        user.previousHashedRefreshToken &&
+        user.refreshTokenRotatedAt &&
+        Date.now() - user.refreshTokenRotatedAt.getTime() <
+          REFRESH_TOKEN_GRACE_PERIOD_MS
+
+      const matchesPrevious =
+        withinGracePeriod &&
+        incomingHash.length === user.previousHashedRefreshToken!.length &&
+        timingSafeEqual(
+          Buffer.from(incomingHash),
+          Buffer.from(user.previousHashedRefreshToken!)
+        )
+
+      if (!matchesPrevious) {
+        throw new RefreshTokenExpiredError(
+          "리프레시 토큰이 만료되었거나 존재하지 않습니다."
+        )
+      }
     }
 
     const tokens = await this.getTokens(

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -90,10 +90,30 @@ export class UsersService {
     const hashedRefreshToken = refreshToken
       ? createHash("sha256").update(refreshToken).digest("hex")
       : null
-    await this.prisma.user.update({
-      where: { id: userId },
-      data: { hashedRefreshToken: hashedRefreshToken }
-    })
+
+    if (refreshToken) {
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { hashedRefreshToken: true }
+      })
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          hashedRefreshToken,
+          previousHashedRefreshToken: user?.hashedRefreshToken ?? null,
+          refreshTokenRotatedAt: new Date()
+        }
+      })
+    } else {
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          hashedRefreshToken: null,
+          previousHashedRefreshToken: null,
+          refreshTokenRotatedAt: null
+        }
+      })
+    }
   }
 
   async updateUser(userId: number, updateUserDto: UpdateUserDto) {

--- a/packages/database/prisma/migrations/20260410184727_add_refresh_token_grace_period/migration.sql
+++ b/packages/database/prisma/migrations/20260410184727_add_refresh_token_grace_period/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "previousHashedRefreshToken" TEXT,
+ADD COLUMN     "refreshTokenRotatedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -43,8 +43,10 @@ model User {
   image              String?
   isAdmin            Boolean  @default(false)
   isApproved         Boolean  @default(false)
-  hashedRefreshToken String?
-  createdAt          DateTime @default(now())
+  hashedRefreshToken         String?
+  previousHashedRefreshToken String?
+  refreshTokenRotatedAt      DateTime?
+  createdAt                  DateTime  @default(now())
   updatedAt          DateTime @updatedAt
 
   generationId      Int


### PR DESCRIPTION
## 🚀 작업 내용

RT rotation 시 동시 요청(next-auth JWT 콜백 다중 호출, 클라이언트/서버 동시 갱신)으로 인해 DB의 RT 해시가 꼬여 정상 사용자가 로그아웃되는 race condition 수정.

**Grace period 방식**: RT 교체 시 이전 RT 해시를 30초간 유효하게 유지하여 동시 요청을 흡수.

### 변경 요약

- **Prisma 스키마**: `User`에 `previousHashedRefreshToken`, `refreshTokenRotatedAt` 컬럼 추가
- **`UsersService.updateRefreshToken()`**: RT 교체 시 현재 해시를 이전 해시로 보존 + 교체 시각 기록, 로그아웃 시 이전 해시도 함께 제거
- **`AuthService.refreshTokens()`**: 현재 RT 불일치 시 grace period(30초) 내 이전 RT 해시와도 비교

### Race condition 재현 시나리오

```
시점 T: AT 만료

요청 A (SSR): JWT 콜백 → POST /auth/refresh (RT=abc)
요청 B (CSR): onTokenExpired → update() → JWT 콜백 → POST /auth/refresh (RT=abc)

Before (현재):
  A: hash("abc") 일치 ✅ → 새 RT "xyz" → DB = hash("xyz")
  B: hash("abc") ≠ hash("xyz") → ❌ RefreshTokenExpiredError → 강제 로그아웃

After (이 PR):
  A: hash("abc") 일치 ✅ → 새 RT "xyz" → DB = hash("xyz"), prev = hash("abc")
  B: hash("abc") ≠ hash("xyz") → grace period 내 prev hash("abc") 일치 ✅ → 새 RT 발급
```

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

Closes #443
Closes #442

## 🙏 리뷰어에게

- Grace period 30초는 상수(`REFRESH_TOKEN_GRACE_PERIOD_MS`)로 관리합니다. 환경별로 다를 이유가 없어 환경변수 대신 상수를 선택했습니다.
- 이 방식은 서버 스케일아웃 시에도 DB 기반이므로 별도 조치 없이 동작합니다.
- #410 (클라이언트 중복 갱신 정리), #439 (비로그인 refresh 폭주 수정)와 별개의 서버사이드 해결입니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)