### PR TITLE
fix(api): /auth/refresh 요청 시 userId anonymous 오기록 버그 수정

### DIFF
--- a/apps/api/src/common/logger/pino-logger.config.ts
+++ b/apps/api/src/common/logger/pino-logger.config.ts
@@ -42,7 +42,12 @@ export const pinoLoggerModuleOption: Params = {
       return mergeObject
     },
     customProps(req: any) {
-      const token = req.headers?.authorization?.split(" ")[1]
+      let token = req.headers?.authorization?.split(" ")[1]
+
+      if (!token) {
+        token = req.body?.refreshToken
+      }
+
       const payload = token ? jwtService.decode<JwtPayload>(token) : null
 
       return payload


### PR DESCRIPTION
## 🚀 작업 내용

`/auth/refresh` 요청 시 `userId`와 `username`이 `anonymous`로 기록되는 버그를 수정합니다.

**원인:**
`/auth/refresh`는 `Authorization` 헤더 없이 request body의 `refreshToken`으로 인증합니다. 기존 코드는 `Authorization` 헤더만 확인하여 토큰이 없다고 판단, 항상 `anonymous`로 기록하고 있었습니다.

**수정 방법:**
`Authorization` 헤더에 토큰이 없을 경우 `req.body.refreshToken`을 fallback으로 디코딩합니다. access/refresh 토큰이 동일한 `JwtPayload`로 서명되므로 `userId`와 `username` 모두 정상 추출됩니다.

```ts
// before
const token = req.headers?.authorization?.split(" ")[1]

// after
let token = req.headers?.authorization?.split(" ")[1]
if (!token) {
  token = req.body?.refreshToken
}
```

## 🔗 관련 이슈

없음

## 🙏 리뷰어에게

- `req.body.refreshToken`은 `redact` 설정으로 로그 출력 시 마스킹됩니다. `customProps`에서 직렬화 전에 직접 읽으므로 redact 우회가 아닙니다.
- NestJS 기본 body parser가 활성화되어 있어 `customProps` 호출 시점에 `req.body`가 정상적으로 파싱된 상태입니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다.