### PR TITLE
feat(infra): Grafana Postgres datasource용 read-only DB 역할 추가

### DIFF
--- a/infra/k8s/db/overlays/production/grafana-ro-init-job.yaml
+++ b/infra/k8s/db/overlays/production/grafana-ro-init-job.yaml
@@ -1,0 +1,71 @@
+---
+# grafana_ro 역할 생성/업데이트 + SELECT 권한 부여
+# ArgoCD Sync 훅으로 실행, 멱등성 보장 (pg_roles 존재 여부 분기 + IF NOT EXISTS GRANT).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgres-grafana-ro-init
+  namespace: amang-db-production
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: api-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init-grafana-ro
+          image: postgres:16.10-alpine
+          env:
+            - name: PGHOST
+              value: postgres-svc.amang-db-production.svc.cluster.local
+            - name: PGPORT
+              value: "5432"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: amang-db-credentials
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: amang-db-credentials
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: amang-db-credentials
+                  key: POSTGRES_DB
+            - name: GRAFANA_RO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-ro-credentials
+                  key: GRAFANA_RO_PASSWORD
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              export PGPASSWORD="$POSTGRES_PASSWORD"
+              psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<'SQL'
+              DO $$
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro') THEN
+                  CREATE ROLE grafana_ro LOGIN;
+                END IF;
+              END
+              $$;
+              SQL
+              psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 \
+                -v pw="$GRAFANA_RO_PASSWORD" \
+                -c "ALTER ROLE grafana_ro WITH PASSWORD :'pw';"
+              psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<SQL
+              GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO grafana_ro;
+              GRANT USAGE ON SCHEMA public TO grafana_ro;
+              GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_ro;
+              ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_ro;
+              SQL

--- a/infra/k8s/db/overlays/production/kustomization.yaml
+++ b/infra/k8s/db/overlays/production/kustomization.yaml
@@ -7,4 +7,6 @@ namespace: amang-db-production
 resources:
   - ../../base
   - sealed-credentials.yaml
+  - sealed-grafana-ro.yaml
+  - grafana-ro-init-job.yaml
   - network-policy.yaml

--- a/infra/k8s/db/overlays/production/network-policy.yaml
+++ b/infra/k8s/db/overlays/production/network-policy.yaml
@@ -31,6 +31,13 @@ spec:
           podSelector:
             matchLabels:
               app: cloudbeaver
+        # Grafana (read-only SELECT via grafana_ro 유저, Postgres datasource)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
       ports:
         - protocol: TCP
           port: 5432

--- a/infra/k8s/db/overlays/production/sealed-grafana-ro.yaml
+++ b/infra/k8s/db/overlays/production/sealed-grafana-ro.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: grafana-ro-credentials
+  namespace: amang-db-production
+spec:
+  encryptedData:
+    DATABASE_URL: AgBiDX7NRXi4dGtcXxbM5yw/eDqNwUQ53ZS+VPBT99Sc+okVFcSN4Ng7zZ+SYWBRSgZuLoWlKwR9uWVU09s1YAo/Wzt94x7j8fAhN8GThmlnUTsEBt6iVKsQBptm3DFfX6OLUkFJSiVklrxvBo0WiZNHmBsosduZO26I61+aYRiZQfZIIh/+TCYoG+s41wtnP0mRoByiqcvgTF8kylJlXiUDZHBkDRnAWUlMzQEx7xVeEvdRbAiksHX3lxYJbN2MrwDDSW13JOia/Pzkfs/9o0uOpD1jVr+mv3HNbEpMI8DFimsjsLP4AG7QBKhqUk5u8T/eD8a/d0QHKivnL0i9Nj6v5/h6sYBvKLCWWp4vHYinG32zi6bj603j608YUtF9RWP1gFYYbPkmaIHfQ0CX7F629E5gk64mPRa1/ylWGgeUCVDXbOoR5l8p0gCqwCBQr+QqCEot06CMAZd3RMnaTx1aLme9uweHTMdlR+HJVfkpKNrUL4FHN0O8ZIuNIMYwQ8GWh8iFkJXaG/eZyIE3V+AspBGoDEWI2QPQVuqsbshOYrZdrEBjSmlBVICrm/PMbugDgLah2lUUnOOyFzQfGNb0PTutzAAvbXvr4ouTRVXPVqSRF8OvcjM6Rc4Cd3k0K2dQSFt2osrx4OhroGxh+FFHlCnBJJWW554o8pzxLo8V184WSR+sPuWgbPKIUyRSN8L3U+7ifZ0EUdnxFyihyFaCmiWE9nyunFVCM6gS4Ye69iKBOSTHeMl4bKjLIGsAzXurgX7uWOgM8dxtTraiQZ4uEfm/foy6UmA6R+uw4BhTcGFBIFOipRItEpXdYXzfNrW6BXwog4Ru4rlhVdc/wockKH79vUNuk+CKXW5Upqt+3RjVtbWFyA==
+    GRAFANA_RO_PASSWORD: AgC+kHH5tO/4FUna4+Lp34Gb5NhW1LGL/xjIVUN1wK3J+XiJHiSImV/FSbSZgNGhheydbdKyc2eTBaPp5f7W+uuWWNyfgdgMjxateGXECwAiV3Lr1Atq6q7WSn8i207MTHLLzZ16rQwu1Swqh+IF0HtB9F72/Ckdhzbc5f5H5LAYkEu3Fyxhs4dLjoBcnWi5JriAt0PW3FuPyTWA/0U2AOWQv+Jb/1jiRDp52hcBrO4jdRssg9rPA4hznysVObF6YmmebEVk/RHkmF7ubffZyyaRTyHRZjkuGUDVb+nTGeNxVxmsStX03UvUpFBV9QQCEgkbcvj+47Xjd15iyKCyi7A0SnnAvjg9o63Ukmgl4JujAz3KExYQAm6/qJeUcJGlx9HgeMhptRH0e0TTdu2ZWpPbNphzt0QVBwspy0I156qvJFY3JtR6wRQamqvIAurniULf7nNykNDSt3tIUAtDoz6YmIW1eL2KYWO7AbIj85XBSsdI2eIvx0+jGnDfI6QBmdJqOdcmJiql4OBnVBlVx5k6Ka5JmqpsB2oiUobKz7n9VPgTIc5mbWccqDCHtD145VbRhZoehVCWi6sQgsRIjDaQZvrOYSgK/5Jj3Ps3HolKuqkV8WgqzbxLnf6GAffClqW/wu+yeHBeyez5wS6zah2ebck3nI99hSxetITynpQ6bM0kLD3qjwfs/zIdzCuiXJom80JyMuRn0UcBWqpngOv0ulU7MvUJRqpdFqHreRWnYg==
+  template:
+    metadata:
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: observability
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: observability
+      name: grafana-ro-credentials
+      namespace: amang-db-production
+    type: Opaque


### PR DESCRIPTION
## 🚀 작업 내용

Grafana가 AMANG 프로덕션 DB를 read-only SELECT로 조회할 수 있도록 인프라 준비. 관측성 스택의 Grafana MCP로 **AMANG DB를 자연어 질의** 가능하게 만드는 사전 작업. 원래 계획(별도 Postgres MCP 서버)에서 스코프 축소됨 — 배경은 이슈 #454 참고.

### 변경 대상

1. **[`sealed-grafana-ro.yaml`](../blob/feat/grafana-ro-postgres/infra/k8s/db/overlays/production/sealed-grafana-ro.yaml)** (신규)
   - `grafana_ro` 유저의 비밀번호 + `DATABASE_URL` SealedSecret
   - reflector annotation으로 `observability` 네임스페이스에 자동 반영 (Grafana 파드 env 주입용)
2. **[`grafana-ro-init-job.yaml`](../blob/feat/grafana-ro-postgres/infra/k8s/db/overlays/production/grafana-ro-init-job.yaml)** (신규)
   - ArgoCD `Sync` 훅 Job. `BeforeHookCreation` 정책
   - 멱등성: `pg_roles`에 `grafana_ro` 없으면 `CREATE ROLE`, 있으면 `ALTER ROLE ... WITH PASSWORD ...` 만
   - 권한: `GRANT SELECT ON ALL TABLES` + `ALTER DEFAULT PRIVILEGES ... GRANT SELECT` (향후 테이블 자동 부여)
   - superuser 자격증명은 기존 `amang-db-credentials`에서 가져옴
   - 라벨 `app: api-job` — 기존 NetworkPolicy 이미 허용
3. **[`network-policy.yaml`](../blob/feat/grafana-ro-postgres/infra/k8s/db/overlays/production/network-policy.yaml)**
   - `observability` ns + `app.kubernetes.io/name=grafana` 소스 허용 추가
4. **[`kustomization.yaml`](../blob/feat/grafana-ro-postgres/infra/k8s/db/overlays/production/kustomization.yaml)**
   - 위 두 신규 리소스 등록

## 📸 스크린샷(선택)

N/A — 인프라 변경이라 시각적 결과 없음. `kubectl kustomize` 빌드 검증 완료.

## 🔗 관련 이슈

Closes #454

## 🙏 리뷰어에게

- **시크릿 정책 검증 요청**: 평문 비밀번호 커밋 없음. `sealed-grafana-ro.yaml`은 kubeseal 봉인본만 포함. [homelab#104](https://github.com/manamana32321/homelab/issues/104) 교훈 반영
- **reflector 패턴 확인**: 기존 `sealed-credentials.yaml`과 동일 방식으로 observability ns에 자동 반영 — Grafana 파드에서 `envFrom: secretRef: grafana-ro-credentials` 로 주입 예정 (홈랩 측 PR에서)
- **init Job 멱등성**: 여러 번 sync해도 안전. 비밀번호 교체 시엔 SealedSecret만 재봉인 → Job이 ALTER ROLE로 반영
- **다음 작업** (별도 PR, 홈랩 레포):
  - `k8s/observability/grafana/values.yaml`에 `amang-prod` Postgres datasource 추가
  - Grafana 파드 envFromSecret로 `grafana-ro-credentials` 참조
  - [homelab#104](https://github.com/manamana32321/homelab/issues/104)의 시크릿 주입 패턴 확립 후 진행

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.