### PR TITLE
chore: meeting-prep 스킬 보고서 모드로 전환

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: meeting-prep
-description: 직전 회의 이후 GitHub 이슈/PR, Sentry 에러를 수집하고 회의록 초안을 생성한다. 회의록 작성, 회의 준비, meeting prep 요청 시 사용.
+description: 직전 회의 이후 GitHub 이슈/PR, Sentry 에러를 수집하고 본인 회의 준비용 보고서를 텍스트로 출력한다. 회의록 작성, 회의 준비, meeting prep 요청 시 사용. 노션에는 작성하지 않음.
 disable-model-invocation: true
 argument-hint: "[이전 회의 노션 URL (생략 시 자동 탐색)]"
 ---
 
-# meeting-prep — 회의록 초안 생성 스킬
+# meeting-prep — 회의 준비 보고서 생성 스킬
 
-직전 회의 이후부터 현재까지의 활동을 수집하여 회의록 초안을 생성한다.
+직전 회의 이후 본인의 활동(GitHub 이슈/PR, Sentry)을 수집하여 **Claude 텍스트 출력으로** 본인 회의 준비 보고서를 생성한다.
 
-- Notion 블록 구조 레퍼런스: [reference.md](reference.md)
-- 출력 형식 및 few-shot 예시: [examples/output.md](examples/output.md)
+## 역할 분담 (중요)
+
+이 스킬은 **노션에 절대 쓰지 않는다.** 회의록은 팀 공유용이라 사람이 합의된 결정사항만 손으로 작성해야 한다. 자동 수집 데이터는 회의 시작 전 본인이 "내가 한 일을 누락 없이 보고할 수 있도록" 정리하는 개인 준비용 메모일 뿐이다.
+
+- ✅ Claude 텍스트 출력 (사용자가 회의 시작 전에 읽음)
+- ❌ 노션 페이지 작성 (절대 금지 — 팀원들에게 다른 영역의 세부 컨텍스트는 노이즈)
 
 ## 프로젝트 상수
 
-- **Notion 회의록 DB**: `29a779af-a9b3-44a1-954a-bc780abc9cfc` (이름: "일정")
+- **Notion 회의록 DB**: `29a779af-a9b3-44a1-954a-bc780abc9cfc` / data_source_id `34d38c39-7d5d-4862-b061-46f226a3da31` (이름: "일정")
 - **GitHub 레포**: `skku-amang/main`
 - **Sentry org**: `amang-23` (프로젝트: web, api)
-- **작업 영역 분류**: 기획, 디자인, 프론트, 백엔드, 인프라
+- **작업 영역 분류**: 기획, 디자인, 프론트, 백엔드, 인프라, AX(AI Experience) — `scope:` 라벨이 SSOT
 
 ## 실행 단계
 
@@ -30,112 +34,75 @@ argument-hint: "[이전 회의 노션 URL (생략 시 자동 탐색)]"
 
 `$ARGUMENTS`에 노션 URL이 있으면 해당 페이지 사용. 없으면:
 
-1. `mcp__amang-notion__API-query-data-source`로 회의록 DB(`29a779af-a9b3-44a1-954a-bc780abc9cfc`)를 `일시` 내림차순으로 쿼리
+1. `mcp__amang-notion__API-query-data-source`로 회의록 데이터소스(`34d38c39-7d5d-4862-b061-46f226a3da31`)를 `일시` 내림차순으로 쿼리
 2. 가장 최근 2개 페이지 가져오기 (직전 회의 = 두 번째, 현재 회의 = 첫 번째)
-3. `mcp__amang-notion__API-retrieve-a-page`로 직전 회의의 `일시` 속성에서 날짜 추출 → 수집 시작일
-4. 직전 회의의 제목에서 차수(N차) 추출 → 이행 상황 표시에 사용
+3. 직전 회의의 `일시` → 수집 시작일, 제목에서 차수(N차) 추출
 
-### 3단계: 직전 회의 작업 분배 파싱
+### 3단계: 직전 회의에서 본인 분배 작업 추출 (선택)
 
-`mcp__amang-notion__API-get-block-children`으로 직전 회의 페이지의 블록을 가져온다.
-`# 작업 분배` 섹션을 찾아 하위 블록을 파싱:
-- 호출자에게 분배된 작업 영역별(프론트, 백엔드, 인프라 등) 항목 추출
-- `has_children: true`인 블록은 재귀적으로 children 조회
-- 각 항목을 이후 수집 결과와 교차 매핑하여 이행 여부(✅ 완료 / 🔧 진행 중 / ⏸️ 미착수) 판정
+직전 회의록 본문에 영역별 분배 사항이 있으면 파싱한다. 26-1 7차(2026-04-27) 이후 새 템플릿은 "팀 역할 조정" 섹션에 영역만 적고 세부 작업은 GitHub Issues로 관리하는 방식으로 전환. 따라서:
+
+- 새 템플릿: 분배 파싱 생략하고 본인 영역(인프라/프론트/AX)만 확인
+- 옛 템플릿(6차 이전): `# 작업 분배` 섹션 파싱하여 미이행 항목 표시
 
 ### 4단계: 데이터 수집 (병렬)
 
-**반드시 서브에이전트 3개를 병렬로 실행한다.** 서브에이전트에는 아래 정보를 전달:
-- 수집 기간 (시작일 ~ 오늘)
-- GitHub 사용자명
-- 프로젝트 컨벤션: 이슈 라벨로 영역 분류 (`scope: frontend` → 프론트, `scope: backend` → 백엔드, `scope: infra` → 인프라)
+서브에이전트 3개를 병렬로 실행한다.
 
 #### 에이전트 A: GitHub Issues
-
 ```
 gh issue list --repo skku-amang/main --state all \
   --search "author:{사용자명} created:{시작일}..{오늘}" \
   --json number,title,state,labels,createdAt,closedAt --limit 100
 ```
-
-수집 필드: 번호, 제목, 상태(OPEN/CLOSED), 라벨(영역+유형), 생성일, 종료일
++ assignee 검색도 추가 (다른 사람이 만든 이슈에 본인 할당된 케이스):
+```
+gh issue list --repo skku-amang/main --state all \
+  --search "assignee:{사용자명} updated:{시작일}..{오늘}" \
+  --json number,title,state,labels,createdAt,closedAt --limit 100
+```
 
 #### 에이전트 B: GitHub PRs
-
 ```
 gh pr list --repo skku-amang/main --state all \
   --search "author:{사용자명} created:{시작일}..{오늘}" \
-  --json number,title,state,labels,createdAt,mergedAt --limit 100
+  --json number,title,state,labels,createdAt,mergedAt,url,body --limit 100
 ```
-
-수집 필드: 번호, 제목, 상태(OPEN/MERGED/CLOSED), 라벨, 생성일, 머지일
-
-이슈-PR 매핑: PR 본문이나 제목에서 `#이슈번호` 참조를 추출하여 연결
+PR body에서 `#숫자` 패턴으로 연결 이슈 추출.
 
 #### 에이전트 C: Sentry 에러
+`mcp__amang-sentry__list_issues`로 web, api 프로젝트 조회 (클라우드 커넥터 `mcp__claude_ai_Sentry__*` 사용 금지).
+- `firstSeen:>{시작일}` (신규)
+- `lastSeen:>{시작일}` is:unresolved (재발)
+- 같은 기간 resolved 이슈도 포함 (PR 매핑용)
+- 이벤트 1-2건 노이즈는 생략 가능
 
-`mcp__amang-sentry__search_issues`로 web, api 프로젝트의 이슈 검색.
+### 5단계: 영역별 분류
 
-수집 필드: 이슈 ID, 에러 제목, 프로젝트(web/api), 이벤트 수, 상태(resolved/unresolved), 담당자
-해결된 이슈는 관련 PR 번호 매핑 시도 (커밋 메시지, PR 제목에서 Sentry 이슈 ID 검색)
+`scope:` 라벨 그대로 사용 (frontend/backend/infra/ax/design/planning).
 
-### 5단계: 분류 및 중복 제거
+라벨 누락된 항목은 "추정" 표시 후 본인 영역 추정. 회의 준비 보고서에 **"라벨 누락 PR 목록"**을 별도 표시 — 라벨 보강이 필요한 항목.
 
-수집된 데이터를 회의록 구조에 맞게 분류:
+### 6단계: 텍스트 보고서 출력
 
-#### 영역 판정
-
-GitHub 이슈/PR의 `scope:` 라벨로 영역을 판정한다. 라벨이 SSOT이므로 별도 매핑 테이블 없이 라벨 값을 그대로 사용.
-
-#### 진행 상황 vs 논의 안건 분류
-- **진행 상황**: CLOSED 이슈, MERGED PR, 진행 중(OPEN PR이 있는 이슈), 미착수(직전 회의 분배 항목 중 이슈/PR 없음)
-- **논의 안건**: 진행 상황에 포함되지 않은 OPEN 이슈 (새 제안, 의사결정 필요 항목)
-- 동일 항목이 양쪽에 중복되면 **진행 상황에만** 남김
-
-### 6단계: 출력 생성
-
-[examples/output.md](examples/output.md)의 형식과 규칙을 **정확히** 따른다.
+[examples/output.md](examples/output.md) 형식대로 마크다운 텍스트로 출력한다.
 
 핵심 규칙:
-- **테이블 형식 사용**: `heading_3` 토글 안에 `table` 블록으로 항목 표시
-- **진행 상황 컬럼**: `#` | `내용` | `진행` | `중요도` | `링크` | `상세` (table_width=6)
-- **논의 안건 컬럼**: `#` | `내용` | `중요도` | `링크` | `상세` (table_width=5, 진행 컬럼 없음)
-- **Sentry 컬럼**: `상태` | `에러` | `프로젝트` | `이벤트` | `링크` | `처리` (table_width=6, 토글 없이 직접 table)
-- **중요도 기준**: 🔴 높음(Sentry·보안·미이행) / 🟡 보통(버그·진행 중·배포) / ⚪ 낮음(chore·리팩토링·제안)
-- **진행 아이콘**: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
-- **정렬**: ✅ → 🔧 → ⏸️ 순서
-- **링크 컬럼**: 이슈/PR 번호에 클릭 가능한 link 속성 필수, `#이슈 → PR #번호` 형태
-- **상세 컬럼**: 직전 분배 부기(`← N차 분배`), 상태 비고(OPEN 등), 한줄 설명
-- **빈 셀 처리**: 빈 셀도 `[{"type": "text", "text": {"content": ""}}]`로 채울 것 (400 에러 방지)
-- **1회 호출로 토글+테이블 생성**: `heading_3.children`에 `table`을 직접 포함하여 한 번에 생성
+- **마크다운 표 형식**: 사용자가 한눈에 스캔 가능하도록
+- **본인 영역만**: 다른 사람 영역은 표시 안 함 (수집 자체를 본인 author로 한정했으므로 자연스럽게 필터됨)
+- **링크 필수**: 이슈/PR/Sentry 링크는 클릭 가능한 마크다운 링크
+- **중요도**: 🔴 높음(Sentry·미이행·보안) / 🟡 보통(버그·진행 중) / ⚪ 낮음(chore·제안)
+- **진행 아이콘**: ✅ 완료 / 🔧 진행 중 / ⏸️ 미착수 / ⚠️ 미해결
+- **정렬**: ✅ → 🔧 → ⏸️ → ⚠️
+- **이슈-PR 연결**: `#이슈 → PR #번호` 형태
+- **Insight 섹션**: 패턴(예: 미이행 작업, 라벨 누락, 영역 편중)을 뽑아 회의에서 짚을 만한 포인트 1-3개 제시
 
-### 7단계: 사용자 확인
+### 7단계: 마무리
 
-출력 결과를 사용자에게 보여주고 확인을 받는다.
-- 분류가 잘못된 항목이 있는지
-- 추가할 논의 안건이나 특이사항이 있는지
-- 참고 문서 링크를 추가할 섹션이 있는지
-
-**노션에 작성하기 전에 반드시 사용자 승인을 받는다.**
-
-### 8단계: 노션 작성 (승인 후)
-
-사용자가 승인하면 Notion MCP 도구로 현재 회의 페이지에 작성:
-
-- `mcp__amang-notion__API-patch-block-children`으로 블록 추가
-- 각 영역별 `heading_2` 뒤에 `heading_3` 토글(children에 `table` 포함)을 **1회 호출로** 삽입
-- `heading_3.children[0]`이 `table`, `table.children`이 `table_row` 배열
-- 모든 `table_row.cells` 배열 길이는 `table_width`와 정확히 일치해야 함
-- 빈 셀도 `[{"type": "text", "text": {"content": ""}}]`로 채움 (빈 배열·null 금지)
-- 이슈/PR 링크는 Notion rich text의 `link` 속성 사용
-- `@멘션`은 가능하면 Notion user mention 사용, 불가하면 plain text `@이름`
-- 특정 블록 뒤에 삽입할 때는 `after` 파라미터 사용
-- Sentry 테이블은 토글 없이 `heading_2` 바로 아래에 `table` 직접 삽입
-- 각 섹션(진행 상황/논의 안건/특이사항)을 **병렬 서브에이전트**로 동시 작성하여 속도 최적화
+출력 후 종료. 사용자가 회의에서 직접 활용하므로 **노션 작성 단계 없음.**
 
 ## 주의사항
 
-- Notion MCP 서버가 연결 안 되면 환경변수 로드 확인 (`direnv allow`) 후 세션 재시작. 재시작 후에도 안 되면 사용자에게 알림
-- Notion API에서 `unsupported` 블록은 건너뛰고, `has_children: true`인 블록은 `mcp__amang-notion__API-get-block-children`으로 재귀 탐색
-- Sentry MCP 도구 권한 오류 시 `search_issues`만으로 수집 가능
-- 회의록 DB에 현재 회의 페이지가 아직 없으면 사용자에게 생성 요청
+- Notion MCP 서버 연결 안 되면 `direnv allow` 후 세션 재시작
+- Sentry는 반드시 `mcp__amang-sentry__*` 사용 (클라우드 커넥터 절대 금지 — 메모리 [feedback_no_cloud_connector.md](file:///home/json/.claude/projects/-home-json-amang-worktrees-main/memory/feedback_no_cloud_connector.md))
+- 회의록 DB에 현재 회의 페이지가 아직 없어도 **에러 아님** — 직전 회의만 잡아서 수집 진행

--- a/.claude/skills/meeting-prep/examples/output.md
+++ b/.claude/skills/meeting-prep/examples/output.md
@@ -1,110 +1,82 @@
-# meeting-prep 출력 예시
+# meeting-prep 출력 예시 (보고서 모드)
 
 > 이 파일은 스킬이 생성해야 하는 출력물의 few-shot 예시이다.
-> 실제 데이터(2026-03-28 ~ 2026-04-04, 손장수)로 작성됨.
+> **노션에 쓰지 않고 Claude 텍스트로만 출력한다.** 사용자가 회의 시작 전 본인의 진행을 누락 없이 보고하기 위한 개인 준비 자료.
+> 실제 데이터(2026-04-11 ~ 2026-04-27, 손장수)로 작성됨.
 
 ---
 
-## `meeting-prep` 실행 결과
+## 📋 meeting-prep 보고서 — 26-1 7차 회의 준비
 
-> **기간**: 2026-03-28 (4차 회의) ~ 2026-04-04 (현재)
+> **기간**: 2026-04-11 (6차 회의) ~ 2026-04-27 (오늘)
 > **대상**: manamana32321 (손장수)
-> **소스**: GitHub Issues/PR, Sentry, Notion 4차 회의록
+> **본인 영역**: 인프라 / 프론트 / AX
 
 ---
 
-# 진행 상황 공유
-
-## 프론트
-### > @손장수
+### 인프라
 
 | # | 내용 | 진행 | 중요도 | 링크 | 상세 |
-|--:|------|:---:|:-----:|------|------|
-| 1 | YouTube URL 검증 강화 | ✅ | ⚪ | [#365](https://github.com/skku-amang/main/issues/365) → [PR #366](https://github.com/skku-amang/main/pull/366) | |
-| 2 | YouTube 유틸 SSOT 통합 | ✅ | ⚪ | [#369](https://github.com/skku-amang/main/issues/369) → [PR #372](https://github.com/skku-amang/main/pull/372) | |
-| 3 | Prisma engine enum entrypoint 분리 | ✅ | 🟡 | [PR #380](https://github.com/skku-amang/main/pull/380) | Vercel 배포 시 Query Engine 누락 해결 |
-| 4 | 에러 메시지 개선 + 팀 지원 에러 표시 | 🔧 | 🟡 | [#382](https://github.com/skku-amang/main/issues/382), [#384](https://github.com/skku-amang/main/issues/384) → [PR #383](https://github.com/skku-amang/main/pull/383) | |
-| 5 | 로그인 재요구 버그 | ⏸️ | 🔴 | [#358](https://github.com/skku-amang/main/issues/358) | ← 4차 분배, 미착수 |
-| 6 | 모바일 회원가입 불가 | ⏸️ | 🔴 | [#359](https://github.com/skku-amang/main/issues/359) | ← 4차 분배, 미착수 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | grafana_ro 역할 + AMANG DB datasource 노출 | ✅ | 🟡 | [#454](https://github.com/skku-amang/main/issues/454) → [PR #461](https://github.com/skku-amang/main/pull/461), [#463](https://github.com/skku-amang/main/pull/463), [#464](https://github.com/skku-amang/main/pull/464), [#465](https://github.com/skku-amang/main/pull/465) | NetworkPolicy/Init Job 이슈 잡으며 4 PR로 진행 |
+| 2 | Grafana MCP(mcp-grafana) 추가 | ✅ | ⚪ | [PR #459](https://github.com/skku-amang/main/pull/459) | 외부 homelab#103 연계 |
 
-## 인프라
-### > @손장수
+### 프론트
 
 | # | 내용 | 진행 | 중요도 | 링크 | 상세 |
-|--:|------|:---:|:-----:|------|------|
-| 1 | Sentry 도입 | ✅ | ⚪ | [#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370) | ← 4차 분배 |
-| 2 | 임베디드 → 유저 QA | ✅ | ⚪ | [#360](https://github.com/skku-amang/main/issues/360) | ← 4차 분배 |
-| 3 | DB CronJob → ArgoCD PreSync Hook 전환 | ✅ | ⚪ | [PR #377](https://github.com/skku-amang/main/pull/377) | |
-| 4 | Job 파드 라벨 충돌 502 해소 | ✅ | 🟡 | [PR #378](https://github.com/skku-amang/main/pull/378) | |
-| 5 | 헬스체크 Sentry 에러 캡처 제외 | ✅ | ⚪ | [PR #387](https://github.com/skku-amang/main/pull/387) | |
-| 6 | 온보딩 자동화 셋업 스크립트 | ✅ | ⚪ | [PR #374](https://github.com/skku-amang/main/pull/374) | |
-| 7 | deps 업데이트 + ESLint 9 마이그레이션 | ✅ | ⚪ | [PR #376](https://github.com/skku-amang/main/pull/376) | |
-| 8 | Jest → Vitest 마이그레이션 | ✅ | ⚪ | [#367](https://github.com/skku-amang/main/issues/367) | |
-| 9 | DB 마이그레이션 Job 생성 | 🔧 | 🟡 | [#362](https://github.com/skku-amang/main/issues/362) | ← 4차 분배, 진행 중 |
-| 10 | CI 테스트 워크플로우 분리 및 병렬화 | 🔧 | ⚪ | [#368](https://github.com/skku-amang/main/issues/368) | |
-| 11 | seed 스크립트 멱등성 확보 | 🔧 | 🟡 | [#379](https://github.com/skku-amang/main/issues/379) → [PR #381](https://github.com/skku-amang/main/pull/381) | |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 어드민 유저 테이블 기수·프로필 인라인 편집 | ✅ | ⚪ | [#455](https://github.com/skku-amang/main/issues/455) → [PR #457](https://github.com/skku-amang/main/pull/457) |  |
+| 2 | 동방 예약 모달 참여자 칩 오버플로우 수정 | ✅ | 🟡 | [#440](https://github.com/skku-amang/main/issues/440) → [PR #466](https://github.com/skku-amang/main/pull/466) |  |
+| 3 | Sentry FAB 동적 위치 (기본 우상단) | ⏸️ | 🔴 | — | ← 6차 분배, 미착수 |
 
-## 직전(4차) 작업 분배 이행
+### AX (AI Experience)
 
-| 분배 작업 | 영역 | 결과 | 링크 |
-|---|---|---|---|
-| 임베디드 → 유저 QA | 인프라 | ✅ 완료 | [#360](https://github.com/skku-amang/main/issues/360) |
-| Sentry 도입 | 인프라 | ✅ 완료 | [#361](https://github.com/skku-amang/main/issues/361) → [PR #370](https://github.com/skku-amang/main/pull/370) |
-| DB 마이그레이션 Job 생성 | 인프라 | 🔧 진행 중 | [#362](https://github.com/skku-amang/main/issues/362) |
-| 로그인 재요구 버그 | 프론트 | ⏸️ 미착수 | [#358](https://github.com/skku-amang/main/issues/358) |
-| 모바일 회원가입 불가 | 프론트 | ⏸️ 미착수 | [#359](https://github.com/skku-amang/main/issues/359) |
+| # | 내용 | 진행 | 중요도 | 링크 | 상세 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | meeting-prep 스킬 출력 테이블 형식 전환 | ✅ | ⚪ | [PR #453](https://github.com/skku-amang/main/pull/453) | 이번 회의 준비에 사용 중 |
+| 2 | Sentry 트리아지 자동화 스킬 + 라벨 체계 재편 | 🔧 | 🟡 | [PR #456](https://github.com/skku-amang/main/pull/456) | OPEN, 머지 일정 확정 필요 |
 
 ---
 
-# 논의 안건
-
-*진행 상황에 포함되지 않은 새로운 제안/의사결정 필요 항목만*
-
-## 프론트
-### > @손장수
-
-| # | 내용 | 중요도 | 링크 | 상세 |
-|--:|------|:-----:|------|------|
-| 1 | NFC 기반 악기/장비 대여·반납 자동화 | ⚪ | [#373](https://github.com/skku-amang/main/issues/373) | 신규 제안 |
-| 2 | 긍정 피드백 위젯 + Slack 알림 파이프라인 | 🟡 | [#385](https://github.com/skku-amang/main/issues/385) | |
-| 3 | Vercel 배포 시 Prisma Query Engine 누락 | 🟡 | [#375](https://github.com/skku-amang/main/issues/375) | |
-| 4 | 에러 타입 매핑 exhaustive switch 전환 | ⚪ | [#388](https://github.com/skku-amang/main/issues/388) | |
-
-## 인프라
-### > @손장수
-
-| # | 내용 | 중요도 | 링크 | 상세 |
-|--:|------|:-----:|------|------|
-| 1 | 주간 활동 리포트 Slack 자동 발송 | ⚪ | [#386](https://github.com/skku-amang/main/issues/386) | |
-
----
-
-# Sentry 에러 현황
+### Sentry 에러 현황
 
 | 상태 | 에러 | 프로젝트 | 이벤트 | 링크 | 처리 |
-|:---:|------|:------:|------:|------|------|
-| ✅ | PrismaClientInitializationError | web | 54건 | [PR #380](https://github.com/skku-amang/main/pull/380) | 해결 |
-| ✅ | 헬스체크 503 | api | 2건 | [PR #387](https://github.com/skku-amang/main/pull/387) | 필터링 처리 |
-| ✅ | PrismaKnownRequestError (rentals) | api | 15건 | | resolved |
-| ⚠️ | 서버 에러 /performances/1/teams | web | 1건 | [WEB-9](https://amang-23.sentry.io/issues/WEB-9) | **미해결** |
+| --- | --- | --- | --- | --- | --- |
+| ⚠️ | TypeError: Load failed (`/performances/1/teams`) | web | 2건 (users 2) | [WEB-T](https://amang-23.sentry.io/issues/WEB-T) | 관찰 — 사파리/모바일 네트워크 단절 가능성 |
+
+---
+
+### ⚠️ 라벨 누락 PR
+
+다음 PR은 `scope:` 라벨이 없어 영역 분류를 추정으로 처리. 회의 전 라벨 보강 권장:
+
+- [PR #453](https://github.com/skku-amang/main/pull/453) — AX 추정 (스킬 도구)
+- [PR #456](https://github.com/skku-amang/main/pull/456) — AX 추정 (스킬 도구)
+
+---
+
+### 💡 회의에서 짚을 포인트
+
+1. **6차 분배 미이행 1건**: Sentry FAB 동적 위치. 인프라 작업(grafana_ro 6 PR)에 시간 쏠리며 프론트 분배가 밀림 → 7차에서 재분배 vs drop 결정 필요
+2. **AX 영역 라벨 부재**: PR #453, #456 모두 라벨 없음. `scope: ax` 라벨 신설 + 기존 PR 소급 적용 검토
+3. **Sentry WEB-T**: 영향 작지만 lastSeen 갱신 → 재현 OS/브라우저 확인 후 등급 재조정 필요
 
 ---
 
 ## 형식 규칙
 
-1. **테이블 형식**: 진행 상황·논의 안건 모두 테이블(`table` + `table_row`) 사용, `has_column_header: true`
-2. **컬럼 구성**:
-   - 진행 상황: `#` | `내용` | `진행` | `중요도` | `링크` | `상세`
-   - 논의 안건: `#` | `내용` | `중요도` | `링크` | `상세` (진행 컬럼 없음)
-   - Sentry: `상태` | `에러` | `프로젝트` | `이벤트` | `링크` | `처리`
-3. **중요도 기준**:
+1. **출력 매체**: Claude 텍스트 출력 only — 노션 작성 절대 금지
+2. **영역 순서**: 본인 우선 영역 순으로 (인프라/프론트/AX). 영역에 항목 없으면 그 영역 표 자체 생략
+3. **컬럼 구성**: `#` | `내용` | `진행` | `중요도` | `링크` | `상세` (Sentry는 별도)
+4. **Sentry 컬럼**: `상태` | `에러` | `프로젝트` | `이벤트` | `링크` | `처리`
+5. **중요도**:
    - 🔴 높음: Sentry 에러 연관, 직전 분배 미이행, 보안 이슈
-   - 🟡 보통: 일반 버그픽스, 진행 중 작업, 배포 관련
+   - 🟡 보통: 일반 버그픽스, 진행 중, 배포 관련
    - ⚪ 낮음: chore, 리팩토링, 제안 단계
-4. **진행 아이콘**: ✅ 완료, 🔧 진행 중, ⏸️ 미착수, ⚠️ 미해결
-5. **정렬**: ✅ → 🔧 → ⏸️ 순서
-6. **링크 필수**: 모든 이슈/PR/Sentry 이슈에 클릭 가능한 링크 포함
-7. **이슈-PR 연결**: 링크 컬럼에서 `#이슈 → PR #번호` 형태
-8. **직전 분배 표시**: 상세 컬럼에 `← 직전(N차) 분배` 부기
-9. **중복 제거**: 진행 상황에 있는 항목은 논의 안건에 포함하지 않음
-10. **토글 헤딩**: `### > @이름`은 노션에서 `is_toggleable: true` heading_3, children으로 테이블 삽입
+6. **진행 아이콘**: ✅ 완료 / 🔧 진행 중 / ⏸️ 미착수 / ⚠️ 미해결
+7. **정렬**: ✅ → 🔧 → ⏸️ 순서, 미이행 항목은 표 끝
+8. **링크 필수**: 모든 이슈/PR/Sentry 이슈에 클릭 가능한 마크다운 링크
+9. **이슈-PR 연결**: `#이슈 → PR #번호` 형태, 다중 PR은 콤마로 나열
+10. **직전 분배 표시**: 상세 컬럼에 `← N차 분배` 부기
+11. **라벨 누락 PR 섹션**: `scope:` 라벨 없는 PR을 별도 목록으로 — 본인 라벨 보강 액션 유도
+12. **Insight 섹션**: 회의에서 짚을 만한 패턴 1-3개 (미이행, 영역 편중, 라벨 누락 등)


### PR DESCRIPTION
## 🚀 작업 내용

`/meeting-prep` 스킬을 **보고서 모드**로 갈아엎음. 직전 회의(7차, 2026-04-27) 결과 — 사용자가 자동 작성된 회의록을 모두 지우고 새로 light-weight 템플릿으로 정리한 것 — 으로부터 도출된 결정.

**핵심 변경**: 노션 자동 작성 제거, Claude 텍스트 출력만 함.

### 변경 이유

회의록은 **팀 공유용**이고 자동 수집 데이터(GitHub PR/이슈, Sentry 에러)는 **본인의 회의 준비 자료**. 다른 팀원에게 다른 영역의 세부 작업 컨텍스트는 노이즈일 뿐. 옛 스킬은 노션 회의록에 진행 상황·논의 안건·특이사항 4섹션을 자동 채웠으나 사용자가 회의 후 모두 지우고 결정사항만 남기는 패턴이 반복되어, **자동화의 정체성을 "본인 보고서 생성"으로 명확히 분리**.

### 변경 내역

- **SKILL.md**:
  - 8단계 (노션 작성) 완전 제거
  - "역할 분담" 섹션 신설 — 노션 작성 절대 금지 명시
  - 작업 영역 분류에 `AX(AI Experience)` 추가
  - Sentry MCP는 `amang-sentry` 만 (`claude_ai_Sentry` 클라우드 커넥터 금지) 명시
  - data_source_id (`34d38c39-7d5d-4862-b061-46f226a3da31`) 발견값 반영 (이전엔 database_id만 있어 query 실패)

- **examples/output.md**:
  - 노션 블록 형식 규칙 → 마크다운 표 형식으로 단순화
  - "⚠️ 라벨 누락 PR" 섹션 신설 — `scope:` 라벨 빠진 PR 별도 표시로 라벨 보강 액션 유도
  - "💡 회의에서 짚을 포인트" Insight 섹션 신설

- **reference.md**: 그대로 유지 (노션 블록 트러블슈팅 노트, 다른 스킬에서 참조용으로 가치 있음)

## 📸 스크린샷(선택)

해당 없음 — 운영 도구(스킬 명세) 변경이라 시각 산출물 없음.

## 🔗 관련 이슈

없음. 본인 도구 개선이라 이슈 별도 등록 안 함.

## 🙏 리뷰어에게

- 본인 운영 도구라 reviewer 별도 지정 안 했습니다. 다른 팀원이 이 스킬을 쓸 일 없음.
- `scope:` 라벨 중 `ax`나 `tooling`이 없어 가장 가까운 `scope: infra`로 임시 부여. 추후 `scope: ax` 라벨 신설 검토 가능.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [ ] 관련 이슈가 연결되었습니다. (해당 없음 — 본인 도구 개선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)