### PR TITLE
feat(web): 관리자 승인 대기 회원 페이지에 카운트 표시

### DIFF
--- a/apps/web/app/(admin)/admin/pending-users/page.tsx
+++ b/apps/web/app/(admin)/admin/pending-users/page.tsx
@@ -134,7 +134,14 @@ export default function PendingUsersAdminPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold">승인 대기 회원</h1>
+      <div className="mb-6 flex items-baseline gap-3">
+        <h1 className="text-2xl font-bold">승인 대기 회원</h1>
+        {!isLoading && (
+          <span className="text-muted-foreground text-sm">
+            {pendingUsers?.length ?? 0}명
+          </span>
+        )}
+      </div>
 
       <DataTable
         columns={columns}


### PR DESCRIPTION
## 🚀 작업 내용

`/admin/pending-users` 페이지 제목 옆에 현재 승인 대기 중인 회원 수를 표시한다.

- 위치: 페이지 제목 우측 (예: `승인 대기 회원   12명`)
- 데이터 로딩 중에는 카운트 미노출 (깜빡임 방지)
- 0명이면 `0명`으로 노출 — empty state 메시지(`승인 대기 중인 회원이 없습니다.`)는 기존대로 테이블에 그대로 표시됨
- 별도 count API 추가 없이 기존 `usePendingUsers()` 결과의 `length` 사용 → 추가 네트워크 비용 0

## 📸 스크린샷(선택)

수동 검증 필요 (manual verification needed) — 로컬 빌드/타입체크는 통과했지만, admin 권한이 필요한 페이지라 자동 시각 검증은 생략. PR 리뷰 시 배포 프리뷰에서 확인 부탁드립니다.

## 🔗 관련 이슈

Closes #475

## 🙏 리뷰어에게

- 카운트 위치는 `flex items-baseline gap-3`으로 제목과 동일한 baseline에 정렬했습니다. 다른 admin 페이지(`/admin/users` 등)에도 동일 패턴을 확장할지는 별도 논의로 분리.
- 디자인 출처: Figma에 별도 시안 없어 기존 헤더 패턴 + `text-muted-foreground text-sm`으로 보조 텍스트 처리.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다. (`priority: low`)
- [x] 관련 이슈가 연결되었습니다. (#475)