### PR TITLE
feat(infra,api): Redis 클라이언트 셋업 (의존성 외 모든 설정)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,5 +20,10 @@ S3_ENDPOINT=http://localhost:9000
 # Server port (default: 8000)
 # PORT=8000
 
+# Redis (use case 미정 — 의존성/모듈 등록 후 required 전환 예정)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=redis
+
 # Sentry DSN (error tracking, disabled in development by default)
 # SENTRY_DSN=https://xxx@xxx.ingest.us.sentry.io/xxx

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -42,7 +42,29 @@ services:
       - minio_data:/data
     command: server /data --console-address ":9001"
 
+  # 캐시/큐/세션 등 in-memory data structure server
+  redis:
+    image: redis:8.4-alpine
+    container_name: redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD:-redis}
+      - --appendonly
+      - "yes"
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis}", "--no-auth-warning", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
 volumes:
   postgres_data:
   pgadmin_data:
   minio_data:
+  redis_data:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -45,6 +45,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sql-formatter": "^15.7.3",
+    "zod": "^3.25.76",
     "zod-validation-error": "^4.0.2"
   },
   "devDependencies": {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from "./app.service"
 import { ConfigModule } from "@nestjs/config"
 import { LoggerModule } from "nestjs-pino"
 import { pinoLoggerModuleOption } from "./common/logger/pino-logger.config"
+import { validateEnv } from "./common/config/env.schema"
 import { PrismaModule } from "./prisma/prisma.module"
 import { UsersModule } from "./users/users.module"
 import { AuthModule } from "./auth/auth.module"
@@ -23,7 +24,8 @@ import { HealthModule } from "./health/health.module"
     SentryModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,
-      cache: true
+      cache: true,
+      validate: validateEnv
     }),
     LoggerModule.forRoot(pinoLoggerModuleOption),
     PrismaModule,

--- a/apps/api/src/common/config/env.schema.ts
+++ b/apps/api/src/common/config/env.schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod"
+import { fromError } from "zod-validation-error"
+
+/**
+ * 부팅 시점 env 검증 schema (fail-fast).
+ *
+ * 정책:
+ * - 알려진 키만 strict 검증, 모르는 키는 통과 (`passthrough()`).
+ *   기존 .env에 schema 미정의 키들(NODE_ENV, S3_*, SENTRY_DSN, PINO_* 등)이
+ *   많아 strict()로 가면 부팅 실패. 단계적 strict화는 별도 작업.
+ * - REDIS_*는 use case 미정 상태라 optional. 의존성 + NestJS 모듈 등록
+ *   PR에서 required로 전환.
+ */
+export const envSchema = z
+  .object({
+    // Database (required) — Prisma 부팅에 필수
+    DATABASE_URL: z.string().url(),
+
+    // JWT (required) — auth 모듈 부팅에 필수
+    ACCESS_TOKEN_SECRET: z.string().min(1),
+    REFRESH_TOKEN_SECRET: z.string().min(1),
+    ACCESS_TOKEN_EXPIRES_IN_SECONDS: z.coerce.number().int().positive(),
+    REFRESH_TOKEN_EXPIRES_IN_SECONDS: z.coerce.number().int().positive(),
+
+    // Redis — use case 미정이라 optional. 의존성/모듈 등록 PR에서 required 전환
+    REDIS_HOST: z.string().min(1).optional(),
+    REDIS_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+    REDIS_PASSWORD: z.string().min(1).optional()
+  })
+  .passthrough()
+
+export type Env = z.infer<typeof envSchema>
+
+/**
+ * ConfigModule.forRoot({ validate }) 콜백.
+ * 검증 실패 시 zod-validation-error로 사람이 읽을 수 있는 메시지로 변환 후 throw.
+ */
+export function validateEnv(config: Record<string, unknown>): Env {
+  const result = envSchema.safeParse(config)
+  if (!result.success) {
+    throw new Error(
+      `환경변수 검증 실패:\n${fromError(result.error).toString()}`
+    )
+  }
+  return result.data
+}

--- a/infra/k8s/api/base/deployment.yaml
+++ b/infra/k8s/api/base/deployment.yaml
@@ -29,6 +29,8 @@ spec:
                 name: amang-db-credentials
             - secretRef:
                 name: minio-s3-credentials
+            - secretRef:
+                name: redis-credentials
           livenessProbe:
             httpGet:
               path: /health

--- a/infra/k8s/api/overlays/production/kustomization.yaml
+++ b/infra/k8s/api/overlays/production/kustomization.yaml
@@ -21,6 +21,12 @@ patches:
       - op: add
         path: /data/SENTRY_DSN
         value: "https://7f3e7589d4887e3e575dee9efcd44d73@o4511134421286912.ingest.us.sentry.io/4511134425677824"
+      - op: add
+        path: /data/REDIS_HOST
+        value: "redis.amang-redis-production.svc.cluster.local"
+      - op: add
+        path: /data/REDIS_PORT
+        value: "6379"
     target:
       kind: ConfigMap
       name: api-config

--- a/infra/k8s/api/overlays/staging/kustomization.yaml
+++ b/infra/k8s/api/overlays/staging/kustomization.yaml
@@ -18,6 +18,12 @@ patches:
       - op: add
         path: /data/NODE_ENV
         value: "development"
+      - op: add
+        path: /data/REDIS_HOST
+        value: "redis.amang-redis-staging.svc.cluster.local"
+      - op: add
+        path: /data/REDIS_PORT
+        value: "6379"
     target:
       kind: ConfigMap
       name: api-config

--- a/infra/k8s/redis/overlays/production/sealed-redis-password.yaml
+++ b/infra/k8s/redis/overlays/production/sealed-redis-password.yaml
@@ -9,5 +9,10 @@ spec:
     REDIS_PASSWORD: AgAhgs7c8c+gKNwlGDXVP9OLbvttIW+IK7bVm5q+llFrwZbQLDOXsgg/njS9MUiLCsOwnPAOZ/nX/qNQLpYdC8J+7NPMrQHUkC4WLRZVWu/dp41YTGt2cTdC10jSzuUXBYwRl59r0ayVF2X7QbDex3JDjWLXTbNOKe+55i29S4jqEnk2shQB0Tdxg7uiSDLdpHF6uL1uuojRV57S4aVT2WSdNevYaczBPcHn1k7MPlvyL2FNPIPwOeo5SYm6e973ExAyZtngb3Un+QnL1UNHKqNqFUDzMmt9s6RA+iT6zAE+ZB/vjdDxIKOrB1bdJWItAmEsrvaJ06T3xaZ0YV9RTGKowhiJyqCONOzx/e4Y39FiAlS+jLHut8tyh7xwsNrPKvLoxs0HrMpLHp5/LSRy4vchX7yzWzp841BvCfRUz2Kwbxh6IT46MJi2OwedguvmgAh3TUQpwCV9qTgZgP4naAh2P5z7uV1l4LDBTDfPoaIj09hWfvHOA0UWYsT5erDk0fddDpda504VLQ83OjZWc3SJJQ2L00lLlaKvR9NdNC92eYvws7C7oFiS4PD9ApMT4vY/G2/6ETLWdl2T9BSDjtersnzuo2WOLe3aojan1Is7iwYa5pAve52eqwG2PODEApJy3R4sRWRan3XbslV3hCja2GeAIuU9m3icJqufQLWuCiLQknG8rCm38glL+v7TZsbryWtvmEtnF2Tn8rtS6Qaj7jE2vCQzDBNrWx+lDMoDZA==
   template:
     metadata:
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: amang-api-production
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: amang-api-production
       name: redis-credentials
       namespace: amang-redis-production

--- a/infra/k8s/redis/overlays/staging/sealed-redis-password.yaml
+++ b/infra/k8s/redis/overlays/staging/sealed-redis-password.yaml
@@ -9,5 +9,10 @@ spec:
     REDIS_PASSWORD: AgCDYRwwK3iMTn7QThvHp6PgdPP+7x7Eyyl2ecSbwV1WHMNia5chA6g8CxlqDgjXsgbLo3IYcMHTIFaqBZfHh5kIbK0wXvtwK0toS141GDcrvUWpKSWANLb5dAR0g0n6jZJF2LRICW757RBDSR1BuOWLA61ldsvbrxszVVYGazvremVpBYTWQBspvyO7flZdmAQpHEO06EgA7Zd0CRgJlsDWJuwzaid+1qpl40xn8s0TNDBvHB2ENFLuKasfdTY2hagBZuA+gL1HvrtKZ3TIjbeGlpupKzyktwyYWDUjCxAlrYBMOCQRZ0b1ixbvWk0hrVWV28QL+s+F+A8wju/X1rUXFhRFEPGteKgEv9cUpEuFjw+UHJIqHX/0le4nibo61XJAC4yBE2Pz2WOqK/8JDkuzWdNXjXAp8fIg3GJZrTBsKOdQRFIpJOSewV5S0yPefH4dxWAR9SHdN+0W0UpBhSrhd26CyT+dmmg8HplnSfgngA0ukGLIiktBO+2Z11qzyzmyu+cJhjLublsoeinnTwPOP1p29FxxjCpat7yZfP3k5jeIYA1sCTWW5WD+j0Cri2MHeEVhzt3/6D3ja4Hxp9ZdYOS5qe0yE9ZiGDt8kNyWIx/fiH1O6z2fIIzgizuh/ZNfXRqHjHckLuHf5VR88kSVXvjpYkcreqw9X4kl4GNrLkjII7nqllgl78fmvWrd6e9t55T8R12GMMFoqN1AFoe6kIOg++Jf63cJnalSDOU8VQ==
   template:
     metadata:
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: amang-api-staging
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: amang-api-staging
       name: redis-credentials
       namespace: amang-redis-staging

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       sql-formatter:
         specifier: ^15.7.3
         version: 15.7.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
       zod-validation-error:
         specifier: ^4.0.2
         version: 4.0.2(zod@3.25.76)


### PR DESCRIPTION
## 🚀 작업 내용

PR [#473](https://github.com/skku-amang/main/pull/473)·[#483](https://github.com/skku-amang/main/pull/483) + [homelab#190](https://github.com/manamana32321/homelab/pull/190)으로 Redis 인프라 + 모니터링이 갖춰졌고, 이번 PR은 **클라이언트-side 셋업**을 use case 결정 전에 선행합니다. 의존성 종류(BullMQ / ioredis / cache-manager 등)만 use case에 의존하고, 나머지(Secret 복제 / env 주입 / 로컬 dev / env validation)는 모두 미리 확정 가능.

> 👉 use case 확정 후 잔여 PR은 매우 작음: \`pnpm add <library>\` + NestJS 모듈 등록 1-2줄 + zod schema에서 REDIS_* \`.optional()\` 제거 + 사용 코드.

### 변경

#### 1. SealedSecret reflector (재sealing 불필요)
\`infra/k8s/redis/overlays/{env}/sealed-redis-password.yaml\`의 \`template.metadata.annotations\`에 reflector annotation 추가. \`encryptedData\`는 손대지 않음 (template은 unsealed). 머지 후 \`amang-api-{env}\` ns에 \`redis-credentials\` Secret 자동 복제 — 기존 \`amang-db-credentials\` 패턴과 동일.

#### 2. api ConfigMap REDIS_HOST/PORT (환경별)
\`infra/k8s/api/overlays/{env}/kustomization.yaml\` patches에 추가:
- staging → \`redis.amang-redis-staging.svc.cluster.local:6379\`
- production → \`redis.amang-redis-production.svc.cluster.local:6379\`

#### 3. api Deployment envFrom
\`infra/k8s/api/base/deployment.yaml\`에 \`secretRef: redis-credentials\` 1줄 추가 → 모든 api pod에 \`REDIS_PASSWORD\` 환경변수 자동 주입.

#### 4. 로컬 docker-compose
\`apps/api/docker-compose.yml\`에 \`redis:8.4-alpine\` 서비스 추가:
- \`requirepass\` (default \`\${REDIS_PASSWORD:-redis}\` — 운영과 동일 코드 경로)
- \`appendonly yes\` (AOF persistence)
- healthcheck (\`redis-cli ping\`)

#### 5. apps/api/.env(.example) REDIS_* 키
\`\`\`
REDIS_HOST=localhost
REDIS_PORT=6379
REDIS_PASSWORD=redis
\`\`\`

#### 6. zod env validation (fail-fast)
\`apps/api/src/common/config/env.schema.ts\` 신규 + \`app.module.ts\`의 \`ConfigModule.forRoot({ validate })\` 등록. 부팅 시점 env 검증 → 잘못된 설정으로 한참 후 발견되는 패턴 차단.

**정책**:
- \`passthrough()\` — 알려진 키만 strict, 기존 \`.env\`의 미정의 키(\`NODE_ENV\`, \`S3_*\`, \`SENTRY_DSN\` 등)는 통과. brownfield 점진적 strict화
- \`REDIS_*\`는 use case 미정이라 \`optional()\` — 이번 PR 머지 시점 race 방지 (SealedSecret reflector 복제 vs api Deployment 재시작 타이밍). 의존성 PR에서 required 전환

\`zod\` 의존성을 apps/api에 직접 추가 (이전엔 nestjs-zod transitive로만 존재).

### 핵심 결정

| 항목 | 결정 | 근거 |
|---|---|---|
| Env 형식 | \`REDIS_HOST/PORT/PASSWORD\` 분리 | ConfigMap(host/port) + Secret(password) 자연 분리. 기존 db 패턴 일관성. URL 단일 string은 escape 이슈 + Secret/ConfigMap 분리 불가 |
| 로컬 비번 | 박기 (default \`redis\`) | 운영과 코드 경로 일관성 (REDIS_PASSWORD 항상 처리) |
| zod \`passthrough()\` | strict() 아님 | 기존 \`.env\` 미정의 키 다수 → strict면 거대 PR 필요. 점진적 strict화 |

## 📸 스크린샷(선택)

해당 없음 (인프라 + 백엔드 설정).

## 🔗 관련 이슈

- 후속: [#473](https://github.com/skku-amang/main/pull/473) (Redis 인프라), [#483](https://github.com/skku-amang/main/pull/483) (Blackbox NetworkPolicy 핫픽스)
- 관련: [homelab#190](https://github.com/manamana32321/homelab/pull/190) (ArgoCD App + ServiceMonitor)

## 🙏 리뷰어에게

1. **\`zod\` 의존성 추가** — 이번 PR이 첫 사용처. 이후 다른 zod 사용 가능
2. **env validation \`passthrough()\` 결정** — 기존 .env에 schema 미정의 키 많아서. strict로 가려면 별도 큰 작업
3. **\`REDIS_*\` optional 시작** — use case 확정 후 required 전환 명시. 머지 시점 race 방지 의도
4. **재sealing 불필요한 이유** — reflector annotation은 SealedSecret의 unsealed template.metadata에 박힘. encryptedData만 sealing됨

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title
- [x] PR은 기본 라벨 없이 제출 (CONTRIBUTING.md 컨벤션)
- [ ] 관련 이슈 — 기존 이슈 없음, PR cross-link로 충분