### PR TITLE
feat(web): captureConsoleIntegration 활성화 (ADR-0001 Phase 5)

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 
 // replayIntegration/feedbackIntegration은 브라우저 전용 — SSR에서 존재하지 않음
-const integrations = []
+const integrations = [
+  Sentry.captureConsoleIntegration({ levels: ["error", "warn"] })
+]
 
 if (typeof window !== "undefined" && Sentry.replayIntegration) {
   integrations.push(Sentry.replayIntegration())


### PR DESCRIPTION
## 🚀 작업 내용

[ADR-0001](docs/architecture/adr/0001-telemetry-routing.md) Phase 5. 결정 3 (FE OTel 보류, Sentry SDK 유지) 의 부수 작업으로 식별된 갭 메움.

브라우저 `console.error` / `console.warn` → Sentry Issue 자동 캡처. 5줄 변경.

## 변경

[apps/web/sentry.client.config.ts](apps/web/sentry.client.config.ts):
```diff
-const integrations = []
+const integrations = [
+  Sentry.captureConsoleIntegration({ levels: ["error", "warn"] })
+]
```

## 정정 — 이슈 본문 vs 실제 구현

이슈 본문은 `consoleLoggingIntegration` (Sentry Logs로 캡처)로 표기되어 있었으나, **`captureConsoleIntegration` (Issues로 캡처)으로 전환**해서 구현. 사유:

| 항목 | captureConsoleIntegration (선택) | consoleLoggingIntegration |
|---|---|---|
| 캡처 대상 | Sentry **Issues** | Sentry **Logs** (별도 view) |
| Dedup | ✅ | 제한적 |
| sentry-triage 스킬([#456](https://github.com/skku-amang/main/pull/456))이 잡음 | ✅ | ❌ Logs는 트리아지 플로우 밖 |
| ADR 결정 3 ("사용자 영역은 Sentry") 정렬 | ✅ | ✅ |

이슈 #497에 정정 코멘트 추가 예정.

## 검증

| 단계 | 방법 |
|---|---|
| 머지 후 ~3-5분 GHA 빌드 + Vercel 프로덕션 배포 | 자동 |
| 의도적 `console.error("phase 5 verification")` | DevTools에서 1회 호출 |
| Sentry [amang-23/web](https://amang-23.sentry.io/issues/?project=4511134423515136) Issue로 도착 확인 | 수동 |

## 후속 — 노이즈 모니터링

이슈 본문 명시:
> staging에서 1주 가동 후 노이즈 비율 확인, 필요 시 levels 조정 (`error` 만 남기기)

머지 후 1주 후 Sentry stats 확인 → noisy하면 `levels: ["error"]`로 좁히는 follow-up commit. 별도 이슈 등록 불필요 (본 이슈에서 close).

## 🙏 리뷰어에게

- `captureConsoleIntegration` 선택 사유에 동의하시는지
- `levels: ["error", "warn"]` 시작 levels이 적절한지 (보수적으로 "error"만 시작할 수도)

## 🔗 관련 이슈

Refs #497

- ADR Phase 1 PR: #498 (BE OTel SDK, 본 PR과 독립)
- 관련: [#456 sentry-triage 스킬](https://github.com/skku-amang/main/pull/456) — 본 PR이 만들어내는 console error 이슈를 자동 트리아지

## ✅ 체크리스트

- [x] Conventional commits 형식
- [x] Refs 이슈 연결
- [x] `pnpm turbo lint check-types --filter=web` 통과 (0 errors, 75 pre-existing warnings)
- [ ] 머지 후 production에서 console.error 캡처 검증
