### PR TITLE
refactor: rename 'posterImage' column into 'image'

### DIFF
--- a/apps/api/src/team/team.service.ts
+++ b/apps/api/src/team/team.service.ts
@@ -145,7 +145,7 @@ export class TeamService {
       leaderId,
       memberSessions,
       description,
-      posterImage,
+      image,
       songYoutubeVideoUrl,
       ...scalarData
     } = updateTeamDto
@@ -245,7 +245,7 @@ export class TeamService {
         data: {
           ...scalarData,
           description: description ?? null,
-          posterImage: posterImage ?? null,
+          image: image ?? null,
           songYoutubeVideoUrl: songYoutubeVideoUrl ?? null,
           leader: { connect: { id: leaderId } }
         }

--- a/apps/web/app/(admin)/admin/performances/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/performances/_components/columns.tsx
@@ -64,16 +64,16 @@ export function getColumns(
       )
     },
     {
-      accessorKey: "posterImage",
+      accessorKey: "image",
       header: "포스터",
       meta: { label: "포스터", editable: { type: "image" } },
       cell: (ctx) => (
         <EditableCell
           cellContext={ctx}
           displayValue={
-            ctx.row.original.posterImage ? (
+            ctx.row.original.image ? (
               <img
-                src={ctx.row.original.posterImage}
+                src={ctx.row.original.image}
                 alt="포스터"
                 className="h-10 w-8 rounded object-cover"
               />

--- a/apps/web/app/(admin)/admin/performances/page.tsx
+++ b/apps/web/app/(admin)/admin/performances/page.tsx
@@ -157,7 +157,7 @@ export default function PerformancesAdminPage() {
         data={performances ?? []}
         isLoading={isLoading}
         initialSorting={[{ id: "id", desc: true }]}
-        initialColumnVisibility={{ description: false, posterImage: false }}
+        initialColumnVisibility={{ description: false, image: false }}
         searchColumn="name"
         searchPlaceholder="공연 검색..."
         onCreateClick={() => {

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -114,16 +114,16 @@ export function getColumns(
         row.original.songArtist === filterValue
     },
     {
-      accessorKey: "posterImage",
+      accessorKey: "image",
       header: "포스터",
       meta: { label: "포스터", editable: { type: "image" } },
       cell: (ctx) => (
         <EditableCell
           cellContext={ctx}
           displayValue={
-            ctx.row.original.posterImage ? (
+            ctx.row.original.image ? (
               <img
-                src={ctx.row.original.posterImage}
+                src={ctx.row.original.image}
                 alt="포스터"
                 className="h-10 w-8 rounded object-cover"
               />

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -109,7 +109,7 @@ export default function TeamsAdminPage() {
       songArtist: team.songArtist,
       isFreshmenFixed: team.isFreshmenFixed,
       isSelfMade: team.isSelfMade,
-      posterImage: team.posterImage,
+      image: team.image,
       songYoutubeVideoUrl: team.songYoutubeVideoUrl,
       memberSessions: team.teamSessions.map((ts) => ({
         sessionId: ts.sessionId,

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailClient.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/_components/TeamDetailClient.tsx
@@ -90,7 +90,7 @@ const TeamDetailClient = () => {
         {/* 기본 정보 및 포스터*/}
         <div className="flex w-[93%] flex-col gap-y-5 md:w-[466px] md:shrink-0 md:gap-y-[24px]">
           <BasicInfo team={team} canEdit={canEdit} />
-          {team.posterImage && <PosterImage src={team.posterImage} />}
+          {team.image && <PosterImage src={team.image} />}
         </div>
 
         {/* 세션 구성 */}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/[teamId]/page.tsx
@@ -17,10 +17,10 @@ function getYoutubeThumbnail(url: string): string | null {
 }
 
 function getOgImage(
-  team: { posterImage?: string | null; songYoutubeVideoUrl?: string | null },
+  team: { image?: string | null; songYoutubeVideoUrl?: string | null },
   alt: string
 ) {
-  if (team.posterImage) return { url: team.posterImage, alt }
+  if (team.image) return { url: team.image, alt }
   if (team.songYoutubeVideoUrl) {
     const thumb = getYoutubeThumbnail(team.songYoutubeVideoUrl)
     if (thumb) return { url: thumb, alt }

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/PosterImageDialog.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/PosterImageDialog.tsx
@@ -27,7 +27,7 @@ interface PosterImageDialogProps {
 function PosterImageDialog({ form }: PosterImageDialogProps) {
   const [open, setOpen] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const currentImage = form.watch("posterImage")
+  const currentImage = form.watch("image")
 
   const {
     file,
@@ -40,14 +40,14 @@ function PosterImageDialog({ form }: PosterImageDialogProps) {
     reset
   } = useImageUpload({
     onSuccess: (publicUrl) => {
-      form.setValue("posterImage", publicUrl)
+      form.setValue("image", publicUrl)
       setOpen(false)
       reset()
     }
   })
 
   function handleRemove(): void {
-    form.setValue("posterImage", "")
+    form.setValue("image", "")
     reset()
   }
 

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/index.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/index.tsx
@@ -65,7 +65,7 @@ const FirstPage = ({
 
   // 모바일 포스터 이미지 업로드
   const poster = useImageUpload({
-    onSuccess: (publicUrl) => form.setValue("posterImage", publicUrl)
+    onSuccess: (publicUrl) => form.setValue("image", publicUrl)
   })
 
   return (
@@ -320,7 +320,7 @@ const FirstPage = ({
                 type="button"
                 onClick={() => {
                   poster.reset()
-                  form.setValue("posterImage", "")
+                  form.setValue("image", "")
                 }}
               >
                 <Trash2 size={18} className="text-gray-400" />
@@ -342,7 +342,7 @@ const FirstPage = ({
               type="button"
               onClick={() => {
                 poster.reset()
-                form.setValue("posterImage", "")
+                form.setValue("image", "")
               }}
             >
               <Trash2 size={18} className="text-gray-400" />
@@ -379,17 +379,16 @@ const FirstPage = ({
         )}
 
         {/* 미리보기 */}
-        {!poster.isUploading &&
-          (poster.preview || form.getValues("posterImage")) && (
-            <div className="relative mt-2 aspect-[3/4] w-full overflow-hidden rounded-lg">
-              <Image
-                src={poster.preview || form.getValues("posterImage") || ""}
-                alt="포스터 미리보기"
-                fill
-                className="object-cover"
-              />
-            </div>
-          )}
+        {!poster.isUploading && (poster.preview || form.getValues("image")) && (
+          <div className="relative mt-2 aspect-[3/4] w-full overflow-hidden rounded-lg">
+            <Image
+              src={poster.preview || form.getValues("image") || ""}
+              alt="포스터 미리보기"
+              fill
+              className="object-cover"
+            />
+          </div>
+        )}
 
         <input
           ref={poster.inputRef}

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/schema.ts
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/FirstPage/schema.ts
@@ -11,7 +11,7 @@ const basicInfoSchema = z.object({
   performanceId: z.number({ required_error: "필수 항목" }),
   isFreshmenFixed: z.boolean().default(false).optional(),
   songYoutubeVideoUrl: songYoutubeVideoUrlSchema,
-  posterImage: z.string().optional(),
+  image: z.string().optional(),
   songName: z
     .string({ required_error: "필수 항목" })
     .min(1, { message: "1글자 이상 입력해주세요" }),

--- a/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
+++ b/apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/index.tsx
@@ -60,7 +60,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
       isSelfMade: initialData?.isSelfMade,
       description: initialData?.description || "",
       songYoutubeVideoUrl: initialData?.songYoutubeVideoUrl || "",
-      posterImage: initialData?.posterImage || ""
+      image: initialData?.image || ""
     }
   })
   function onFirstPageValid(formData: z.infer<typeof basicInfoSchema>) {
@@ -215,7 +215,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
         isSelfMade: initialData.isSelfMade,
         description: initialData.description || "",
         songYoutubeVideoUrl: initialData.songYoutubeVideoUrl || "",
-        posterImage: initialData.posterImage || ""
+        image: initialData.image || ""
       })
       secondPageForm.reset(constructDefaultValues(initialData))
     }
@@ -310,7 +310,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
         description: firstPageForm.getValues("description") || null,
         songYoutubeVideoUrl:
           firstPageForm.getValues("songYoutubeVideoUrl") || null,
-        posterImage: firstPageForm.getValues("posterImage") || null,
+        image: firstPageForm.getValues("image") || null,
         isFreshmenFixed: firstPageForm.getValues("isFreshmenFixed") ?? false,
         isSelfMade: firstPageForm.getValues("isSelfMade") ?? false
       }
@@ -338,7 +338,7 @@ const TeamForm = ({ initialData, className }: TeamCreateFormProps) => {
         description: firstPageForm.getValues("description") || null,
         songYoutubeVideoUrl:
           firstPageForm.getValues("songYoutubeVideoUrl") || null,
-        posterImage: firstPageForm.getValues("posterImage") || null,
+        image: firstPageForm.getValues("image") || null,
         isFreshmenFixed: firstPageForm.getValues("isFreshmenFixed") ?? false,
         isSelfMade: firstPageForm.getValues("isSelfMade") ?? false
       }

--- a/apps/web/app/(general)/(light)/performances/[id]/_components/PerformanceDetailClient.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/_components/PerformanceDetailClient.tsx
@@ -113,7 +113,7 @@ const PerformanceDetailClient = () => {
         <div className="w-full shrink-0 md:w-[400px]">
           <PosterImage
             alt={`${performance.name} 포스터`}
-            src={performance.posterImage}
+            src={performance.image}
           />
         </div>
 

--- a/apps/web/app/(general)/(light)/performances/[id]/page.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/page.tsx
@@ -22,8 +22,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       openGraph: {
         title: `${title} | AMANG`,
         description,
-        images: performance.posterImage
-          ? [{ url: performance.posterImage, alt: title }]
+        images: performance.image
+          ? [{ url: performance.image, alt: title }]
           : [{ url: SEO.DEFAULT_OG_IMAGE, alt: SEO.SITE_NAME }]
       }
     }

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/columns.tsx
@@ -145,7 +145,7 @@ export const columns: ColumnDef<TeamColumn>[] = [
         {/* 곡명 */}
         <div className="flex items-center gap-x-1">
           {row.original.songName}
-          {row.original.posterImage && (
+          {row.original.image && (
             <span>
               <Image size={15} className="text-neutral-800" strokeWidth={1.5} />
             </span>

--- a/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/apps/web/app/(general)/(light)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -535,7 +535,7 @@ export function TeamListDataTable<TValue>({
                   songArtist={row.original.songArtist}
                   isFreshmenFixed={row.original.isFreshmenFixed}
                   isSelfMade={row.original.isSelfMade}
-                  image={row.original.posterImage}
+                  image={row.original.image}
                   leader={row.original.leader}
                   missingTeamSessions={missingMemberSessions(
                     row.original.teamSessions

--- a/apps/web/app/(general)/(light)/performances/_components/PerformanceListClient.tsx
+++ b/apps/web/app/(general)/(light)/performances/_components/PerformanceListClient.tsx
@@ -50,7 +50,7 @@ const PerformanceListClient = () => {
               key={p.id}
               id={p.id}
               name={p.name}
-              posterSrc={p.posterImage}
+              posterSrc={p.image}
               location={p.location}
               startAt={p.startAt}
             />

--- a/apps/web/hooks/api/mapper.ts
+++ b/apps/web/hooks/api/mapper.ts
@@ -311,7 +311,7 @@ type TestPerformance = MapperResult<
 //   name: string,            // 원본 유지
 //   description: string,     // 원본 유지
 //   location: string,        // 원본 유지
-//   posterImage: string,     // 원본 유지
+//   image: string,           // 원본 유지
 //   startAt: Date | null,    // string → Date로 변환됨
 //   endAt: Date | null,      // string → Date로 변환됨
 //   createdAt: Date,         // string → Date로 변환됨

--- a/packages/database/prisma/migrations/20260412173843_rename_poster_image_to_image/migration.sql
+++ b/packages/database/prisma/migrations/20260412173843_rename_poster_image_to_image/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "performances" RENAME COLUMN "posterImage" TO "image";
+ALTER TABLE "teams" RENAME COLUMN "posterImage" TO "image";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -98,7 +98,7 @@ model Performance {
 
   name        String // 공연 이름
   description String? // 공연 설명
-  posterImage String? // 대표 이미지 URL
+  image       String? // 대표 이미지 URL
   location    String? // 공연 장소
   startAt     DateTime? // 공연 시작 일시
   endAt       DateTime? // 공연 종료 일시
@@ -116,7 +116,7 @@ model Team {
 
   name                String // 팀 이름
   description         String? // 팀 설명
-  posterImage         String? // 포스터 이미지 URL
+  image               String? // 포스터 이미지 URL
   songName            String // 곡 제목
   songArtist          String // 곡 아티스트
   isFreshmenFixed     Boolean @default(false) // 신입생 고정 여부

--- a/packages/database/prisma/seeds/04-performance.seed.ts
+++ b/packages/database/prisma/seeds/04-performance.seed.ts
@@ -16,7 +16,7 @@ export const seedPerformance = async (prisma: PrismaClient) => {
     {
       name: `${year - 1} 새내기 배움터 공연`,
       description: `${year - 1} 새내기 배움터 공연입니다.`,
-      posterImage: "https://picsum.photos/200/300",
+      image: "https://picsum.photos/200/300",
       location: "MT 대강당",
       startAt: getDate(-365),
       endAt: getDate(-305, 21)
@@ -24,7 +24,7 @@ export const seedPerformance = async (prisma: PrismaClient) => {
     {
       name: `${year - 1} 가을 정기 공연`,
       description: `${year - 1} 가을 정기 공연입니다.`,
-      posterImage: "https://picsum.photos/200/300",
+      image: "https://picsum.photos/200/300",
       location: "홍대 롤러코스터 라이브홀",
       startAt: getDate(-120),
       endAt: getDate(-60, 21)
@@ -32,7 +32,7 @@ export const seedPerformance = async (prisma: PrismaClient) => {
     {
       name: `${year} 새내기 배움터 공연`,
       description: `${year} 새내기 배움터 공연입니다.`,
-      posterImage: "https://picsum.photos/200/300",
+      image: "https://picsum.photos/200/300",
       location: "MT 대강당",
       startAt: getDate(-30),
       endAt: getDate(30, 21)
@@ -40,7 +40,7 @@ export const seedPerformance = async (prisma: PrismaClient) => {
     {
       name: `${year} 1학기 정기 공연`,
       description: `${year} 1학기 정기 공연입니다.`,
-      posterImage: "https://picsum.photos/200/300",
+      image: "https://picsum.photos/200/300",
       location: "홍대 롤러코스터 라이브홀",
       startAt: getDate(60),
       endAt: getDate(120, 21)
@@ -48,7 +48,7 @@ export const seedPerformance = async (prisma: PrismaClient) => {
     {
       name: `${year} 2학기 정기 공연`,
       description: `${year} 2학기 정기 공연입니다.`,
-      posterImage: "https://picsum.photos/200/300",
+      image: "https://picsum.photos/200/300",
       location: "홍대 롤러코스터 라이브홀",
       startAt: getDate(180),
       endAt: getDate(240, 21)

--- a/packages/database/prisma/seeds/05-team.seed.ts
+++ b/packages/database/prisma/seeds/05-team.seed.ts
@@ -54,7 +54,7 @@ export const seedTeam = async (prisma: PrismaClient) => {
           data: {
             name: `${performance.name} ${teamNumber}팀`,
             description: `${performance.name} ${teamNumber}팀입니다.`,
-            posterImage: "https://picsum.photos/200/300",
+            image: "https://picsum.photos/200/300",
             songName: isSelfMade
               ? `자작곡 ${teamNumber}`
               : `커버곡 ${teamNumber}`,

--- a/packages/shared-types/src/performance/performance.schema.ts
+++ b/packages/shared-types/src/performance/performance.schema.ts
@@ -3,7 +3,7 @@ import z from "zod"
 export const PerformanceObjectSchema = z.object({
   name: z.string().min(1, "공연 이름은 필수입니다."),
   description: z.string().nullable().optional(),
-  posterImage: z.string().nullable().optional(),
+  image: z.string().nullable().optional(),
   location: z.string().nullable().optional(),
   startAt: z.coerce.date().nullable().optional(),
   endAt: z.coerce.date().nullable().optional()

--- a/packages/shared-types/src/team/create-team.schema.ts
+++ b/packages/shared-types/src/team/create-team.schema.ts
@@ -17,7 +17,7 @@ export const CreateTeamSchema = z.object({
   description: z.string().nullable().optional(),
   leaderId: z.number().int().positive("팀 리더 ID는 정수여야 합니다."),
   performanceId: z.number().int("공연 ID는 정수여야 합니다.").positive(),
-  posterImage: z
+  image: z
     .string()
     .url("포스터 이미지 URL은 유효한 URL이어야 합니다.")
     .nullable()


### PR DESCRIPTION
## Summary

- `Performance`, `Team` 모델의 `posterImage` 필드를 `image`로 통일
- DB 스키마(컬럼명 RENAME), shared-types, API, Web 전 레이어 일괄 적용

## Changes

| 레이어 | 변경 내용 |
|---|---|
| DB | `ALTER TABLE ... RENAME COLUMN "posterImage" TO "image"` (데이터 보존) |
| Prisma Schema | `Performance`, `Team` 모델 필드명 변경 |
| Seed | 시드 데이터 필드명 변경 |
| shared-types | `PerformanceObjectSchema`, `CreateTeamSchema` 키 변경 |
| API | `TeamService` 참조 변경 |
| Web | TeamForm, Team 상세·목록, Performance 상세·목록, Admin 페이지 전체 변경 |

## Test plan

- [ ] 팀 생성/수정 폼에서 이미지 업로드 정상 동작 확인
- [ ] 팀 상세 페이지에서 포스터 이미지 렌더링 확인
- [ ] 공연 상세·목록 페이지에서 이미지 렌더링 확인
- [ ] Admin 팀·공연 테이블에서 이미지 컬럼 정상 동작 확인
- [ ] `pnpm check-types` 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)