### PR TITLE
feat(frontend): 어드민 유저 기수·프로필 이미지 편집 지원 (인라인 + 모달)

### DIFF
--- a/apps/web/app/(admin)/_components/data-table/EditableCell.tsx
+++ b/apps/web/app/(admin)/_components/data-table/EditableCell.tsx
@@ -13,9 +13,10 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
+import { useGenerations } from "@/hooks/api/useGeneration"
 import { useGetPresignedUrl } from "@/hooks/api/useUpload"
 import { useUsers } from "@/hooks/api/useUser"
-import { cn } from "@/lib/utils"
+import { cn, formatGenerationOrder } from "@/lib/utils"
 import { ACCEPTED_IMAGE_TYPES, MAX_FILE_SIZE } from "@repo/shared-types"
 
 import "./types"
@@ -160,6 +161,51 @@ function UserSelectCellEditor({
           <SelectValue />
         </SelectTrigger>
         <UserSelectContent users={users} allowNone={allowNone} />
+      </Select>
+      {isPending && (
+        <Loader2 className="absolute right-7 top-1/2 h-3 w-3 -translate-y-1/2 animate-spin text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// --- Generation select cell editor ---
+
+function GenerationSelectCellEditor({
+  value,
+  onSelect,
+  onCancel,
+  isPending
+}: {
+  value: string
+  onSelect: (value: string) => void
+  onCancel: () => void
+  isPending: boolean
+}) {
+  const { data: generations } = useGenerations()
+  const sorted = generations?.slice().sort((a, b) => b.order - a.order) ?? []
+
+  return (
+    <div className="absolute inset-0 z-10 flex items-center px-1">
+      <Select
+        defaultOpen
+        value={value}
+        onValueChange={onSelect}
+        onOpenChange={(open) => {
+          if (!open) onCancel()
+        }}
+        disabled={isPending}
+      >
+        <SelectTrigger className="h-7 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {sorted.map((g) => (
+            <SelectItem key={g.id} value={g.id.toString()}>
+              {formatGenerationOrder(g.order)}기
+            </SelectItem>
+          ))}
+        </SelectContent>
       </Select>
       {isPending && (
         <Loader2 className="absolute right-7 top-1/2 h-3 w-3 -translate-y-1/2 animate-spin text-muted-foreground" />
@@ -503,6 +549,17 @@ function EditableCellInner({
         onCancel={handleCancel}
         isPending={isPending}
         allowNone
+      />
+    )
+  }
+
+  if (editable.type === "generation") {
+    return (
+      <GenerationSelectCellEditor
+        value={String(rawValue ?? "")}
+        onSelect={handleSelectSave}
+        onCancel={handleCancel}
+        isPending={isPending}
       />
     )
   }

--- a/apps/web/app/(admin)/_components/data-table/types.ts
+++ b/apps/web/app/(admin)/_components/data-table/types.ts
@@ -16,7 +16,15 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string
     editable?: {
-      type: "text" | "number" | "date" | "select" | "boolean" | "image" | "user"
+      type:
+        | "text"
+        | "number"
+        | "date"
+        | "select"
+        | "boolean"
+        | "image"
+        | "user"
+        | "generation"
       step?: number
       displayTransform?: (v: number) => string
       saveTransform?: (v: number) => number

--- a/apps/web/app/(admin)/admin/users/_components/UserFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/UserFormDialog.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { Camera, Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -22,16 +25,31 @@ import {
   FormMessage
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { Checkbox } from "@/components/ui/checkbox"
-import { useSessions } from "@/hooks/api/useSession"
 import { getSessionDisplayName } from "@/constants/session"
+import { useGenerations } from "@/hooks/api/useGeneration"
+import { useSessions } from "@/hooks/api/useSession"
+import { useImageUpload } from "@/hooks/useImageUpload"
+import { formatGenerationOrder } from "@/lib/utils"
 import { publicUser } from "@repo/shared-types"
 
 const UserEditSchema = z.object({
   name: z.string().min(1, "이름을 입력해주세요."),
   nickname: z.string().min(1, "닉네임을 입력해주세요."),
   bio: z.string().optional(),
+  image: z
+    .string()
+    .url({ message: "유효한 이미지 주소(URL)를 입력해 주세요." })
+    .nullable()
+    .optional(),
+  generationId: z.number({ invalid_type_error: "기수를 선택해주세요." }).int(),
   sessions: z
     .array(z.number().int())
     .min(1, "최소 하나의 세션을 선택해야 합니다.")
@@ -55,6 +73,7 @@ export function UserFormDialog({
   isPending = false
 }: UserFormDialogProps) {
   const { data: sessions } = useSessions()
+  const { data: generations } = useGenerations()
 
   const form = useForm<UserEditValues>({
     resolver: zodResolver(UserEditSchema),
@@ -62,7 +81,15 @@ export function UserFormDialog({
       name: "",
       nickname: "",
       bio: "",
+      image: null,
+      generationId: undefined,
       sessions: []
+    }
+  })
+
+  const imageUpload = useImageUpload({
+    onSuccess: (publicUrl) => {
+      form.setValue("image", publicUrl, { shouldDirty: true })
     }
   })
 
@@ -72,10 +99,19 @@ export function UserFormDialog({
         name: editingUser.name,
         nickname: editingUser.nickname,
         bio: editingUser.bio ?? "",
+        image: editingUser.image ?? null,
+        generationId: editingUser.generation.id,
         sessions: editingUser.sessions.map((s) => s.id)
       })
     }
   }, [open, editingUser, form])
+
+  const sortedGenerations = generations
+    ?.slice()
+    .sort((a, b) => b.order - a.order)
+
+  const currentImage = form.watch("image")
+  const previewImage = imageUpload.preview ?? currentImage ?? undefined
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -86,6 +122,42 @@ export function UserFormDialog({
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                className="group relative"
+                onClick={() => imageUpload.inputRef.current?.click()}
+                disabled={imageUpload.isUploading}
+              >
+                <Avatar className="size-16 border-2 border-slate-100">
+                  <AvatarImage src={previewImage} />
+                  <AvatarFallback className="text-xl">
+                    {editingUser?.name?.[0] ?? "?"}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                  {imageUpload.isUploading ? (
+                    <Loader2 className="size-5 animate-spin text-white" />
+                  ) : (
+                    <Camera className="size-5 text-white" />
+                  )}
+                </div>
+              </button>
+              <input
+                ref={imageUpload.inputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={imageUpload.selectAndUpload}
+              />
+              <div className="text-sm text-slate-500">
+                {imageUpload.isUploading
+                  ? `업로드 중... ${imageUpload.progress}%`
+                  : (imageUpload.error ??
+                    "클릭하여 프로필 이미지를 변경할 수 있습니다.")}
+              </div>
+            </div>
+
             <FormField
               control={form.control}
               name="name"
@@ -123,6 +195,34 @@ export function UserFormDialog({
                   <FormControl>
                     <Textarea className="resize-none" rows={3} {...field} />
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="generationId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>기수</FormLabel>
+                  <Select
+                    value={field.value !== undefined ? String(field.value) : ""}
+                    onValueChange={(v) => field.onChange(Number(v))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="기수 선택" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {sortedGenerations?.map((g) => (
+                        <SelectItem key={g.id} value={String(g.id)}>
+                          {formatGenerationOrder(g.order)}기
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/app/(admin)/admin/users/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/users/_components/columns.tsx
@@ -99,15 +99,19 @@ export function getColumns({
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="기수" />
       ),
-      meta: { label: "기수" },
-      accessorFn: (row) => row.generation.order,
-      cell: ({ row }) => (
-        <Link
-          href={`${ROUTES.ADMIN.GENERATIONS}?rowId=${row.original.generation.id}`}
-          className="text-blue-600 hover:underline"
-        >
-          {formatGenerationOrder(row.original.generation.order)}기
-        </Link>
+      meta: { label: "기수", editable: { type: "generation" } },
+      accessorFn: (row) => row.generation.id,
+      sortingFn: (a, b) =>
+        a.original.generation.order - b.original.generation.order,
+      cell: (ctx) => (
+        <EditableCell
+          cellContext={ctx}
+          displayValue={
+            <span>
+              {formatGenerationOrder(ctx.row.original.generation.order)}기
+            </span>
+          }
+        />
       ),
       filterFn: (row, _columnId, filterValue) =>
         String(row.original.generation.order) === filterValue

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -98,12 +98,19 @@ export default function UsersAdminPage() {
     name: string
     nickname: string
     bio?: string
+    image?: string | null
+    generationId: number
     sessions: number[]
   }) => {
     if (!editing) return
 
+    const payload = {
+      ...data,
+      image: data.image ?? undefined
+    }
+
     updateMutation
-      .mutateAsync([editing.id, data])
+      .mutateAsync([editing.id, payload])
       .then(() => {
         toast({ title: "회원 정보가 수정되었습니다." })
         queryClient.invalidateQueries({ queryKey: ["users"] })

--- a/apps/web/app/(admin)/admin/users/page.tsx
+++ b/apps/web/app/(admin)/admin/users/page.tsx
@@ -54,8 +54,14 @@ export default function UsersAdminPage() {
 
   const handleCellUpdate = useCallback(
     async (rowId: number, columnId: string, value: unknown) => {
+      const payload: Record<string, unknown> = {}
+      if (columnId === "generation") {
+        payload.generationId = Number(value)
+      } else {
+        payload[columnId] = value
+      }
       try {
-        await updateMutation.mutateAsync([rowId, { [columnId]: value }])
+        await updateMutation.mutateAsync([rowId, payload])
         toast({ title: "회원 정보가 수정되었습니다." })
         queryClient.invalidateQueries({ queryKey: ["users"] })
       } catch (error) {


### PR DESCRIPTION
## 🚀 작업 내용

운영진이 유저 정보(**기수 FK**, **프로필 이미지**)를 개발자 개입 없이 어드민 UI에서 직접 수정할 수 있도록 추가. 인라인 편집과 모달 편집 양쪽에서 지원.

### 1. 인라인 편집 (기수)

- `EditableCell` 타입 union에 `"generation"` 추가
- `GenerationSelectCellEditor` 컴포넌트: `useGenerations`로 기수 목록 조회, 최신 기수 우선 정렬
- `users/_components/columns`: `accessorFn`이 `generation.id` 반환 (Select value 기준), `sortingFn`으로 `order` 기반 정렬 유지, `filterFn`은 기존 `order` 비교 유지
- `users/page`: `columnId === "generation"` → payload `generationId` 매핑 ([sessions `leader` → `leaderId`](https://github.com/skku-amang/main/blob/main/apps/web/app/(admin)/admin/sessions/page.tsx#L38-L39) 패턴과 동일)

### 2. 모달 편집 (기수 + 프로필 이미지)

- `UserEditSchema`: `image`, `generationId` 필드 추가
- 아바타 업로드 UI: 기존 `useImageUpload` 훅 재사용 (profile/edit 패턴 동일)
- 기수 Select: `useGenerations` 기반 드롭다운
- `handleSubmit`: `image: null → undefined` 정규화 후 PATCH (백엔드 `UpdateUserSchema`와 호환)

## 📸 스크린샷(선택)

<!-- 로컬 검증:
- 인라인: 관리자2 37기 → 36기 저장 성공
- 모달: 관리자1 기수 35.5기 → 27기 저장 성공, 아바타 업로드 UI 렌더 확인
- 콘솔 에러 0 -->

## 🔗 관련 이슈

Closes #455

## 🙏 리뷰어에게

- **`accessorFn` 변경**: 기존 `order` 반환 → `id` 반환. `sortingFn`을 명시해 정렬은 `order` 기준으로 유지, `filterFn`은 `row.original.generation.order`를 직접 쓰므로 영향 없음. 다른 곳에서 이 컬럼의 raw value를 참조하는 코드가 있는지 확인 부탁드립니다.
- **FK 셀렉터 패턴 복제**: `user` 타입을 그대로 차용해 `generation` 타입 추가. 3번째 FK 셀렉터 나올 때 범용 `type: "fk"`로 리팩토링하면 좋을 것 같습니다.
- **이미지 업로드 실기 검증**: 로컬에서 업로드 UI 렌더까지만 확인. 실제 파일 업로드는 프리뷰 배포에서 검증 예정 (`useImageUpload`는 profile/edit에서 이미 사용 중인 훅).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.