### PR TITLE
fix(infra): grafana_ro 초기화 Job이 NetworkPolicy에 차단되는 문제 수정

### DIFF
--- a/infra/k8s/db/overlays/production/network-policy.yaml
+++ b/infra/k8s/db/overlays/production/network-policy.yaml
@@ -24,6 +24,10 @@ spec:
           podSelector:
             matchLabels:
               app: api-job
+        # DB 관리 Job (같은 ns 내, 예: grafana_ro 초기화)
+        - podSelector:
+            matchLabels:
+              app: api-job
         # CloudBeaver (DB 관리 UI)
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## 🚀 작업 내용

[#461](https://github.com/skku-amang/main/pull/461)로 추가한 grafana_ro 초기화 Job이 `amang-db-production` ns에서 실행되지만, 기존 `postgres-allow-api-only` NetworkPolicy는 외부 소스만 허용(`amang-api-production`의 `app=api-job` 등) — 같은 ns 내부 접근은 허용되지 않아 **connection refused**.

### 변경

`network-policy.yaml`에 같은 ns 내부 `app=api-job` 라벨 허용 규칙 추가. DB 관리 목적 Job은 `amang-db-production`에 두는 게 의미적으로 자연스러움.

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- 후속: [#454](https://github.com/skku-amang/main/issues/454)
- 수정 대상: [#461](https://github.com/skku-amang/main/pull/461)

## 🙏 리뷰어에게

- 같은 ns 내부 `app=api-job` 허용은 기존 의도를 해치지 않음 — 이미 `amang-api-production`의 `app=api-job`을 허용 중이라 동일 라벨 정책 확장
- 머지 후 ArgoCD sync → Init Job 재실행 → grafana_ro 역할 생성 확인 필요

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.