### PR TITLE
feat(web): 멤버 선택 UI에 한글 친화 검색 + 기수 표기 도입

### DIFF
--- a/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
+++ b/apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx
@@ -27,7 +27,8 @@ import {
 } from "@/components/ui/select"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { useToast } from "@/components/hooks/use-toast"
-import { cn } from "@/lib/utils"
+import MemberPicker from "@/components/MemberPicker"
+import { cn, formatGenerationOrder } from "@/lib/utils"
 import { useCreateRental } from "@/hooks/api/useRental"
 import { useUsers } from "@/hooks/api/useUser"
 import { Equipment } from "@repo/shared-types"
@@ -195,8 +196,7 @@ export default function AddScheduleButton({
     resetForm()
   }
 
-  const addUser = (userId: string) => {
-    const id = Number(userId)
+  const addUser = (id: number) => {
     if (!selectedUserIds.includes(id)) {
       setSelectedUserIds((prev) => [...prev, id])
     }
@@ -208,8 +208,6 @@ export default function AddScheduleButton({
 
   const selectedUsers =
     users?.filter((u) => selectedUserIds.includes(u.id)) ?? []
-  const availableUsers =
-    users?.filter((u) => !selectedUserIds.includes(u.id)) ?? []
 
   return (
     <Dialog
@@ -522,18 +520,11 @@ export default function AddScheduleButton({
 
             <div className="space-y-1.5">
               <label className="text-sm text-muted-foreground">Members</label>
-              <Select onValueChange={addUser} value={undefined}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableUsers.map((user) => (
-                    <SelectItem key={user.id} value={user.id.toString()}>
-                      {user.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <MemberPicker
+                users={users ?? []}
+                excludeIds={selectedUserIds}
+                onSelect={(user) => addUser(user.id)}
+              />
             </div>
 
             {/* Selected members as avatar chips */}
@@ -550,9 +541,14 @@ export default function AddScheduleButton({
                         {user.name?.slice(0, 2)}
                       </AvatarFallback>
                     </Avatar>
-                    <span className="max-w-[60px] truncate text-xs">
+                    <span className="max-w-[80px] truncate text-xs">
                       {user.name}
                     </span>
+                    {user.generation && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {formatGenerationOrder(user.generation.order)}기
+                      </span>
+                    )}
                     <button
                       type="button"
                       onClick={() => removeUser(user.id)}

--- a/apps/web/components/MemberPicker.tsx
+++ b/apps/web/components/MemberPicker.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { ChevronsUpDown } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@/components/ui/popover"
+import { koreanCommandFilter } from "@/lib/hangul-search"
+import { cn, formatGenerationOrder } from "@/lib/utils"
+
+export interface PickableMember {
+  id: number
+  name: string
+  generation: { order: number }
+}
+
+interface MemberPickerProps<T extends PickableMember> {
+  /** 선택 후보 멤버 목록 */
+  users: T[]
+  /** 멤버를 선택했을 때 호출되는 콜백 (단건). 다중 선택은 호출자가 외부 state로 관리 */
+  onSelect: (user: T) => void
+  /** 후보에서 제외할 ID (이미 선택된 멤버 등). 지정하면 옵션 목록에서 숨김 */
+  excludeIds?: number[]
+  /** Trigger 버튼 placeholder. 기본값: "멤버 추가" */
+  placeholder?: string
+  /** Command 입력 placeholder. 기본값: "이름 또는 기수로 검색" */
+  searchPlaceholder?: string
+  /** Popover trigger 버튼 className 오버라이드 */
+  className?: string
+  /** 비활성화 */
+  disabled?: boolean
+}
+
+/**
+ * 한글 친화 검색 + 기수 표기를 지원하는 멤버 선택 컴포넌트.
+ *
+ * - cmdk `Command` + `koreanCommandFilter`로 영문/한글/초성 검색 모두 매칭
+ * - 검색 대상은 `${name} ${generation}기` 합친 문자열 → 이름과 기수 모두 검색 가능
+ * - 동명이인은 옵션과 트리거에서 기수로 구분 표기
+ *
+ * 다중 선택 패턴: `excludeIds`에 이미 선택된 멤버 ID를 넘기면 후보에서 빠진다.
+ * 선택 시 popover가 닫히고 호출자가 `onSelect`에서 자체 state에 추가한다.
+ */
+export default function MemberPicker<T extends PickableMember>({
+  users,
+  onSelect,
+  excludeIds = [],
+  placeholder = "멤버 추가",
+  searchPlaceholder = "이름 또는 기수로 검색",
+  className,
+  disabled
+}: MemberPickerProps<T>) {
+  const [open, setOpen] = useState(false)
+
+  const availableUsers = users.filter((u) => !excludeIds.includes(u.id))
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn("w-full justify-between font-normal", className)}
+        >
+          <span className="text-muted-foreground">{placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command filter={koreanCommandFilter}>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>일치하는 멤버가 없어요</CommandEmpty>
+            <CommandGroup>
+              {availableUsers.map((user) => {
+                const generationLabel = `${formatGenerationOrder(user.generation.order)}기`
+                // cmdk filter는 단일 string(value)만 받으므로, 이름과 기수를
+                // 함께 합쳐 둘 다 검색 가능하게 한다. id 접두사는 동명이인
+                // 동기수까지 같은 경우의 value 충돌을 방지한다.
+                const searchValue = `${user.id} ${user.name} ${generationLabel}`
+                return (
+                  <CommandItem
+                    key={user.id}
+                    value={searchValue}
+                    onSelect={() => {
+                      onSelect(user)
+                      setOpen(false)
+                    }}
+                  >
+                    <span className="flex-1 truncate">{user.name}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {generationLabel}
+                    </span>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}


### PR DESCRIPTION
## 🚀 작업 내용

동방·장비 예약 시 참여자를 추가하는 Members Select가 단순 드롭다운이라 유저가 많을수록 찾기 어렵고, 동명이인이 있을 때 누가 누군지 구분할 수 없었어요. 두 명의 외부/내부 voter가 같은 요청을 독립적으로 올린 high priority 피드백입니다.

이번 PR로:

- **`apps/web/components/MemberPicker.tsx`** (신규): shadcn `Command` + 기존 [`koreanCommandFilter`](apps/web/lib/hangul-search.ts) 조합으로
  - 영문 (`kim`), 한글 부분 일치 (`김`), 초성 (`ㄱㅁㅅ`) 모두 매칭
  - cmdk filter는 단일 string에만 동작하므로 검색 대상 value에 `${name} ${generation}기`를 합쳐 이름·기수 둘 다로 검색 가능
  - 옵션 행 우측에 `32기` 등 기수 라벨 표시 → 동명이인 구분
- **[`AddScheduleButton.tsx`](apps/web/app/(general)/(light)/reservations/_components/AddScheduleButton.tsx)** (동방·장비 예약 모달이 공용으로 사용): 참여자 `<Select>`를 `MemberPicker`로 교체. 선택된 멤버 chip에도 기수 라벨 추가
- **팀 편집 폼 ([`TeamForm/ThirdPage/UserSelect`](apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/ThirdPage/UserSelect.tsx))**: 이미 동일한 `Command + koreanCommandFilter + formatGenerationOrder` 패턴이 적용돼 있어 변경 없음

## 📸 스크린샷(선택)

시각 검증은 dev server에서 `/reservations/clubroom` SSR 200 / 빌드 통과까지 확인했어요. 실제 검색 동작 스크린샷은 follow-up으로 남길게요. (기존 [`UserSelect`](apps/web/app/(general)/(dark)/performances/[id]/teams/_components/TeamForm/ThirdPage/UserSelect.tsx)가 같은 헬퍼·컴포넌트 조합을 production에서 이미 검증된 채로 사용 중이라 회귀 위험은 낮음)

## 🔗 관련 이슈

Closes #474

## 🙏 리뷰어에게

- `MemberPicker`의 `searchValue` 구성: cmdk filter 한계로 value에 `${id} ${name} ${generation}기`를 넣었어요. id 접두사는 동명이인+동기수까지 같은 극단 케이스의 value 충돌 방지 목적입니다. 숫자만 입력하면 매칭될 수 있다는 부작용은 있지만, 실사용 시 거의 발생하지 않을 거라 판단했어요. 더 깔끔한 방법(예: cmdk `keywords` prop)이 좋다는 의견 있으시면 말씀해 주세요.
- `useUsers()`가 반환하는 [`publicUserList`](packages/shared-types/src/user/user.types.ts)에는 `generation: { id, order }`가 항상 포함되어 있어서 별도 fetch 없이 기수 표시 가능합니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)