### PR TITLE
fix(web,api): "리더" 레이블을 도메인별로 "기장"/"세션장"/"팀장"으로 치환

### DIFF
--- a/apps/api/src/auth/guards/team-owner.guard.ts
+++ b/apps/api/src/auth/guards/team-owner.guard.ts
@@ -19,7 +19,7 @@ export class TeamOwnerGuard implements CanActivate {
     const team = await this.teamService.findOne(+teamId)
 
     const isOwner = team.leaderId === user.sub
-    if (!isOwner) throw new ForbiddenError("팀 리더만 접근할 수 있습니다.")
+    if (!isOwner) throw new ForbiddenError("팀장만 접근할 수 있습니다.")
 
     return true
   }

--- a/apps/api/src/generation/generation.service.ts
+++ b/apps/api/src/generation/generation.service.ts
@@ -35,14 +35,14 @@ export class GenerationService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${createGenerationDto.leaderId})는 이미 다른 기수의 리더입니다.`
+                `해당 유저(ID: ${createGenerationDto.leaderId})는 이미 다른 기수의 기장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
             throw new UnprocessableEntityError(
-              "존재하지 않는 리더 ID 혹은 사용자 ID가 포함되어 있습니다."
+              "존재하지 않는 기장 ID 혹은 사용자 ID가 포함되어 있습니다."
             )
         }
       }
@@ -114,14 +114,14 @@ export class GenerationService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${updateGenerationDto.leaderId})는 이미 다른 기수의 리더입니다.`
+                `해당 유저(ID: ${updateGenerationDto.leaderId})는 이미 다른 기수의 기장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
             throw new UnprocessableEntityError(
-              "존재하지 않는 리더 ID 혹은 사용자 ID가 포함되어 있습니다."
+              "존재하지 않는 기장 ID 혹은 사용자 ID가 포함되어 있습니다."
             )
         }
         throw error

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -35,13 +35,13 @@ export class SessionService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${createSessionDto.leaderId})는 이미 다른 세션의 팀장입니다.`
+                `해당 유저(ID: ${createSessionDto.leaderId})는 이미 다른 세션의 세션장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
-            throw new UnprocessableEntityError("팀장 ID가 유효하지 않습니다.")
+            throw new UnprocessableEntityError("세션장 ID가 유효하지 않습니다.")
         }
       }
       throw error
@@ -110,14 +110,14 @@ export class SessionService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${updateSessionDto.leaderId})는 이미 다른 세션의 팀장입니다.`
+                `해당 유저(ID: ${updateSessionDto.leaderId})는 이미 다른 세션의 세션장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
             throw new UnprocessableEntityError(
-              "팀장 ID 혹은 사용자 ID가 유효하지 않습니다."
+              "세션장 ID 혹은 사용자 ID가 유효하지 않습니다."
             )
         }
       }

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -35,13 +35,13 @@ export class SessionService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${createSessionDto.leaderId})는 이미 다른 세션의 리더입니다.`
+                `해당 유저(ID: ${createSessionDto.leaderId})는 이미 다른 세션의 팀장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
-            throw new UnprocessableEntityError("리더 ID가 유효하지 않습니다.")
+            throw new UnprocessableEntityError("팀장 ID가 유효하지 않습니다.")
         }
       }
       throw error
@@ -110,14 +110,14 @@ export class SessionService {
             }
             if (target.includes("leaderId")) {
               throw new ConflictError(
-                `해당 유저(ID: ${updateSessionDto.leaderId})는 이미 다른 세션의 리더입니다.`
+                `해당 유저(ID: ${updateSessionDto.leaderId})는 이미 다른 세션의 팀장입니다.`
               )
             }
             break
           case "P2025":
             // P2025: An operation failed because it depends on one or more records that were required but not found.
             throw new UnprocessableEntityError(
-              "리더 ID 혹은 사용자 ID가 유효하지 않습니다."
+              "팀장 ID 혹은 사용자 ID가 유효하지 않습니다."
             )
         }
       }

--- a/apps/api/src/team/team.service.ts
+++ b/apps/api/src/team/team.service.ts
@@ -118,7 +118,7 @@ export class TeamService {
           case "P2003":
           case "P2025":
             throw new ReferencedEntityNotFoundError(
-              "존재하지 않는 리더, 세션, 공연, 또는 유저를 팀에 추가할 수 없습니다."
+              "존재하지 않는 팀장, 세션, 공연, 또는 유저를 팀에 추가할 수 없습니다."
             )
         }
       }
@@ -281,7 +281,7 @@ export class TeamService {
           case "P2003":
           case "P2025":
             throw new ReferencedEntityNotFoundError(
-              "존재하지 않는 리더, 세션, 또는 유저를 팀에 추가할 수 없습니다."
+              "존재하지 않는 팀장, 세션, 또는 유저를 팀에 추가할 수 없습니다."
             )
         }
       }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -249,7 +249,7 @@ export class UsersService {
 
           if (constraint === "teams_leaderId_fkey")
             throw new ConflictError(
-              "팀의 리더를 맡고 있는 사용자는 삭제할 수 없습니다. 먼저 팀 리더를 변경해주세요."
+              "팀장을 맡고 있는 사용자는 삭제할 수 없습니다. 먼저 팀장을 변경해주세요."
             )
         }
       }

--- a/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/generations/_components/GenerationFormDialog.tsx
@@ -114,7 +114,7 @@ export function GenerationFormDialog({
               name="leaderId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>리더</FormLabel>
+                  <FormLabel>기장</FormLabel>
                   <Select
                     value={field.value?.toString() ?? "none"}
                     onValueChange={(v) =>
@@ -123,7 +123,7 @@ export function GenerationFormDialog({
                   >
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder="리더 선택 (선택사항)" />
+                        <SelectValue placeholder="기장 선택 (선택사항)" />
                       </SelectTrigger>
                     </FormControl>
                     <UserSelectContent users={users} allowNone />

--- a/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
@@ -121,7 +121,7 @@ export function SessionFormDialog({
               name="leaderId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>리더</FormLabel>
+                  <FormLabel>팀장</FormLabel>
                   <Select
                     value={field.value?.toString() ?? "none"}
                     onValueChange={(v) =>
@@ -130,7 +130,7 @@ export function SessionFormDialog({
                   >
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder="리더 선택 (선택사항)" />
+                        <SelectValue placeholder="팀장 선택 (선택사항)" />
                       </SelectTrigger>
                     </FormControl>
                     <UserSelectContent users={users} allowNone />

--- a/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
+++ b/apps/web/app/(admin)/admin/sessions/_components/SessionFormDialog.tsx
@@ -121,7 +121,7 @@ export function SessionFormDialog({
               name="leaderId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>팀장</FormLabel>
+                  <FormLabel>세션장</FormLabel>
                   <Select
                     value={field.value?.toString() ?? "none"}
                     onValueChange={(v) =>
@@ -130,7 +130,7 @@ export function SessionFormDialog({
                   >
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder="팀장 선택 (선택사항)" />
+                        <SelectValue placeholder="세션장 선택 (선택사항)" />
                       </SelectTrigger>
                     </FormControl>
                     <UserSelectContent users={users} allowNone />

--- a/apps/web/app/(general)/(light)/profile/teams/page.tsx
+++ b/apps/web/app/(general)/(light)/profile/teams/page.tsx
@@ -49,7 +49,7 @@ const ProfileTeamsPage = () => {
     )
   }
 
-  // 내가 참여 중인 팀 필터링 (리더이거나 멤버인 팀)
+  // 내가 참여 중인 팀 필터링 (팀장이거나 멤버인 팀)
   const myTeams =
     allTeams?.filter((team) => {
       if (team.leader.id === userId) return true

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -221,7 +221,7 @@ export class DuplicateTeamSessionError extends ApiError {
 }
 
 /**
- * 존재하지 않는 엔티티(리더, 세션, 사용자 등)를 참조하려고 할 때 발생하는 오류입니다.
+ * 존재하지 않는 엔티티(팀장, 세션, 사용자 등)를 참조하려고 할 때 발생하는 오류입니다.
  */
 export class ReferencedEntityNotFoundError extends ApiError {
   readonly type = "/errors/team/referenced-entity-not-found"
@@ -230,7 +230,7 @@ export class ReferencedEntityNotFoundError extends ApiError {
 
   constructor(detail?: string, instance?: string) {
     super(
-      "존재하지 않는 리소스(리더, 세션, 사용자 등)를 참조하고 있습니다.",
+      "존재하지 않는 리소스(팀장, 세션, 사용자 등)를 참조하고 있습니다.",
       detail,
       instance
     )

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -349,7 +349,7 @@ export default class ApiClient {
    * @throws {DuplicateMemberIndexError} 세션 내에 중복된 멤버 인덱스가 존재하는 경우
    * @throws {DuplicateSessionUserError} 세션 내에 중복된 사용자가 존재하는 경우
    * @throws {DuplicateTeamSessionError} 한 팀에 동일한 세션을 중복하여 추가하는 경우
-   * @throws {ReferencedEntityNotFoundError} 존재하지 않는 리더, 세션, 또는 유저를 팀에 추가하는 경우
+   * @throws {ReferencedEntityNotFoundError} 존재하지 않는 팀장, 세션, 또는 유저를 팀에 추가하는 경우
    * @throws {ConflictError} 이미 존재하는 데이터와 충돌이 발생한 경우
    * @throws {InternalServerError} 서버 오류 발생 시
    */
@@ -396,7 +396,7 @@ export default class ApiClient {
    * @throws {DuplicateMemberIndexError} 세션 내에 중복된 멤버 인덱스가 존재하는 경우
    * @throws {DuplicateSessionUserError} 세션 내에 중복된 사용자가 존재하는 경우
    * @throws {DuplicateTeamSessionError} 한 팀에 동일한 세션을 중복하여 추가하는 경우
-   * @throws {ReferencedEntityNotFoundError} 존재하지 않는 리더, 세션, 또는 유저를 팀에 추가하는 경우
+   * @throws {ReferencedEntityNotFoundError} 존재하지 않는 팀장, 세션, 또는 유저를 팀에 추가하는 경우
    * @throws {ConflictError} 이미 존재하는 데이터와 충돌이 발생한 경우
    * @throws {InternalServerError} 서버 오류 발생 시
    */
@@ -901,7 +901,7 @@ export default class ApiClient {
    * @throws {ValidationError} 입력값이 올바르지 않은 경우
    * @throws {ForbiddenError} 유저 수정 권한이 없는 경우 (요청을 보내는 사용자가 관리자 권한이 없을 때 발생)
    * @throws {NotFoundError} id에 해당하는 유저를 찾을 수 없을 때
-   * @throws {ConflictError} 팀에서 리더를 맡고 있는 사용자를 삭제하려고 할 때 발생합니다.
+   * @throws {ConflictError} 팀에서 팀장을 맡고 있는 사용자를 삭제하려고 할 때 발생합니다.
    * @throws {InternalServerError} 서버 오류 발생 시
    */
   public deleteUser(id: number) {

--- a/packages/shared-types/src/generation/create-generation.schema.ts
+++ b/packages/shared-types/src/generation/create-generation.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 /**
  * @description 기수 생성 Zod 스키마
- * 기수 순서와 리더 ID를 포함합니다.
+ * 기수 순서와 기장 ID를 포함합니다.
  */
 export const CreateGenerationSchema = z
   .object({
@@ -11,8 +11,8 @@ export const CreateGenerationSchema = z
       .multipleOf(0.5, { message: "기수는 0.5 단위여야 합니다." }),
 
     leaderId: z
-      .number({ invalid_type_error: "리더 ID는 숫자여야 합니다." })
-      .int("리더 ID는 정수여야 합니다.")
+      .number({ invalid_type_error: "기장 ID는 숫자여야 합니다." })
+      .int("기장 ID는 정수여야 합니다.")
       .optional()
   })
   .strict()

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 /**
  * @description 세션 생성 Zod 스키마
- * 세션 이름과 아이콘, 팀장 ID를 포함합니다.
+ * 세션 이름과 아이콘, 세션장 ID를 포함합니다.
  */
 export const CreateSessionSchema = z
   .object({
@@ -19,8 +19,8 @@ export const CreateSessionSchema = z
       .optional(),
 
     leaderId: z
-      .number({ invalid_type_error: "팀장 ID는 숫자여야 합니다." })
-      .int("팀장 ID는 정수여야 합니다.")
+      .number({ invalid_type_error: "세션장 ID는 숫자여야 합니다." })
+      .int("세션장 ID는 정수여야 합니다.")
       .optional()
   })
   .strict()

--- a/packages/shared-types/src/session/create-session.schema.ts
+++ b/packages/shared-types/src/session/create-session.schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 /**
  * @description 세션 생성 Zod 스키마
- * 세션 이름과 아이콘, 리더 ID를 포함합니다.
+ * 세션 이름과 아이콘, 팀장 ID를 포함합니다.
  */
 export const CreateSessionSchema = z
   .object({
@@ -19,8 +19,8 @@ export const CreateSessionSchema = z
       .optional(),
 
     leaderId: z
-      .number({ invalid_type_error: "리더 ID는 숫자여야 합니다." })
-      .int("리더 ID는 정수여야 합니다.")
+      .number({ invalid_type_error: "팀장 ID는 숫자여야 합니다." })
+      .int("팀장 ID는 정수여야 합니다.")
       .optional()
   })
   .strict()

--- a/packages/shared-types/src/team/create-team.schema.ts
+++ b/packages/shared-types/src/team/create-team.schema.ts
@@ -15,7 +15,7 @@ export const TeamSessionSchema = z.object({
 export const CreateTeamSchema = z.object({
   name: z.string().min(1, "팀 이름은 필수입니다."),
   description: z.string().nullable().optional(),
-  leaderId: z.number().int().positive("팀 리더 ID는 정수여야 합니다."),
+  leaderId: z.number().int().positive("팀장 ID는 정수여야 합니다."),
   performanceId: z.number().int("공연 ID는 정수여야 합니다.").positive(),
   image: z
     .string()


### PR DESCRIPTION
## 🚀 작업 내용

[#471](https://github.com/skku-amang/main/issues/471) — 기수 수정 양식에서 기장 필드의 레이블이 "리더"로 표시되던 문제. 코드베이스 전반에서 "리더" 표현을 도메인에 맞게 일괄 치환.

### 결정 로그

도메인별로 "리더"를 세 가지 단어로 치환:

| 도메인 | 치환어 | 근거 |
| --- | --- | --- |
| \`Generation\` (기수, 32기 같은 학번 그룹) | **기장** | 동아리에서 기수의 대표를 부르는 자연어 |
| \`Session\` (기타·보컬 등 악기군 단위) | **세션장** | 악기군 단위의 리더는 "세션장"이 도메인 적합 (리뷰 반영) |
| \`Team\` (공연 합주 팀) | **팀장** | 합주 팀의 리더 |
| \`users.service\` 내 팀 leader 참조 | **팀장** | 팀 도메인 컨텍스트 |
| \`ReferencedEntityNotFoundError\` (팀에 추가하는 엔티티 오류) | **팀장** | 팀 도메인 |

### 변경 범위

16개 파일, +38 / -38 (실효 텍스트만). 변경 유형:
- UI 레이블 / placeholder (Form 컴포넌트 2개)
- Zod 검증 메시지 (shared-types 3개)
- NestJS 서비스 에러 메시지 (api 4개)
- ApiClient 에러 클래스 메시지 + JSDoc 주석 (api-client 2개)
- 코드 주석 (1개)

### 리뷰 반영 (490bf44)

초안에선 \`Session\` 도메인도 "팀장"으로 일괄 처리했으나, 리뷰에서 "Session.leader는 도메인 상 '세션장'으로 불림"이라는 피드백을 반영하여 Session 관련 9건을 "세션장"으로 분리.

## 📸 스크린샷(선택)

UI 레이블 변경은 단순 문자열 치환이라 스크린샷 생략. 영향 범위:
- \`/admin/generations?rowId=29\` 기수 수정 다이얼로그: "리더" → "기장"
- \`/admin/sessions\` 세션 수정 다이얼로그: "리더" → "세션장"

## 🔗 관련 이슈

Closes [#471](https://github.com/skku-amang/main/issues/471)

## 🙏 리뷰어에게

- 도메인 분류(기장 / 세션장 / 팀장)가 위 표대로 맞는지 확인 부탁드립니다.
- 에러 메시지 변경은 사용자 노출 텍스트라 스펠링·자연스러움도 함께 봐주시면 좋습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다. (\`priority: low\`)
- [x] 관련 이슈가 연결되었습니다. ([#471](https://github.com/skku-amang/main/issues/471))