### PR TITLE
feat(web): 예약 폼 데스크톱에서 시작일 선택 시 종료일 자동 채우기

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
@@ -309,7 +309,13 @@ export default function AddScheduleButton({
                 <Calendar
                   mode="single"
                   selected={startDate}
-                  onSelect={setStartDate}
+                  onSelect={(date) => {
+                    setStartDate(date)
+                    // 종료일이 비어있거나 시작일보다 이전이면 자동으로 시작일과 동일하게 맞춤
+                    if (date && (!endDate || endDate < date)) {
+                      setEndDate(date)
+                    }
+                  }}
                   disabled={disablePastDates}
                   className="rounded-md border p-1"
                   classNames={{


### PR DESCRIPTION
## 🚀 작업 내용

예약 폼의 **데스크톱** 시작일 캘린더에서 날짜 선택 시 종료일이 자동으로 동일 날짜로 채워지도록 수정.

- 종료일이 비어있을 때: 시작일과 동일하게 자동 입력
- 종료일이 시작일보다 이전일 때: 시작일과 동일하게 재설정 (UX 깨짐 방지)

모바일은 이미 [`mode="range"` 캘린더](apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx#L344-L355)에서 동일한 동작을 하고 있어, 데스크톱(별도 `mode="single"` 캘린더 두 개)과 일관성을 맞췄다.

```tsx
// Before
<Calendar mode="single" selected={startDate} onSelect={setStartDate} ... />

// After
<Calendar
  mode="single"
  selected={startDate}
  onSelect={(date) => {
    setStartDate(date)
    if (date && (!endDate || endDate < date)) {
      setEndDate(date)
    }
  }}
  ...
/>
```

대부분의 동방 이용은 하루 안에 끝나는 패턴이라, 매번 종료일을 따로 누를 필요 없는 구글 캘린더 방식으로 맞췄다 (피드백 작성자 의도).

## 📸 스크린샷(선택)

> Manual verification needed — UI 작은 변경(데스크톱 캘린더 onSelect 핸들러)이라 시각 검증 스킵.
> 리뷰 시 데스크톱(`sm:` breakpoint 이상)에서 시작일 선택 후 종료일 캘린더에 자동 표시되는지 확인 부탁.

## 🔗 관련 이슈

Closes #477

## 🙏 리뷰어에게

- 변경 위치: [apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx#L309-L325](apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx#L309-L325)
- 한 컴포넌트의 시작일 캘린더 `onSelect`만 수정 (7줄 추가, 1줄 삭제)
- 종료일을 먼저 만지고 시작일을 늦게 골랐을 때(end < start 케이스)도 깨지지 않도록 함께 처리

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.