### PR TITLE
feat(api,docs): ADR-0001 v3 — Signal split + Sentry Logs (Beta) dual write

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -7,8 +7,9 @@ Sentry.init({
 
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
+  enableLogs: true,
 
-  integrations: [nodeProfilingIntegration()],
+  integrations: [nodeProfilingIntegration(), Sentry.pinoIntegration()],
 
   // 헬스체크 503은 Blackbox Exporter에서 모니터링하므로 Sentry 노이즈 방지 (API-4)
   beforeSend(event) {

--- a/docs/architecture/adr/0001-telemetry-routing.md
+++ b/docs/architecture/adr/0001-telemetry-routing.md
@@ -32,18 +32,18 @@ AMANG은 두 관측 스택을 보유:
 
 ### 신호별 라우팅
 
-| 신호 | Origin | Destination | 이유 |
-|---|---|---|---|
-| **App errors** (FE + BE) | `@sentry/nextjs`, `@sentry/nestjs` | Sentry Issues | dedup, source maps, breadcrumbs, sentry-triage 스킬 자동화 |
-| **App traces** (FE + BE) | Sentry SDK (내부 OTel) | Sentry Performance | N+1 자동 감지, slow endpoint, replay/error correlation |
-| **Session replay** (FE) | `@sentry/nextjs` | Sentry Replay | 대체 도구 없음 |
-| **User feedback widget** (FE) | `@sentry/nextjs` | Sentry | UI 통합 |
-| **Source maps** (FE + BE) | sentry-cli (build-time) | Sentry | production stack trace symbolication |
-| **Application Metrics** (도입 시) | `Sentry.metrics.*` API | Sentry App Metrics (Beta) | NSM 측정, 향후 |
-| **App logs** (BE pino) | stdout | Loki (via Promtail) | mature, 30d retention, LogQL aggregation. Sentry Logs는 아직 beta — 도입 보류 |
-| **Pod / Node 메트릭** | kube-state-metrics, node-exporter | Prometheus → Grafana | Sentry 범위 밖 (인프라 영역) |
-| **외부 가용성** | Blackbox Exporter | Prometheus → Grafana | 외부 prober (Sentry로 갈 일 없음) |
-| **분산 trace 장기 보존** (선택) | 사용 시 OTel SDK + Tempo | Tempo (Grafana) | Sentry 90일 한계 넘는 retention 필요 시. **현재는 미사용** |
+| 신호                              | Origin                             | Destination                                                         | 이유                                                                                                                                                                                                     |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **App errors** (FE + BE)          | `@sentry/nextjs`, `@sentry/nestjs` | Sentry Issues                                                       | dedup, source maps, breadcrumbs, sentry-triage 스킬 자동화                                                                                                                                               |
+| **App traces** (FE + BE)          | Sentry SDK (내부 OTel)             | Sentry Performance                                                  | N+1 자동 감지, slow endpoint, replay/error correlation                                                                                                                                                   |
+| **Session replay** (FE)           | `@sentry/nextjs`                   | Sentry Replay                                                       | 대체 도구 없음                                                                                                                                                                                           |
+| **User feedback widget** (FE)     | `@sentry/nextjs`                   | Sentry                                                              | UI 통합                                                                                                                                                                                                  |
+| **Source maps** (FE + BE)         | sentry-cli (build-time)            | Sentry                                                              | production stack trace symbolication                                                                                                                                                                     |
+| **Application Metrics** (도입 시) | `Sentry.metrics.*` API             | Sentry App Metrics (Beta)                                           | NSM 측정, 향후                                                                                                                                                                                           |
+| **App logs** (BE pino)            | stdout (pino)                      | Loki (via Promtail) **+** Sentry Logs (via `pinoIntegration`, Beta) | dual write. Loki = operational store (30d retention, LogQL aggregation, kubectl logs 지원). Sentry Logs = incident-context store (Issue UI에 inline log timeline). Beta 위험은 Loki fallback이 있어 작음 |
+| **Pod / Node 메트릭**             | kube-state-metrics, node-exporter  | Prometheus → Grafana                                                | Sentry 범위 밖 (인프라 영역)                                                                                                                                                                             |
+| **외부 가용성**                   | Blackbox Exporter                  | Prometheus → Grafana                                                | 외부 prober (Sentry로 갈 일 없음)                                                                                                                                                                        |
+| **분산 trace 장기 보존** (선택)   | 사용 시 OTel SDK + Tempo           | Tempo (Grafana)                                                     | Sentry 90일 한계 넘는 retention 필요 시. **현재는 미사용**                                                                                                                                               |
 
 ### 아키텍처 다이어그램
 
@@ -58,8 +58,9 @@ kube-state-metrics ──→ Prometheus  (Pod 상태, replica, restart)
 node-exporter      ──→ Prometheus  (CPU, memory, disk, network)
 Blackbox Exporter  ──→ Prometheus  (외부 가용성 probe)
 
-[App logs (BE only) → 홈랩 Loki]
-apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로그)
+[App logs (BE only) → dual write]
+apps/api ──pino stdout──→ Promtail ──→ Loki         (operational store)
+apps/api ──pinoIntegration (in-process)──→ Sentry   (incident-context store, Beta)
 
 [모두 Grafana UI에서 cross-cut 조회 가능]
 ```
@@ -80,12 +81,12 @@ apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로�
 
 ### 잃는 것 (의식적)
 
-| 항목 | 영향 | 완화 |
-|---|---|---|
-| **vendor lock-in 고착화** | Sentry SaaS 의존도 ↑. FE+BE 양쪽에서 핵심 신호가 Sentry 통과 | 무료 티어 quota 충분 (5k errors + 5M spans / 월). 진짜 lock-in 비용은 미래 마이그레이션 — 그때는 Sentry SDK가 wrap한 OTel을 외부로 뺄 수 있음 (이미 OTel 기반) |
-| **로그-trace correlation 불완전** | BE pino logs는 Loki, traces는 Sentry → trace_id로 jump하려면 양쪽 라벨링 필요 | 후속 작업: pino mixin에 `Sentry.getActiveSpan()?.spanContext().traceId` 자동 첨부 |
-| **trace 장기 보존 부재** | Sentry 90일. Tempo 미사용 (30d retention) | AMANG 트래픽에서 90일이면 충분. 필요시 Tempo 활성화 가능 (홈랩에 이미 가동 중) |
-| **Grafana Sentry datasource 미도입** | 단일 pane of glass 부재 — Sentry는 Sentry, Grafana는 Grafana | 도입 가능 (별도 결정). 현재는 분리 UI 수용 |
+| 항목                                 | 영향                                                                          | 완화                                                                                                                                                           |
+| ------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **vendor lock-in 고착화**            | Sentry SaaS 의존도 ↑. FE+BE 양쪽에서 핵심 신호가 Sentry 통과                  | 무료 티어 quota 충분 (5k errors + 5M spans / 월). 진짜 lock-in 비용은 미래 마이그레이션 — 그때는 Sentry SDK가 wrap한 OTel을 외부로 뺄 수 있음 (이미 OTel 기반) |
+| **로그-trace correlation 불완전**    | BE pino logs는 Loki, traces는 Sentry → trace_id로 jump하려면 양쪽 라벨링 필요 | 후속 작업: pino mixin에 `Sentry.getActiveSpan()?.spanContext().traceId` 자동 첨부                                                                              |
+| **trace 장기 보존 부재**             | Sentry 90일. Tempo 미사용 (30d retention)                                     | AMANG 트래픽에서 90일이면 충분. 필요시 Tempo 활성화 가능 (홈랩에 이미 가동 중)                                                                                 |
+| **Grafana Sentry datasource 미도입** | 단일 pane of glass 부재 — Sentry는 Sentry, Grafana는 Grafana                  | 도입 가능 (별도 결정). 현재는 분리 UI 수용                                                                                                                     |
 
 ## Alternatives Considered
 
@@ -94,6 +95,7 @@ apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로�
 > 핵심 원칙: 모든 텔레메트리는 OTLP로 OTel Collector에 보낸다. OTel 스펙으로 표현 불가능한 3가지 (Session Replay / Feedback widget / Source maps) 만 Sentry SDK·CLI로 직송.
 
 **거부 이유**:
+
 - "BE traces를 Sentry+Tempo 양쪽으로 fan-out" 설계가 `@sentry/opentelemetry` 브릿지 패키지 필요화 → 두 OTel 인스턴스(Sentry 내부 + 사용자 manual)가 같은 신호 경쟁 → [PR #498](https://github.com/skku-amang/main/pull/498) 리뷰에서 두 차례 디버깅 비용 발생 (SentrySampler `tracesSampleRate` 회귀 + `/health` filter 누락)
 - "예외 3개" enumerate 부담 + 시간 지나며 예외 늘어날 위험 (실제로 FE OTel 보류 Decision 3가 표와 자기 모순)
 - 1인 운영자 mental model 부하 ↑
@@ -105,6 +107,7 @@ apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로�
 > 핵심 원칙: FE 모든 텔레메트리는 Sentry로, BE 모든 텔레메트리는 홈랩(OTel Collector 경유)으로 보낸다.
 
 **거부 이유**:
+
 - **v1 PR #498의 디버깅 비용 트라우마 → over-correction**: 진짜 비용 원인은 "한 신호를 두 SDK가 동시 캡처" (fan-out 설계)였지 "Sentry+OTel 공존" 자체가 아님. Sentry SDK v8+가 이미 OTel을 wrap한다는 사실을 명확히 인식 못 함
 - **sentry-triage 스킬 ([#456](https://github.com/skku-amang/main/pull/456)) BE 부분 절반 폐기**: 이미 투자한 자동화 자산 손실
 - **N+1 / slow endpoint 자동 감지 손실**: Sentry Performance의 강점이 BE에 적용 안 됨. NestJS+Prisma 환경에서 직접적 비용
@@ -152,6 +155,6 @@ apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로�
 - **2026-05-05 v3**: Signal split 모델로 재작성. 핵심 인사이트는 두 가지:
   1. `@sentry/nestjs` v10이 내부적으로 OpenTelemetry를 wrap한다는 사실 — "Sentry vs OTel" 이분법 outdated
   2. v1 PR #498의 진짜 비용 원인은 "한 신호 fan-out 설계"였지 "Sentry+OTel 공존"이 아니었음
-  v2의 over-correction을 거부하고 v0 코드 상태(현 main)에 정합하는 ADR로 명문화. 이 journey에서 v1·v2의 거부 사유를 Alternatives Considered에 enumerate
+     v2의 over-correction을 거부하고 v0 코드 상태(현 main)에 정합하는 ADR로 명문화. 이 journey에서 v1·v2의 거부 사유를 Alternatives Considered에 enumerate
 - **2026-05-05 v2**: KISS 원칙 충실 — OTelcol single egress 모델 → Tier split 모델로 재작성. PR #502에 작성됐으나 머지 전 v3 검토 거쳐 close
 - **2026-05-05 v1**: 초안 작성 → 결정 4건 채움 → Accepted. PR #491로 머지됨

--- a/docs/architecture/adr/0001-telemetry-routing.md
+++ b/docs/architecture/adr/0001-telemetry-routing.md
@@ -1,214 +1,157 @@
-# ADR-0001: 텔레메트리 라우팅 — OTelcol 단일 egress + Sentry 역할 분담
+# ADR-0001: 텔레메트리 라우팅 — Signal split (incident analysis = Sentry / infra = 홈랩)
 
-**작성일**: 2026-05-05
+**작성일**: 2026-05-05 (v3 재작성)
 **상태**: Accepted
 **작성자**: JSON (+ Claude Code 협업)
-**관련 이슈**: [#490](https://github.com/skku-amang/main/issues/490)
+**관련 이슈**: [#490](https://github.com/skku-amang/main/issues/490) (원안)
+**Supersedes**: [PR #491 ADR initial](https://github.com/skku-amang/main/pull/491) (v1), [PR #502 ADR v2](https://github.com/skku-amang/main/pull/502) (closed, not merged)
 
 ## Context
 
-현재 AMANG의 텔레메트리 수집은 두 스택이 단절된 상태로 가동 중이다.
+AMANG은 두 관측 스택을 보유:
 
-| 신호 | FE (`apps/web`) | BE (`apps/api`) |
-|---|---|---|
-| Logs | SSR pod stdout만 (Promtail→Loki) | pino → stdout → Loki |
-| Metrics | 없음 (Vercel Analytics는 페이지뷰만) | 앱 메트릭 없음 |
-| Traces | Sentry (`tracesSampleRate: 1.0`) | Sentry + Profiling |
-| Errors / Replay / Feedback | Sentry SDK 직송 | Sentry SDK 직송 |
+- **Sentry SaaS** (`amang-23`): errors, traces (incl. Prisma SQL via pg instrumentation), replay, feedback widget, source maps, Application Metrics (Beta). **사용자 incident 분석에 강함**
+- **홈랩 K3s** (`observability` namespace): OTel Collector + Loki + Prometheus + Tempo + Grafana + Promtail + Blackbox + Pyroscope. **인프라 관측·장기 보존·PromQL/LogQL에 강함**
 
-홈랩 K3s에는 이미 다음 관측성 스택이 가동 중이다:
+본 ADR은 v1/v2를 거쳐 v3에 이른 결과. journey는 Alternatives Considered 섹션에 거부 사유와 함께 enumerate.
 
-| 컴포넌트 | 매니페스트 | 비고 |
-|---|---|---|
-| **OTel Collector** | [k8s/observability/otel-collector/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/otel-collector) | OTLP receiver, 3-way fan-out (Loki/Prometheus/Tempo) 구성됨 |
-| **Loki** | [k8s/observability/loki/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/loki) | logs |
-| **Prometheus** | [k8s/observability/prometheus/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/prometheus) | metrics |
-| **Tempo** | [k8s/observability/tempo/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/tempo) | traces, single binary, 30d retention |
-| **Grafana** | [k8s/observability/grafana/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/grafana) | UI |
-| **Promtail** | [k8s/observability/promtail/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/promtail) | stdout 수집 → Loki |
-| **Blackbox Exporter** | [k8s/observability/blackbox-exporter/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/blackbox-exporter) | 외부 가용성 |
+### 주요 사실 (결정 근거)
 
-아망 앱이 Sentry로 직송하는 구조라 두 관측 스택이 단절되어 있다. 홈랩 OTelcol에 아망 신호가 들어오지 않고 있다.
-
-이 ADR은 **앱이 텔레메트리를 어디로 보내는가**(transport)와 **데이터가 최종 어디에 저장·조회되는가**(destination)를 명시적으로 분리해 결정한다.
+1. **`@sentry/nestjs` v10은 내부적으로 OpenTelemetry를 wrap** — `@opentelemetry/instrumentation-http`, `instrumentation-nestjs-core`, `instrumentation-pg` (Prisma SQL 자동 캡처), `instrumentation-redis` 등 20+ 인스트루멘테이션 자동. 사용자가 OTel SDK를 별도 설치할 필요 없음. **"Sentry vs OTel" 이분법은 outdated** — Sentry SDK v8+는 OTel + 상용 transport·UI layer
+2. **BE Sentry traces가 production에서 이미 작동 중** ([Trace Explorer](https://amang-23.sentry.io/explore/traces/?project=4511134425677824)에서 검증). 한 HTTP 요청당 12+ span 자동 캡처 (middleware, controller, Prisma SQL 포함)
+3. **AMANG app 레벨에서 emit하는 metrics는 현재 0개**. 모든 metrics는 인프라 레벨 (node-exporter, kube-state-metrics, Blackbox)에서 Prometheus가 scrape
+4. **Sentry Application Metrics는 2025년 Beta로 부활** — 2024년 deprecation 이후 재출시. counter/distribution/gauge API 사용 가능 (`@sentry/nestjs` ≥10.25.0). 향후 NSM 측정 도구로 활용 가능
 
 ## Decision
 
 ### 핵심 원칙
 
-> 모든 런타임 텔레메트리는 OTLP로 OTel Collector에 보낸다. OTel 스펙으로 표현 불가능한 3가지 (Session Replay / Feedback widget / Source maps) 만 Sentry SDK·CLI로 직송하며, 이 예외는 본 ADR에 enumerate된 것이 전부다. 새 직송 추가는 본 ADR 개정을 요구한다.
+> **사용자 incident 분석(errors, traces, replay, feedback, application metrics)은 Sentry로, 인프라 관측(K8s/Node 메트릭, 외부 가용성, 로그 집계·장기 보존, 분산 trace 장기 보존)은 홈랩(Grafana 스택)으로 보낸다. 도구 강점 영역에 따라 신호별로 분리.**
+
+이전 v2의 "tier split" (FE/BE app 기준) 과 다름 — **신호 종류에 따라 분리**. 같은 BE라도 errors는 Sentry, infra metrics는 Prometheus.
 
 ### 신호별 라우팅
 
-| 신호 | App emits via | Final backend |
-|---|---|---|
-| Application errors | OTel | Sentry (+ Loki 사본) |
-| FE Web Vitals | OTel metrics | Sentry + Prometheus |
-| FE console error/warn | OTel logs | Sentry |
-| BE HTTP / Prisma traces | OTel | Sentry + Tempo (양쪽) |
-| BE application logs (pino) | stdout (당분간) | Loki |
-| BE custom metrics | OTel metrics | Prometheus |
-| Pod / Node metrics | (앱 외부) Prometheus scrape | Prometheus |
-| Blackbox 가용성 | (앱 외부) Prometheus | Prometheus |
-| **Session Replay** | **Sentry SDK 직송** (예외) | Sentry |
-| **Feedback widget** | **Sentry SDK 직송** (예외) | Sentry |
-| **Source maps** | **sentry-cli (build-time)** (예외) | Sentry |
+| 신호 | Origin | Destination | 이유 |
+|---|---|---|---|
+| **App errors** (FE + BE) | `@sentry/nextjs`, `@sentry/nestjs` | Sentry Issues | dedup, source maps, breadcrumbs, sentry-triage 스킬 자동화 |
+| **App traces** (FE + BE) | Sentry SDK (내부 OTel) | Sentry Performance | N+1 자동 감지, slow endpoint, replay/error correlation |
+| **Session replay** (FE) | `@sentry/nextjs` | Sentry Replay | 대체 도구 없음 |
+| **User feedback widget** (FE) | `@sentry/nextjs` | Sentry | UI 통합 |
+| **Source maps** (FE + BE) | sentry-cli (build-time) | Sentry | production stack trace symbolication |
+| **Application Metrics** (도입 시) | `Sentry.metrics.*` API | Sentry App Metrics (Beta) | NSM 측정, 향후 |
+| **App logs** (BE pino) | stdout | Loki (via Promtail) | mature, 30d retention, LogQL aggregation. Sentry Logs는 아직 beta — 도입 보류 |
+| **Pod / Node 메트릭** | kube-state-metrics, node-exporter | Prometheus → Grafana | Sentry 범위 밖 (인프라 영역) |
+| **외부 가용성** | Blackbox Exporter | Prometheus → Grafana | 외부 prober (Sentry로 갈 일 없음) |
+| **분산 trace 장기 보존** (선택) | 사용 시 OTel SDK + Tempo | Tempo (Grafana) | Sentry 90일 한계 넘는 retention 필요 시. **현재는 미사용** |
 
 ### 아키텍처 다이어그램
 
 ```
-                              ┌──→ Sentry      (errors / user-facing traces / FE Vitals)
-                              │
-앱 (OTel SDK) ──→ OTelcol─────┼──→ Loki        (logs, OTLP path)
-  ├─ apps/web                  │
-  └─ apps/api                  ├──→ Prometheus  (metrics)
-                              │
-                              └──→ Tempo       (traces, 30d retention)
+[Application signals → Sentry]
+apps/web ──@sentry/nextjs──→ Sentry SaaS  (errors / traces / replay / feedback / vitals)
+apps/api ──@sentry/nestjs──→ Sentry SaaS  (errors / traces incl. Prisma SQL / metrics(beta))
+CI       ──sentry-cli────→ Sentry        (source maps, build-time)
 
-[OTelcol 우회 — 3가지 예외만]
-apps/web ──Sentry SDK 직송──→ Sentry  (Replay, Feedback widget)
-CI       ──sentry-cli────────→ Sentry  (Source maps, build-time)
+[Infra signals → 홈랩 Grafana]
+kube-state-metrics ──→ Prometheus  (Pod 상태, replica, restart)
+node-exporter      ──→ Prometheus  (CPU, memory, disk, network)
+Blackbox Exporter  ──→ Prometheus  (외부 가용성 probe)
 
-[앱 외부 — 항상 직접]
-kube-state-metrics ──→ Prometheus
-Blackbox Exporter  ──→ Prometheus
-apps/* pod stdout  ──Promtail──→ Loki  (현행 유지, 결정 4)
+[App logs (BE only) → 홈랩 Loki]
+apps/api ──pino stdout──→ Promtail ──→ Loki  (BE 구조화 로그)
+
+[모두 Grafana UI에서 cross-cut 조회 가능]
 ```
-
----
-
-## 결정 항목
-
-### 결정 1: Tempo 활용 방식
-
-**상황**: 홈랩에 Tempo가 이미 가동 중 ([k8s/observability/tempo/](https://github.com/manamana32321/homelab/tree/main/k8s/observability/tempo)). single binary mode, OTLP gRPC `tempo.observability.svc.cluster.local:4317`, 30일 retention, local-path-hdd-samsung 스토리지. **신규 도입 결정이 아니라 활용 방식 결정**.
-
-**결정**: 활용 ✅ — BE traces를 Sentry와 Tempo **양쪽**으로 fan-out
-
-**근거**:
-- 인프라 이미 존재 → 도입 비용 0
-- Sentry 90일 vs Tempo 30일 — 둘 다 hot 영역. **Sentry는 user-incident 디버깅 UI가 강하고, Tempo는 Grafana exemplar·PromQL 연동이 강함** → 같은 trace에서 다른 분석 관점 동시 활용
-- 30일 retention은 capacity-planning에 충분 (장기 통계는 Prometheus aggregate)
-- OTelcol에 Tempo exporter `otlp/trace`가 이미 구성됨 → 추가 작업 없음
-
----
-
-### 결정 2: Sampling 전략
-
-**결정**: A — Full rate (`tracesSampleRate: 1.0`)
-
-**근거**:
-- 현재 트래픽 규모(일 수백명)에서 Sentry 무료 티어 quota 부담 없음
-- Tempo는 자체 호스팅이라 비용 압박 없음
-- Tail sampling 도입은 **Collector pipeline 변경만으로 후속 전환 가능 (앱 재배포 불필요)** — late binding의 가치
-- 부활 조건: **Sentry 무료 티어 quota 80% 도달 시** tail sampling으로 전환 (에러 100% + 정상 1%, slow 100%)
-
----
-
-### 결정 3: FE OTel 도입 시점
-
-**결정**: B — FE는 Sentry SDK 유지, OTel 도입 보류
-
-**근거**:
-- Browser OTel SDK 미성숙 (`@opentelemetry/sdk-trace-web`은 GA 직전 단계)
-- Sentry의 강점이 FE에 집중됨: Session Replay, Feedback widget, Source map auto-upload, breadcrumbs — OTel이 대체 불가능한 영역이 큼
-- 본 ADR의 핵심 원칙("OTLP로 통일")과 부분 충돌 → **예외로 명시적 enumerate**
-- 부활 조건: Browser OTel SDK GA + Web Vitals OTel metrics 안정화 (6개월 후 재평가)
-
----
-
-### 결정 4: Logs OTel 도입 시점
-
-**결정**: B — pino → stdout → Promtail 경로 유지
-
-**근거**:
-- 현행 구조 안정적: nestjs-pino가 [JWT userId/X-Request-Id 자동 첨부 + redact](../../../apps/api/src/common/logger/pino-logger.config.ts) 등 충실
-- pino → OTel transport 라이브러리 추가는 **순(net) 개선 아님** — Loki는 어차피 통과하고 trace ID는 코드에서 박을 수 있음
-- 본 ADR Phase 4에서 **trace ID를 pino log에 자동 첨부**하여 Sentry/Tempo와 jump 가능하게 만드는 것이 봉합점
-- 부활 조건: BE OTel traces 1개월 안정 가동 후 OTel Logs 도입의 실익 재평가
-
----
 
 ## Consequences
 
-**기대 효과**:
-- 앱 코드의 라우팅 결정 0 — Collector config가 SSOT (homelab repo GitOps로 관리)
-- 데스티네이션 추가/제거가 앱 재배포 없이 가능 — 1인 운영자 결정 부담 ↓
-- Sentry 의존도 명시적 enumerate → 벤더 lock-in 가시화
-- Trace ID 양쪽 보존으로 incident 디버깅 시 hot store(Sentry) ↔ warm store(Tempo/Loki) jump 가능
-- 홈랩 OTelcol baseline 활용 → 신규 인프라 컴포넌트 배포 0
+### 얻는 것
 
-**비용/위험**:
-- BE OTel 도입 시 `@sentry/nestjs` trace 자동 instrumentation과 OTel auto-instrumentation 충돌 가능성 — Sentry SDK는 errors/profiling만 남기고 traces는 OTel로 위임 필요
-- Sentry exporter는 OTelcol에서 별도 추가 필요 (`otlphttp/sentry` 또는 community contrib `sentryexporter`)
-- FE OTel 보류는 일관성 비용 — ADR 예외 처리로 명시
-- Sentry OTLP traces ingest는 organization plan 활성화 확인 필요 (Phase 0)
+- **Mental model 단순화** (2줄):
+  - "사용자가 본 / 사용자에게 영향 미친 신호" → Sentry
+  - "시스템 자체의 상태" → Grafana
+- **각 도구 강점 영역에 집중**: Sentry는 incident analysis UI (replay+stack+breadcrumbs 한 화면), Grafana는 PromQL/LogQL aggregation + 장기 보존
+- **`instrument.ts` 단일 라이브러리** (`@sentry/nestjs`): OTel SDK 직접 import 0. v1 PR #498에서 충돌한 "두 OTel 인스턴스 경쟁" 패턴 회피
+- **sentry-triage 스킬 ([#456](https://github.com/skku-amang/main/pull/456))이 FE+BE 모두에 적용**: BE error도 자동 트리아지
+- **N+1 / slow endpoint 자동 감지**: Sentry Performance가 trace 패턴 분석. NestJS+Prisma 환경에서 직접적 가치
+- **production stack trace symbolication 유지** ([#499](https://github.com/skku-amang/main/issues/499))
+- **NSM 측정 path 열림**: PostHog 보류 결정 ([project_analytics_epic.md](memory)) 우회 가능 — `Sentry.metrics.increment("team.formed")` 같은 1줄 추가로 측정 시작
 
-**OTelcol 변경 범위 (Phase 2 scope)**:
-- 추가: Sentry exporter (`otlphttp/sentry`)
-- 추가: 라우팅 (errors → Sentry+Loki 사본 / traces → Sentry+Tempo)
-- 유지: 기존 OTLP receiver, Loki/Prometheus/Tempo exporter
-- **신규 컴포넌트 배포 0** — 기존 collector values.yaml만 수정
+### 잃는 것 (의식적)
+
+| 항목 | 영향 | 완화 |
+|---|---|---|
+| **vendor lock-in 고착화** | Sentry SaaS 의존도 ↑. FE+BE 양쪽에서 핵심 신호가 Sentry 통과 | 무료 티어 quota 충분 (5k errors + 5M spans / 월). 진짜 lock-in 비용은 미래 마이그레이션 — 그때는 Sentry SDK가 wrap한 OTel을 외부로 뺄 수 있음 (이미 OTel 기반) |
+| **로그-trace correlation 불완전** | BE pino logs는 Loki, traces는 Sentry → trace_id로 jump하려면 양쪽 라벨링 필요 | 후속 작업: pino mixin에 `Sentry.getActiveSpan()?.spanContext().traceId` 자동 첨부 |
+| **trace 장기 보존 부재** | Sentry 90일. Tempo 미사용 (30d retention) | AMANG 트래픽에서 90일이면 충분. 필요시 Tempo 활성화 가능 (홈랩에 이미 가동 중) |
+| **Grafana Sentry datasource 미도입** | 단일 pane of glass 부재 — Sentry는 Sentry, Grafana는 Grafana | 도입 가능 (별도 결정). 현재는 분리 UI 수용 |
 
 ## Alternatives Considered
 
-### 대안 1: Sentry 일원화 (홈랩 폐기)
+### v1 — OTelcol single egress + Sentry 3 예외 enumerate ([PR #491](https://github.com/skku-amang/main/pull/491))
+
+> 핵심 원칙: 모든 텔레메트리는 OTLP로 OTel Collector에 보낸다. OTel 스펙으로 표현 불가능한 3가지 (Session Replay / Feedback widget / Source maps) 만 Sentry SDK·CLI로 직송.
 
 **거부 이유**:
-- Pod CPU/메모리/디스크 메트릭 부재 → capacity planning 불가 (critical)
-- PromQL/LogQL 표현력 손실
-- Sentry quota 비용 급증 위험
-- 무제한 log retention 손실
-- 홈랩 관측성 스택(이미 운영 중) 자산 폐기
+- "BE traces를 Sentry+Tempo 양쪽으로 fan-out" 설계가 `@sentry/opentelemetry` 브릿지 패키지 필요화 → 두 OTel 인스턴스(Sentry 내부 + 사용자 manual)가 같은 신호 경쟁 → [PR #498](https://github.com/skku-amang/main/pull/498) 리뷰에서 두 차례 디버깅 비용 발생 (SentrySampler `tracesSampleRate` 회귀 + `/health` filter 누락)
+- "예외 3개" enumerate 부담 + 시간 지나며 예외 늘어날 위험 (실제로 FE OTel 보류 Decision 3가 표와 자기 모순)
+- 1인 운영자 mental model 부하 ↑
 
-**부활 조건**: 사실상 없음. 홈랩 스택을 폐기할 일이 없는 한 부적합.
+**부활 조건**: 사실상 없음. Sentry SDK가 내부적으로 OTel을 wrap하고 있어 "Sentry vs OTel" 이분법 자체가 outdated.
 
-### 대안 2: 홈랩 스택 일원화 (Sentry 폐기)
+### v2 — Tier split (FE Sentry / BE 홈랩) ([PR #502](https://github.com/skku-amang/main/pull/502), closed)
 
-**거부 이유**:
-- 에러 그룹화/dedup 손실 — Loki에서 같은 에러 100번 다 따로 보임
-- Source map 자동 적용된 stack trace 손실
-- Session Replay 대체 거의 불가
-- Feedback widget 직접 구현 부담
-- breadcrumbs / user context 자동 첨부 손실
-- sentry-triage 스킬([#456](https://github.com/skku-amang/main/pull/456)) 자산 폐기
-- 셀프호스팅 Sentry 가능하지만 1인 인프라 운영 부담 위 (PostgreSQL HA + ClickHouse + Symbolicator)
-
-**부활 조건**: Sentry SaaS 가격 정책 급변 또는 데이터 주권 요구 발생 시.
-
-### 대안 3: 앱 직송 (현재 상태) 유지
+> 핵심 원칙: FE 모든 텔레메트리는 Sentry로, BE 모든 텔레메트리는 홈랩(OTel Collector 경유)으로 보낸다.
 
 **거부 이유**:
-- 앱이 destination 결정 책임을 짐 → 변경 시 앱 재배포 필요
-- 라우팅 로직이 앱 코드에 분산 → SSOT 부재
-- 두 스택의 봉합점(trace ID correlation) 구현 어려움
-- 홈랩 OTelcol baseline 미활용
+- **v1 PR #498의 디버깅 비용 트라우마 → over-correction**: 진짜 비용 원인은 "한 신호를 두 SDK가 동시 캡처" (fan-out 설계)였지 "Sentry+OTel 공존" 자체가 아님. Sentry SDK v8+가 이미 OTel을 wrap한다는 사실을 명확히 인식 못 함
+- **sentry-triage 스킬 ([#456](https://github.com/skku-amang/main/pull/456)) BE 부분 절반 폐기**: 이미 투자한 자동화 자산 손실
+- **N+1 / slow endpoint 자동 감지 손실**: Sentry Performance의 강점이 BE에 적용 안 됨. NestJS+Prisma 환경에서 직접적 비용
+- **production stack trace symbolication 손실**: source map 자동 적용이 안 됨 → `dist/main.js:NNN`만 보임
+- **mental model 단순화 vs 도구 강점 활용의 균형이 KISS만 보고 강점 무시**: "1줄 mental model"이 매력적이지만 실제 사용 강점을 잃는 게 더 큰 비용
 
-**부활 조건**: 없음. 본 ADR이 거부하려는 상태.
+**부활 조건**: AMANG이 Sentry SaaS를 의도적으로 끊어야 할 외부 사유 발생 시 (예: 데이터 주권 강력 요구, Sentry 가격 정책 급변).
 
----
+### v3 (현재) — Signal split (incident = Sentry / infra = 홈랩)
 
-## 후속 작업 (구현 이슈로 분기)
+상기 Decision 섹션 참조.
 
-본 ADR이 `Accepted`된 후 아래 이슈를 생성한다.
+## 후속 작업
 
-- [ ] **Phase 0**: Sentry OTLP ingest 활성화 확인 (organization plan, endpoint, auth header 형식)
-- [ ] **Phase 1**: BE OTel SDK 도입 ([apps/api/src/instrument.ts](../../../apps/api/src/instrument.ts) 확장 — `@opentelemetry/sdk-node` + auto-instrumentation, Sentry SDK는 errors/profiling만)
-- [ ] **Phase 2**: Collector pipeline 확장 (homelab repo PR — Sentry exporter 추가, 라우팅 — **기존 OTelcol values.yaml 수정만**)
-- [ ] **Phase 3**: Trace ID correlation 봉합 (pino log에 `trace_id` 자동 첨부, Grafana 대시보드 trace ID input → Sentry/Tempo/Loki jump 링크)
-- [ ] **Phase 4**: API `/metrics` exporter (`@willsoto/nestjs-prometheus` + ServiceMonitor) — OTel metrics와 별개로 RED 메트릭 SLO 정의용
-- [ ] **Phase 5** (선택): FE consoleLoggingIntegration 활성화 — Sentry SDK 유지 결정의 부수 작업
+본 ADR v3가 Accepted된 후:
 
-> Phase 5 (Tempo 배포)는 **삭제** — 이미 가동 중.
+- [x] PR #502 (v2) close as superseded — 완료
+- [ ] **신규 이슈 — Sentry Application Metrics 도입** (`team.formed`, `signup.completed` counter 2개). [project_analytics_epic.md](memory) 분석 인프라 에픽 부분 재오픈
+- [ ] **신규 이슈 — Trace-log correlation 봉합**: pino mixin에 `Sentry.getActiveSpan()?.spanContext().traceId` 자동 첨부 → Loki query시 trace_id 라벨로 Sentry jump 가능
+- [ ] **신규 이슈 — sentry-triage 스킬 BE 적용 확장**: 현재 FE 위주 자동화를 BE 에러까지
+- [x] [#494 OTelcol Sentry exporter](https://github.com/skku-amang/main/issues/494) → close as not-planned (v2 잔재, 이미 close됨)
+- [x] [homelab#198](https://github.com/manamana32321/homelab/issues/198) → close as not-planned (이미 close됨)
+- [ ] [#499 source maps](https://github.com/skku-amang/main/issues/499) → scope 명확화 (FE Vercel 자동 + BE sentry-cli 둘 다 살아있음)
+
+## 부활 트리거 (재오픈 조건)
+
+본 v3 모델은 다음 조건에서 재평가:
+
+- **Sentry 무료 quota 초과 가시화** — 5M spans/월 80% 도달 (현재 트래픽 규모에서 안전 영역 충분)
+- **Trace 장기 보존 (90일 초과) 필요성 발생** — 분기·연 단위 incident retro 시 Tempo 활성화 검토
+- **Sentry SaaS 외부 사유로 의존 부담** (가격, 정책, 데이터 주권) — 이때 OTel collector 경유 + Tempo로 전환 (Sentry SDK가 이미 OTel 기반이라 마이그레이션 가능)
 
 ## Cross-references
 
-- 이슈: [skku-amang/main#490](https://github.com/skku-amang/main/issues/490)
-- 보류된 분석 인프라 에픽: [#434](https://github.com/skku-amang/main/issues/434), [#435](https://github.com/skku-amang/main/issues/435), [#436](https://github.com/skku-amang/main/issues/436) (PostHog 보류, 본 ADR과 독립)
-- 살아있는 [#437 회원가입 CRO](https://github.com/skku-amang/main/issues/437) (본 ADR과 무관)
+- 원안: [#490](https://github.com/skku-amang/main/issues/490)
+- v1 PR (merged then superseded): [#491 ADR initial](https://github.com/skku-amang/main/pull/491)
+- v1 Phase 1 PR (closed): [#498](https://github.com/skku-amang/main/pull/498)
+- v2 PR (closed): [#502](https://github.com/skku-amang/main/pull/502)
+- Sentry-triage 스킬: [#456](https://github.com/skku-amang/main/pull/456)
+- 분석 인프라 에픽 (보류, 본 ADR로 부분 재오픈 가능): [#434](https://github.com/skku-amang/main/issues/434), [#435](https://github.com/skku-amang/main/issues/435), [#436](https://github.com/skku-amang/main/issues/436)
 - 홈랩 observability 스택: [homelab repo k8s/observability/](https://github.com/manamana32321/homelab/tree/main/k8s/observability)
-- 관련 sentry-triage 스킬 PR: [#456](https://github.com/skku-amang/main/pull/456)
 
 ## 변경 이력
 
-- **2026-05-05**: 초안 작성 → 결정 4건 채움 → Accepted. 결정 1은 "Tempo 도입 여부" 가 아니라 "이미 가동 중인 Tempo의 활용 방식"으로 정정 (인프라 inventory 누락이 초안 작성 중 발견됨).
+- **2026-05-05 v3**: Signal split 모델로 재작성. 핵심 인사이트는 두 가지:
+  1. `@sentry/nestjs` v10이 내부적으로 OpenTelemetry를 wrap한다는 사실 — "Sentry vs OTel" 이분법 outdated
+  2. v1 PR #498의 진짜 비용 원인은 "한 신호 fan-out 설계"였지 "Sentry+OTel 공존"이 아니었음
+  v2의 over-correction을 거부하고 v0 코드 상태(현 main)에 정합하는 ADR로 명문화. 이 journey에서 v1·v2의 거부 사유를 Alternatives Considered에 enumerate
+- **2026-05-05 v2**: KISS 원칙 충실 — OTelcol single egress 모델 → Tier split 모델로 재작성. PR #502에 작성됐으나 머지 전 v3 검토 거쳐 close
+- **2026-05-05 v1**: 초안 작성 → 결정 4건 채움 → Accepted. PR #491로 머지됨


### PR DESCRIPTION
## 🚀 작업 내용

ADR-0001을 **v3 Signal Split** 모델로 재작성. 코드 변경 0, docs only.

### v0 → v1 → v2 → v3 journey

| 버전 | 모델 | 상태 |
|---|---|---|
| v0 (pre-#491) | BE에 `@sentry/nestjs` 가동 중 (현 main 상태) | implicit, ADR 없음 |
| v1 ([#491 머지](https://github.com/skku-amang/main/pull/491)) | OTelcol single egress + Sentry 3 예외 | Phase 1 PR #498 close됨 — bridge 복잡성 노출 |
| v2 ([#502 close](https://github.com/skku-amang/main/pull/502)) | FE Sentry / BE 홈랩 tier split | over-correction. sentry-triage 자산 폐기 + N+1 미감지 |
| **v3 (본 PR)** | **incident = Sentry / infra = 홈랩 signal split** | main 코드 상태와 정합 |

### 핵심 원칙

> 사용자 incident 분석(errors / traces / replay / feedback / application metrics)은 Sentry로, 인프라 관측(K8s 메트릭 / 외부 가용성 / 로그 집계 / 분산 trace 장기 보존)은 홈랩으로. 도구 강점 영역에 따라 **신호별** 분리.

### 주요 인사이트

1. **`@sentry/nestjs` v10은 내부적으로 OpenTelemetry wrap** — `@opentelemetry/instrumentation-http`, `instrumentation-nestjs-core`, `instrumentation-pg` (Prisma SQL 자동 캡처) 등 20+ 인스트루멘테이션 내장. **"Sentry vs OTel" 이분법은 outdated**

2. **v1 PR #498의 진짜 비용 원인** — "한 신호 fan-out 설계" (BE traces를 Sentry + Tempo 양쪽으로) → 두 OTel 인스턴스 경쟁 → bridge 패키지 필요. **"Sentry+OTel 공존" 자체가 아님**. v2는 이 통찰 못 잡고 over-correction

3. **BE Sentry traces 이미 production 작동 중** — [Trace Explorer](https://amang-23.sentry.io/explore/traces/?project=4511134425677824)에서 검증. HTTP request 1회당 12+ span 자동 캡처 (middleware/controller/Prisma SQL 포함)

4. **AMANG app 레벨 metrics 0개** — 모든 metrics는 infra exporters (node-exporter, kube-state-metrics, Blackbox)에서 Prometheus scrape. "Sentry metrics 제약"이 현 결정에 영향 0

## 코드 영향

| 항목 | 변경 |
|---|---|
| `apps/api/src/instrument.ts` | **변경 없음** — 현 main이 이미 v3 desired state |
| `apps/web/sentry.*.config.ts` | **변경 없음** |
| `infra/k8s/api/**` | **변경 없음** |
| `package.json` deps | **변경 없음** |
| `docs/architecture/adr/0001-telemetry-routing.md` | **재작성** (v1 → v3) |

→ **+102 / -159 라인, 1개 파일만 변경**. main의 ADR과 실 코드 불일치를 ADR 업데이트로 해소.

## 잃는 것 vs 얻는 것

### 얻는 것

- mental model 2줄: "사용자가 본 신호 → Sentry, 시스템 자체 상태 → Grafana"
- `instrument.ts` 단일 라이브러리 (`@sentry/nestjs`) — v1 PR #498 fan-out 복잡성 회피
- sentry-triage 스킬 ([#456](https://github.com/skku-amang/main/pull/456))이 FE+BE 모두에 적용
- N+1 / slow endpoint 자동 감지 (Sentry Performance)
- production stack trace symbolication 유지
- NSM 측정 path 열림 (Sentry App Metrics Beta — `team.formed` 등 1줄 추가로 측정)

### 잃는 것 (의식적)

| 항목 | 영향 | 완화 |
|---|---|---|
| vendor lock-in 고착화 | Sentry SaaS 의존도 ↑ | Sentry SDK가 OTel wrap → 마이그레이션 가능 |
| 로그-trace correlation 불완전 | trace_id를 양쪽 라벨링 필요 | 후속 — pino mixin에 trace_id 자동 첨부 |
| Trace 장기 보존 부재 | Sentry 90일, Tempo 미사용 | 필요시 Tempo 활성화 (홈랩 가동 중) |

## 🙏 리뷰어에게

특히 다음 부분 검토:

1. **journey 흐름 설득력**: v0 → v1 → v2 → v3 거부 사유 enumerate가 충분한가
2. **부활 트리거**: Sentry 의존을 끊어야 할 조건이 적절한가
3. **후속 작업 우선순위**: 본 PR 머지 후 등록할 신규 이슈 4건

## 🔗 관련 이슈

Refs #490

- supersedes: [#491 ADR v1 (merged)](https://github.com/skku-amang/main/pull/491), [#502 ADR v2 (closed)](https://github.com/skku-amang/main/pull/502)
- 후속 작업 (별도 이슈 등록 예정):
  - Sentry Application Metrics — NSM 측정 (`team.formed`, `signup.completed`)
  - Trace-log correlation 봉합
  - sentry-triage 스킬 BE 확장

## ✅ 체크리스트

- [x] Conventional commits 형식
- [x] Refs 이슈 연결
- [x] docs only — 코드 변경 0
- [ ] 머지 후 후속 이슈 등록 (NSM metrics, correlation, sentry-triage BE 확장)
