### PR TITLE
fix(web): 동방 예약 모달 참여자 칩 오버플로우 수정

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -140,7 +140,7 @@ export default function RentalDetailModal({
               {rental.users.map((user) => (
                 <div
                   key={user.id}
-                  className="flex flex-1 min-w-[120px] basis-[140px] items-center gap-1 rounded-lg border px-2 py-1.5"
+                  className="flex w-[140px] items-center gap-1 rounded-lg border px-2 py-1.5"
                   style={{
                     borderColor: "rgba(197, 197, 197, 0.5)",
                     borderWidth: "0.5px"

--- a/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx
@@ -136,15 +136,14 @@ export default function RentalDetailModal({
             <p className="text-sm font-medium" style={{ color: "#71717A" }}>
               Participants
             </p>
-            <div className="flex justify-between gap-1.5">
+            <div className="flex flex-wrap gap-1.5">
               {rental.users.map((user) => (
                 <div
                   key={user.id}
-                  className="flex items-center gap-1 rounded-lg border px-2 py-1.5"
+                  className="flex flex-1 min-w-[120px] basis-[140px] items-center gap-1 rounded-lg border px-2 py-1.5"
                   style={{
                     borderColor: "rgba(197, 197, 197, 0.5)",
-                    borderWidth: "0.5px",
-                    width: 140
+                    borderWidth: "0.5px"
                   }}
                 >
                   <Avatar className="h-6 w-6 shrink-0">


### PR DESCRIPTION
## 🚀 작업 내용

[RentalDetailModal.tsx](apps/web/app/(general)/(light)/reservations/_components/RentalDetailModal.tsx)의 Participants 섹션이 `justify-between` + 인라인 `width: 140px`로 고정되어 있어, 참여자 4명 이상일 때 모달(max-w 486px)을 벗어나 오른쪽으로 overflow 발생.

- `flex justify-between` → `flex flex-wrap`
- 인라인 `width: 140` 제거 → `flex-1 min-w-[120px] basis-[140px]` (공간 있으면 140px 지향, 좁아지면 120px까지 축소 후 wrap)
- 칩 내부 `truncate`는 그대로 유지되어 긴 이름은 ellipsis 처리

## 📸 스크린샷(선택)

> 로컬 dev 서버에서 시각 검증은 리뷰어(작성자)가 직접 수행 예정.

## 🔗 관련 이슈

Closes #440

## 🙏 리뷰어에게

- 유동 칩(flex-wrap) vs 그리드(grid-cols-3) 방식 중 전자 선택함 — 밴드 세션 참여자 수가 2~5명으로 가변적이라 고정 열보다 공간 적응이 낫다고 판단.
- `basis-[140px]`가 디자인 의도(140px 칩)를 유지하면서 `flex-1`로 과도한 빈 공간 없이 균등 분배.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)