### PR TITLE
fix(infra): grafana_ro Init Job의 psql 변수 치환 버그 수정

### DIFF
--- a/infra/k8s/db/overlays/production/grafana-ro-init-job.yaml
+++ b/infra/k8s/db/overlays/production/grafana-ro-init-job.yaml
@@ -60,9 +60,9 @@ spec:
               END
               $$;
               SQL
-              psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 \
-                -v pw="$GRAFANA_RO_PASSWORD" \
-                -c "ALTER ROLE grafana_ro WITH PASSWORD :'pw';"
+              psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<SQL
+              ALTER ROLE grafana_ro WITH PASSWORD '$GRAFANA_RO_PASSWORD';
+              SQL
               psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<SQL
               GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO grafana_ro;
               GRANT USAGE ON SCHEMA public TO grafana_ro;


### PR DESCRIPTION
## 🚀 작업 내용

[#461](https://github.com/skku-amang/main/pull/461)의 Init Job이 psql의 `-v` 변수 치환(`:'pw'`)을 `-c` 옵션과 결합해 사용하는데, 이 조합에서 psql이 변수 보간을 수행하지 않아 `syntax error at or near ":"` 발생.

### 변경

`-c "ALTER ROLE ... :'pw';"` → 언쿼트 heredoc + `$GRAFANA_RO_PASSWORD` 직접 주입.

비밀번호는 `openssl rand -base64` 후 `/+=` 제거한 32자 문자열로 생성되어 SQL 리터럴에 안전하게 들어감 (단일 인용부호·백슬래시 부재).

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- 수정 대상: [#461](https://github.com/skku-amang/main/pull/461), [#463](https://github.com/skku-amang/main/pull/463)
- 관련 이슈: [#454](https://github.com/skku-amang/main/issues/454)

## 🙏 리뷰어에게

- 대안으로 `\set` 메타커맨드 + `\connect` 조합도 가능하지만 heredoc이 더 간단
- 비밀번호 생성 로직이 바뀌어 특수문자가 포함될 가능성이 생기면 `sed "s/'/''/g"`로 SQL 이스케이프 필요

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.