### PR TITLE
fix(infra): Redis NetworkPolicy에 Blackbox Exporter 허용 추가

### DIFF
--- a/infra/k8s/redis/overlays/production/network-policy.yaml
+++ b/infra/k8s/redis/overlays/production/network-policy.yaml
@@ -24,6 +24,13 @@ spec:
           podSelector:
             matchLabels:
               app: api-job
+        # Blackbox Exporter (TCP probe로 가용성 모니터링)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
       ports:
         - protocol: TCP
           port: 6379

--- a/infra/k8s/redis/overlays/staging/network-policy.yaml
+++ b/infra/k8s/redis/overlays/staging/network-policy.yaml
@@ -24,6 +24,13 @@ spec:
           podSelector:
             matchLabels:
               app: api-job
+        # Blackbox Exporter (TCP probe로 가용성 모니터링)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
       ports:
         - protocol: TCP
           port: 6379


### PR DESCRIPTION
## 🚀 작업 내용

[#473](https://github.com/skku-amang/main/pull/473) 머지 후 배포 검증 중 발견된 Blackbox monitoring 차단 핫픽스. `observability` ns의 `prometheus-blackbox-exporter`가 cross-ns로 redis 6379에 TCP probe 시도하는데 기존 NetworkPolicy는 `amang-api-{env}`의 `api/api-job` pod만 허용해서 차단됨.

### 증상

\`\`\`
$ promql: probe_success{instance=~\".*amang-redis.*\"}
redis.amang-redis-staging.svc.cluster.local:6379    0
redis.amang-redis-production.svc.cluster.local:6379 0
\`\`\`

ServiceMonitor는 정상 등록(homelab#190 머지 후 자동 생성), Redis 자체도 정상 (same-ns \`redis-cli ping\` → PONG). NP가 단독 원인.

### Fix

staging + production 양쪽 \`network-policy.yaml\`에 observability ns의 blackbox exporter pod 허용 ingress rule 추가:

\`\`\`yaml
- namespaceSelector:
    matchLabels:
      kubernetes.io/metadata.name: observability
  podSelector:
    matchLabels:
      app.kubernetes.io/name: prometheus-blackbox-exporter
\`\`\`

기존 db NetworkPolicy(production은 grafana ns 허용)와 동일한 cross-ns allow 패턴.

### 검증

- [x] \`kubectl kustomize infra/k8s/redis/overlays/{staging,production}\` 빌드 성공
- [ ] 머지 후 ArgoCD sync → Grafana \`probe_success{instance=~\".*amang-redis.*\"} == 1\`

## 📸 스크린샷(선택)

해당 없음.

## 🔗 관련 이슈

- 후속: [#473](https://github.com/skku-amang/main/pull/473) (Redis 인프라 도입)
- 관련: [manamana32321/homelab#190](https://github.com/manamana32321/homelab/pull/190) (ServiceMonitor 등록)

## 🙏 리뷰어에게

- 1줄 fix지만 \`observability\` ns 신뢰 가정이 합리적인지만 확인. blackbox-exporter는 helm으로 배포된 표준 컴포넌트라 위험 낮음
- 후속: db/api NetworkPolicy도 동일 패턴 점검 필요할 수 있음 (별도 작업)

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] PR은 기본 라벨 없이 제출 (CONTRIBUTING.md 컨벤션)
- [ ] 관련 이슈 연결 — 기존 이슈 없음, PR cross-link로 충분