### PR TITLE
feat(skill): meeting-prep 출력을 테이블 형식으로 전환

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -97,11 +97,17 @@ GitHub 이슈/PR의 `scope:` 라벨로 영역을 판정한다. 라벨이 SSOT이
 [examples/output.md](examples/output.md)의 형식과 규칙을 **정확히** 따른다.
 
 핵심 규칙:
-- **모든 이슈/PR/Sentry 이슈에 클릭 가능한 링크 필수**
-- `### > @이름` 토글 헤딩 구조 사용
-- 상태 아이콘: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
-- 정렬: ✅ → 🔧 → ⏸️ 순서
-- 직전 분배 항목: `← 직전(N차) 분배` 부기 (N은 직전 회의 차수)
+- **테이블 형식 사용**: `heading_3` 토글 안에 `table` 블록으로 항목 표시
+- **진행 상황 컬럼**: `#` | `내용` | `진행` | `중요도` | `링크` | `상세` (table_width=6)
+- **논의 안건 컬럼**: `#` | `내용` | `중요도` | `링크` | `상세` (table_width=5, 진행 컬럼 없음)
+- **Sentry 컬럼**: `상태` | `에러` | `프로젝트` | `이벤트` | `링크` | `처리` (table_width=6, 토글 없이 직접 table)
+- **중요도 기준**: 🔴 높음(Sentry·보안·미이행) / 🟡 보통(버그·진행 중·배포) / ⚪ 낮음(chore·리팩토링·제안)
+- **진행 아이콘**: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
+- **정렬**: ✅ → 🔧 → ⏸️ 순서
+- **링크 컬럼**: 이슈/PR 번호에 클릭 가능한 link 속성 필수, `#이슈 → PR #번호` 형태
+- **상세 컬럼**: 직전 분배 부기(`← N차 분배`), 상태 비고(OPEN 등), 한줄 설명
+- **빈 셀 처리**: 빈 셀도 `[{"type": "text", "text": {"content": ""}}]`로 채울 것 (400 에러 방지)
+- **1회 호출로 토글+테이블 생성**: `heading_3.children`에 `table`을 직접 포함하여 한 번에 생성
 
 ### 7단계: 사용자 확인
 
@@ -117,10 +123,15 @@ GitHub 이슈/PR의 `scope:` 라벨로 영역을 판정한다. 라벨이 SSOT이
 사용자가 승인하면 Notion MCP 도구로 현재 회의 페이지에 작성:
 
 - `mcp__amang-notion__API-patch-block-children`으로 블록 추가
-- `heading_3`은 `is_toggleable: true` + children으로 항목 삽입
+- 각 영역별 `heading_2` 뒤에 `heading_3` 토글(children에 `table` 포함)을 **1회 호출로** 삽입
+- `heading_3.children[0]`이 `table`, `table.children`이 `table_row` 배열
+- 모든 `table_row.cells` 배열 길이는 `table_width`와 정확히 일치해야 함
+- 빈 셀도 `[{"type": "text", "text": {"content": ""}}]`로 채움 (빈 배열·null 금지)
 - 이슈/PR 링크는 Notion rich text의 `link` 속성 사용
 - `@멘션`은 가능하면 Notion user mention 사용, 불가하면 plain text `@이름`
 - 특정 블록 뒤에 삽입할 때는 `after` 파라미터 사용
+- Sentry 테이블은 토글 없이 `heading_2` 바로 아래에 `table` 직접 삽입
+- 각 섹션(진행 상황/논의 안건/특이사항)을 **병렬 서브에이전트**로 동시 작성하여 속도 최적화
 
 ## 주의사항
 

--- a/.claude/skills/meeting-prep/examples/output.md
+++ b/.claude/skills/meeting-prep/examples/output.md
@@ -17,36 +17,42 @@
 
 ## 프론트
 ### > @손장수
-- ✅ YouTube URL 검증 강화 ([#365](https://github.com/skku-amang/main/issues/365) → [PR #366](https://github.com/skku-amang/main/pull/366))
-- ✅ YouTube 유틸 SSOT 통합 ([#369](https://github.com/skku-amang/main/issues/369) → [PR #372](https://github.com/skku-amang/main/pull/372))
-- ✅ Prisma engine enum entrypoint 분리 ([PR #380](https://github.com/skku-amang/main/pull/380)) — Vercel 배포 시 Query Engine 누락 해결
-- 🔧 에러 메시지 개선 + 팀 지원 에러 표시 ([#382](https://github.com/skku-amang/main/issues/382), [#384](https://github.com/skku-amang/main/issues/384) → [PR #383](https://github.com/skku-amang/main/pull/383))
-- ⏸️ 로그인 재요구 버그 ([#358](https://github.com/skku-amang/main/issues/358)) ← 직전(4차) 분배, 미착수
-- ⏸️ 모바일 회원가입 불가 ([#359](https://github.com/skku-amang/main/issues/359)) ← 직전(4차) 분배, 미착수
+
+| # | 내용 | 진행 | 중요도 | 링크 | 상세 |
+|--:|------|:---:|:-----:|------|------|
+| 1 | YouTube URL 검증 강화 | ✅ | ⚪ | [#365](https://github.com/skku-amang/main/issues/365) → [PR #366](https://github.com/skku-amang/main/pull/366) | |
+| 2 | YouTube 유틸 SSOT 통합 | ✅ | ⚪ | [#369](https://github.com/skku-amang/main/issues/369) → [PR #372](https://github.com/skku-amang/main/pull/372) | |
+| 3 | Prisma engine enum entrypoint 분리 | ✅ | 🟡 | [PR #380](https://github.com/skku-amang/main/pull/380) | Vercel 배포 시 Query Engine 누락 해결 |
+| 4 | 에러 메시지 개선 + 팀 지원 에러 표시 | 🔧 | 🟡 | [#382](https://github.com/skku-amang/main/issues/382), [#384](https://github.com/skku-amang/main/issues/384) → [PR #383](https://github.com/skku-amang/main/pull/383) | |
+| 5 | 로그인 재요구 버그 | ⏸️ | 🔴 | [#358](https://github.com/skku-amang/main/issues/358) | ← 4차 분배, 미착수 |
+| 6 | 모바일 회원가입 불가 | ⏸️ | 🔴 | [#359](https://github.com/skku-amang/main/issues/359) | ← 4차 분배, 미착수 |
 
 ## 인프라
 ### > @손장수
-- ✅ Sentry 도입 ([#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370)) ← 직전(4차) 분배
-- ✅ 임베디드 → 유저 QA ([#360](https://github.com/skku-amang/main/issues/360)) ← 직전(4차) 분배
-- ✅ DB CronJob → ArgoCD PreSync Hook 전환 ([PR #377](https://github.com/skku-amang/main/pull/377))
-- ✅ Job 파드 라벨 충돌 502 해소 ([PR #378](https://github.com/skku-amang/main/pull/378))
-- ✅ 헬스체크 Sentry 에러 캡처 제외 ([PR #387](https://github.com/skku-amang/main/pull/387))
-- ✅ 온보딩 자동화 셋업 스크립트 ([PR #374](https://github.com/skku-amang/main/pull/374))
-- ✅ deps 업데이트 + ESLint 9 마이그레이션 ([PR #376](https://github.com/skku-amang/main/pull/376))
-- ✅ Jest → Vitest 마이그레이션 ([#367](https://github.com/skku-amang/main/issues/367))
-- 🔧 DB 마이그레이션 Job 생성 ([#362](https://github.com/skku-amang/main/issues/362)) ← 직전(4차) 분배, 진행 중
-- 🔧 CI 테스트 워크플로우 분리 및 병렬화 ([#368](https://github.com/skku-amang/main/issues/368))
-- 🔧 seed 스크립트 멱등성 확보 ([#379](https://github.com/skku-amang/main/issues/379) → [PR #381](https://github.com/skku-amang/main/pull/381))
+
+| # | 내용 | 진행 | 중요도 | 링크 | 상세 |
+|--:|------|:---:|:-----:|------|------|
+| 1 | Sentry 도입 | ✅ | ⚪ | [#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370) | ← 4차 분배 |
+| 2 | 임베디드 → 유저 QA | ✅ | ⚪ | [#360](https://github.com/skku-amang/main/issues/360) | ← 4차 분배 |
+| 3 | DB CronJob → ArgoCD PreSync Hook 전환 | ✅ | ⚪ | [PR #377](https://github.com/skku-amang/main/pull/377) | |
+| 4 | Job 파드 라벨 충돌 502 해소 | ✅ | 🟡 | [PR #378](https://github.com/skku-amang/main/pull/378) | |
+| 5 | 헬스체크 Sentry 에러 캡처 제외 | ✅ | ⚪ | [PR #387](https://github.com/skku-amang/main/pull/387) | |
+| 6 | 온보딩 자동화 셋업 스크립트 | ✅ | ⚪ | [PR #374](https://github.com/skku-amang/main/pull/374) | |
+| 7 | deps 업데이트 + ESLint 9 마이그레이션 | ✅ | ⚪ | [PR #376](https://github.com/skku-amang/main/pull/376) | |
+| 8 | Jest → Vitest 마이그레이션 | ✅ | ⚪ | [#367](https://github.com/skku-amang/main/issues/367) | |
+| 9 | DB 마이그레이션 Job 생성 | 🔧 | 🟡 | [#362](https://github.com/skku-amang/main/issues/362) | ← 4차 분배, 진행 중 |
+| 10 | CI 테스트 워크플로우 분리 및 병렬화 | 🔧 | ⚪ | [#368](https://github.com/skku-amang/main/issues/368) | |
+| 11 | seed 스크립트 멱등성 확보 | 🔧 | 🟡 | [#379](https://github.com/skku-amang/main/issues/379) → [PR #381](https://github.com/skku-amang/main/pull/381) | |
 
 ## 직전(4차) 작업 분배 이행
 
-| 분배 작업 | 영역 | 결과 |
-|---|---|---|
-| 임베디드 → 유저 QA | 인프라 | ✅ 완료 ([#360](https://github.com/skku-amang/main/issues/360)) |
-| Sentry 도입 | 인프라 | ✅ 완료 ([#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370)) |
-| DB 마이그레이션 Job 생성 | 인프라 | 🔧 진행 중 ([#362](https://github.com/skku-amang/main/issues/362)) |
-| 로그인 재요구 버그 | 프론트 | ⏸️ 미착수 ([#358](https://github.com/skku-amang/main/issues/358)) |
-| 모바일 회원가입 불가 | 프론트 | ⏸️ 미착수 ([#359](https://github.com/skku-amang/main/issues/359)) |
+| 분배 작업 | 영역 | 결과 | 링크 |
+|---|---|---|---|
+| 임베디드 → 유저 QA | 인프라 | ✅ 완료 | [#360](https://github.com/skku-amang/main/issues/360) |
+| Sentry 도입 | 인프라 | ✅ 완료 | [#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370) |
+| DB 마이그레이션 Job 생성 | 인프라 | 🔧 진행 중 | [#362](https://github.com/skku-amang/main/issues/362) |
+| 로그인 재요구 버그 | 프론트 | ⏸️ 미착수 | [#358](https://github.com/skku-amang/main/issues/358) |
+| 모바일 회원가입 불가 | 프론트 | ⏸️ 미착수 | [#359](https://github.com/skku-amang/main/issues/359) |
 
 ---
 
@@ -56,35 +62,49 @@
 
 ## 프론트
 ### > @손장수
-- NFC 기반 악기/장비 대여·반납 자동화 ([#373](https://github.com/skku-amang/main/issues/373))
-- 긍정 피드백 위젯 + Slack 알림 파이프라인 ([#385](https://github.com/skku-amang/main/issues/385))
-- Vercel 배포 시 Prisma Query Engine 누락 ([#375](https://github.com/skku-amang/main/issues/375))
-- 에러 타입 매핑 exhaustive switch 전환 ([#388](https://github.com/skku-amang/main/issues/388))
+
+| # | 내용 | 중요도 | 링크 | 상세 |
+|--:|------|:-----:|------|------|
+| 1 | NFC 기반 악기/장비 대여·반납 자동화 | ⚪ | [#373](https://github.com/skku-amang/main/issues/373) | 신규 제안 |
+| 2 | 긍정 피드백 위젯 + Slack 알림 파이프라인 | 🟡 | [#385](https://github.com/skku-amang/main/issues/385) | |
+| 3 | Vercel 배포 시 Prisma Query Engine 누락 | 🟡 | [#375](https://github.com/skku-amang/main/issues/375) | |
+| 4 | 에러 타입 매핑 exhaustive switch 전환 | ⚪ | [#388](https://github.com/skku-amang/main/issues/388) | |
 
 ## 인프라
 ### > @손장수
-- 주간 활동 리포트 Slack 자동 발송 ([#386](https://github.com/skku-amang/main/issues/386))
+
+| # | 내용 | 중요도 | 링크 | 상세 |
+|--:|------|:-----:|------|------|
+| 1 | 주간 활동 리포트 Slack 자동 발송 | ⚪ | [#386](https://github.com/skku-amang/main/issues/386) | |
 
 ---
 
 # Sentry 에러 현황
 
-| 상태 | 에러 | 프로젝트 | 이벤트 | 처리 |
-|---|---|---|---|---|
-| ✅ | PrismaClientInitializationError | web | 54건 | [PR #380](https://github.com/skku-amang/main/pull/380) |
-| ✅ | 헬스체크 503 | api | 2건 | [PR #387](https://github.com/skku-amang/main/pull/387) |
-| ✅ | PrismaKnownRequestError (rentals) | api | 15건 | resolved |
-| ⚠️ | 서버 에러 /performances/1/teams ([WEB-9](https://amang-23.sentry.io/issues/WEB-9)) | web | 1건 | **미해결** |
+| 상태 | 에러 | 프로젝트 | 이벤트 | 링크 | 처리 |
+|:---:|------|:------:|------:|------|------|
+| ✅ | PrismaClientInitializationError | web | 54건 | [PR #380](https://github.com/skku-amang/main/pull/380) | 해결 |
+| ✅ | 헬스체크 503 | api | 2건 | [PR #387](https://github.com/skku-amang/main/pull/387) | 필터링 처리 |
+| ✅ | PrismaKnownRequestError (rentals) | api | 15건 | | resolved |
+| ⚠️ | 서버 에러 /performances/1/teams | web | 1건 | [WEB-9](https://amang-23.sentry.io/issues/WEB-9) | **미해결** |
 
 ---
 
 ## 형식 규칙
 
-1. **상태 아이콘**: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
-2. **링크 필수**: 모든 이슈/PR/Sentry 이슈에 클릭 가능한 링크 포함
-3. **이슈-PR 연결**: `(#이슈 → PR #번호)` 형태로 연결 관계 명시
-4. **직전 분배 표시**: 직전 회의에서 분배받은 항목에 `← 직전(N차) 분배` 부기
-5. **중복 제거**: 진행 상황에 있는 항목은 논의 안건에 포함하지 않음
-6. **토글 헤딩**: `### > @이름`은 노션에서 `is_toggleable: true` heading_3으로 변환
-7. **영역 분류**: GitHub `scope:` 라벨이 SSOT, 라벨 없으면 제목에서 추정
-8. **정렬**: ✅ → 🔧 → ⏸️ 순서로 정렬
+1. **테이블 형식**: 진행 상황·논의 안건 모두 테이블(`table` + `table_row`) 사용, `has_column_header: true`
+2. **컬럼 구성**:
+   - 진행 상황: `#` | `내용` | `진행` | `중요도` | `링크` | `상세`
+   - 논의 안건: `#` | `내용` | `중요도` | `링크` | `상세` (진행 컬럼 없음)
+   - Sentry: `상태` | `에러` | `프로젝트` | `이벤트` | `링크` | `처리`
+3. **중요도 기준**:
+   - 🔴 높음: Sentry 에러 연관, 직전 분배 미이행, 보안 이슈
+   - 🟡 보통: 일반 버그픽스, 진행 중 작업, 배포 관련
+   - ⚪ 낮음: chore, 리팩토링, 제안 단계
+4. **진행 아이콘**: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
+5. **정렬**: ✅ → 🔧 → ⏸️ 순서
+6. **링크 필수**: 모든 이슈/PR/Sentry 이슈에 클릭 가능한 링크 포함
+7. **이슈-PR 연결**: 링크 컬럼에서 `#이슈 → PR #번호` 형태
+8. **직전 분배 표시**: 상세 컬럼에 `← 직전(N차) 분배` 부기
+9. **중복 제거**: 진행 상황에 있는 항목은 논의 안건에 포함하지 않음
+10. **토글 헤딩**: `### > @이름`은 노션에서 `is_toggleable: true` heading_3, children으로 테이블 삽입

--- a/.claude/skills/meeting-prep/reference.md
+++ b/.claude/skills/meeting-prep/reference.md
@@ -2,7 +2,9 @@
 
 Notion MCP 도구로 블록을 작성할 때 참고할 JSON 구조.
 
-## 토글 헤딩 (heading_3 with children)
+## 토글 헤딩 + 테이블 (heading_3 with table children)
+
+진행 상황·논의 안건 각 영역별 `@이름` 토글 안에 테이블을 넣는 구조.
 
 ```json
 {
@@ -12,12 +14,38 @@ Notion MCP 도구로 블록을 작성할 때 참고할 JSON 구조.
     "rich_text": [{"type": "text", "text": {"content": "@손장수 "}}],
     "children": [
       {
-        "type": "bulleted_list_item",
-        "bulleted_list_item": {
-          "rich_text": [
-            {"type": "text", "text": {"content": "✅ 작업 제목 ("}},
-            {"type": "text", "text": {"content": "#365", "link": {"url": "https://github.com/skku-amang/main/issues/365"}}},
-            {"type": "text", "text": {"content": ")"}}
+        "type": "table",
+        "table": {
+          "table_width": 6,
+          "has_column_header": true,
+          "has_row_header": false,
+          "children": [
+            {
+              "type": "table_row",
+              "table_row": {
+                "cells": [
+                  [{"type": "text", "text": {"content": "#"}}],
+                  [{"type": "text", "text": {"content": "내용"}}],
+                  [{"type": "text", "text": {"content": "진행"}}],
+                  [{"type": "text", "text": {"content": "중요도"}}],
+                  [{"type": "text", "text": {"content": "링크"}}],
+                  [{"type": "text", "text": {"content": "상세"}}]
+                ]
+              }
+            },
+            {
+              "type": "table_row",
+              "table_row": {
+                "cells": [
+                  [{"type": "text", "text": {"content": "1"}}],
+                  [{"type": "text", "text": {"content": "모바일 예약 FAB 버튼"}}],
+                  [{"type": "text", "text": {"content": "✅"}}],
+                  [{"type": "text", "text": {"content": "⚪"}}],
+                  [{"type": "text", "text": {"content": "PR #409", "link": {"url": "https://github.com/skku-amang/main/pull/409"}}}],
+                  [{"type": "text", "text": {"content": "← 5차 분배"}}]
+                ]
+              }
+            }
           ]
         }
       }
@@ -26,24 +54,45 @@ Notion MCP 도구로 블록을 작성할 때 참고할 JSON 구조.
 }
 ```
 
-## 링크가 포함된 bulleted_list_item
+### 테이블 셀 내 다중 링크
+
+하나의 셀에 이슈→PR 연결을 표현할 때:
 
 ```json
-{
-  "type": "bulleted_list_item",
-  "bulleted_list_item": {
-    "rich_text": [
-      {"type": "text", "text": {"content": "항목 제목 ("}},
-      {"type": "text", "text": {"content": "#123", "link": {"url": "https://github.com/skku-amang/main/issues/123"}}},
-      {"type": "text", "text": {"content": " → "}},
-      {"type": "text", "text": {"content": "PR #456", "link": {"url": "https://github.com/skku-amang/main/pull/456"}}},
-      {"type": "text", "text": {"content": ")"}}
-    ]
-  }
-}
+"cells": [
+  [
+    {"type": "text", "text": {"content": "#445", "link": {"url": "https://github.com/skku-amang/main/issues/445"}}},
+    {"type": "text", "text": {"content": " → "}},
+    {"type": "text", "text": {"content": "PR #449", "link": {"url": "https://github.com/skku-amang/main/pull/449"}}}
+  ]
+]
 ```
 
+## 지원 블록 타입
+
+`mcp__amang-notion__API-patch-block-children`의 JSON Schema는 `paragraph`과 `bulleted_list_item`만 명시하지만, 실제로는 아래 타입도 정상 동작한다 (2026-04-11 검증):
+
+- `heading_1`, `heading_2`, `heading_3` (생성 확인)
+- `heading_3` + `is_toggleable: true` + `children` (토글 헤딩 + 자식 블록 일괄 생성)
+- `rich_text` 내 `mention` 타입 (`{"type": "mention", "mention": {"type": "user", "user": {"id": "..."}}}`)
+- `rich_text` 내 `link` 속성 (`{"type": "text", "text": {"content": "#123", "link": {"url": "..."}}}`)
+- `divider`
+- `table` + `table_row` (테이블 생성, `has_column_header`/`has_row_header` 지원, 셀 내 링크 가능)
+- 토글 헤딩 children으로 `table` 삽입 (토글 안에 테이블 가능)
+
+**별도 테스트 없이 바로 사용할 것.** Schema 검증은 MCP 서버가 Notion API로 passthrough하므로 실패하지 않는다.
+
 ## 주의사항
+
+### 중첩 블록 생성 시 400 에러 방지
+
+Notion API는 **2단계까지** 중첩 생성을 지원한다: `heading_3(토글) > table > table_row`. 하지만 다음 경우 400 에러가 발생할 수 있다:
+
+1. **table_row의 cells 수 ≠ table_width**: `table_width: 6`이면 모든 row의 cells 배열이 정확히 6개여야 한다. 빈 셀은 `[{"type": "text", "text": {"content": ""}}]`로 채운다.
+2. **빈 cells 배열**: `cells: [[]]`는 에러. 최소 `[{"type": "text", "text": {"content": ""}}]` 필요.
+3. **children 없는 table**: `table` 블록에는 최소 1개의 `table_row` children이 필요하다.
+4. **heading_3 토글에 테이블을 넣을 때**: `heading_3.children` 안에 `table`을 직접 넣는 1회 호출 방식이 가장 안정적. 토글을 먼저 만들고 나중에 table을 append하면 2회 호출이 되어 비효율적이고 ordering 이슈가 생길 수 있다.
+5. **rich_text 배열이 비어있으면 에러**: 셀에 내용이 없어도 빈 문자열 text 객체를 넣어야 한다.
 
 ### unsupported 블록
 


### PR DESCRIPTION
## 🚀 작업 내용

meeting-prep 스킬 출력을 bullet 리스트에서 Notion table 블록으로 전환하여 가독성 향상.

- 컬럼 구성: `#` | `내용` | `진행` | `중요도` | `링크` | `상세` (진행 상황), 논의 안건은 `진행` 컬럼 제외
- Notion API 400 에러 방지 가이드 추가 (빈 셀 처리, cells 수 일치, 1회 호출 패턴)
- 지원 블록 타입 문서화 (`heading_1/2/3`, `table`, `table_row`, `mention`, `divider` 등)

## 📸 스크린샷(선택)

6차 회의록에 적용된 결과: [26-1 6차 회의](https://www.notion.so/26-1-6-33ebbc180bd68006997af75ac5f49fbb)

## 🔗 관련 이슈

N/A (스킬 개선)

## 🙏 리뷰어에게

스킬 파일만 변경되어 앱 코드에 영향 없습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)