### PR TITLE
chore(infra): Grafana MCP 추가 (mcp-grafana)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,5 +3,8 @@ export VERCEL_ORG_ID=team_aDiKenl6xun665nVWV49POd4
 export VERCEL_PROJECT_ID=prj_Be6ghVdveO0bbNJZrfyTFnQsXLRo
 export AWS_PROFILE=homelab
 
+# Go bin (mcp-grafana 등 `go install` 바이너리용)
+PATH_add ~/go/bin
+
 # Load local secrets (not committed to git)
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -15,3 +15,9 @@ export SENTRY_ACCESS_TOKEN=sntryu_xxx
 # Vercel: https://vercel.com/account/tokens 에서 토큰 생성
 # 빌드 로그 조회, 배포 상태 확인 등에 사용
 export VERCEL_TOKEN=vcp_xxx
+
+# Grafana MCP (https://grafana.json-server.win → Administration → Service accounts → Add service account token)
+# 설치: go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
+# TODO: 추후 MCP 전용 Service Account 분리 (현재는 개인 토큰 사용)
+export GRAFANA_URL=https://grafana.json-server.win
+export GRAFANA_SERVICE_ACCOUNT_TOKEN=glsa_xxx

--- a/.mcp.json
+++ b/.mcp.json
@@ -26,6 +26,10 @@
     "amang-figma": {
       "type": "http",
       "url": "https://mcp.figma.com/mcp"
+    },
+    "amang-grafana": {
+      "command": "direnv",
+      "args": ["exec", ".", "mcp-grafana"]
     }
   }
 }


### PR DESCRIPTION
## 🚀 작업 내용

Claude Code에서 홈랩 Grafana를 조회할 수 있도록 `amang-grafana` MCP 서버 연결. 인증 관련 장애(e.g. PR #444에서 다루는 RT refresh race condition) 디버깅 시 Loki 로그·Prometheus 메트릭을 자연어로 조회 가능해짐.

### 변경 요약

- **`.mcp.json`**: `amang-grafana` 엔트리 추가 (`direnv exec . mcp-grafana`, stdio transport)
- **`.envrc`**: `PATH_add ~/go/bin` — `go install` 바이너리 접근용
- **`.envrc.local.example`**: `GRAFANA_URL`, `GRAFANA_SERVICE_ACCOUNT_TOKEN` 템플릿 + 설치 가이드

### 설치

```bash
go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
cp .envrc.local.example .envrc.local
# GRAFANA_SERVICE_ACCOUNT_TOKEN 채우기
direnv allow
```

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- 홈랩 측 대응 PR: [manamana32321/homelab#103](https://github.com/manamana32321/homelab/pull/103)
- 공식: [grafana/mcp-grafana](https://github.com/grafana/mcp-grafana)

## 🙏 리뷰어에게

- 현재는 개인 Service Account 토큰 사용. 추후 **Terraform Grafana provider로 MCP 전용 SA 선언적 관리 + SealedSecret 전환** 예정 (별도 작업).
- `.mcp.json` 끝 개행 누락은 기존 파일 상태 유지 (별도 정리 안 함).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 PR이 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)