### PR TITLE
feat(api): NSM Sentry Application Metrics — signup.completed + team.formed

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import {
   UserNotApprovedError
 } from "@repo/api-client"
 import { JwtPayload } from "@repo/shared-types"
+import * as Sentry from "@sentry/nestjs"
 import * as bcrypt from "bcrypt"
 import { createHash, timingSafeEqual } from "crypto"
 import { CreateUserDto } from "../users/dto/create-user.dto"
@@ -23,6 +24,9 @@ export class AuthService {
 
   async signUp(createUserDto: CreateUserDto) {
     await this.usersService.create(createUserDto)
+    Sentry.metrics.count("signup.completed", 1, {
+      attributes: { provider: "credentials" }
+    })
   }
 
   async login(loginDto: LoginUserDto) {

--- a/apps/api/src/team/team.service.ts
+++ b/apps/api/src/team/team.service.ts
@@ -23,6 +23,7 @@ import {
   teamWithBasicUsersInclude,
   teamWithPublicUsersInclude
 } from "@repo/shared-types"
+import * as Sentry from "@sentry/nestjs"
 import { ObjectStorageService } from "../object-storage/object-storage.service"
 
 @Injectable()
@@ -100,6 +101,13 @@ export class TeamService {
     try {
       const team = await this.prisma.team.create({
         data: createPayload
+      })
+
+      Sentry.metrics.count("team.formed", 1, {
+        attributes: {
+          performanceId: performanceId,
+          sessionCount: memberSessions?.length ?? 0
+        }
       })
 
       return this.findOne(team.id)


### PR DESCRIPTION
## 🚀 작업 내용

[#508](https://github.com/skku-amang/main/issues/508) 구현 — AMANG NSM (북극성 지표) 2건을 Sentry Application Metrics counter로 측정 시작.

NSM(North Star Metric / 북극성 지표) — 제품의 방향을 단 하나의 숫자로 압축한 지표.

ADR-0001 v3 ([#507](https://github.com/skku-amang/main/pull/507) 머지) 후속 작업. [보류된 분석 인프라 에픽](https://github.com/skku-amang/main/issues/434)의 NSM 측정 부분만 Sentry SDK 활용으로 우회 실현 (PostHog 풀패키지는 보류 그대로).

## 변경 사항

`apps/api/src/auth/auth.service.ts`

- `AuthService.signUp()` 성공 path에 `signup.completed` counter 증가
- attributes: `{ provider: "credentials" }` (향후 OAuth 추가 시 확장)

`apps/api/src/team/team.service.ts`

- `TeamService.create()` Prisma create 성공 직후 `team.formed` counter 증가
- attributes: `{ performanceId, sessionCount }`

총 +12줄, 라이브러리 추가 0.

## 설계 결정

- **`signup.completed` 위치 = AuthService.signUp, not UsersService.create**
  - `UsersService.create`는 POST /users (admin-only)에서도 호출됨 → 관리자가 수동 생성한 사용자가 NSM에 섞이면 신호 오염
  - `AuthService.signUp`은 POST /signup (public) 전용 → 자발적 가입만 카운트

- **`team.formed` 위치 = Prisma create 직후, findOne 호출 전**
  - 실패 시 Prisma throw → metric 호출 자연스럽게 skip
  - findOne은 read-only라 timing 무관

## 🙏 리뷰어에게

검토 부탁:

**`signup.completed` 위치 — AuthService vs UsersService**: 관리자 admin-create는 NSM에서 제외하는 게 맞는지

## 검증 (머지 후 staging)

- [ ] staging에 의도적 가입 1회 → [Sentry Metrics](https://amang-23.sentry.io/explore/metrics/?project=4511134425677824)에서 `signup.completed` counter 1 증가 확인
- [ ] staging에 의도적 팀 생성 1회 → `team.formed` counter 1 증가 확인
- [ ] Sentry UI "Set up the Sentry SDK" wizard가 자동으로 metrics 페이지로 전환

## 🔗 관련 이슈

Refs [#508](https://github.com/skku-amang/main/issues/508)

- ADR v3: [#507](https://github.com/skku-amang/main/pull/507)
- 보류된 분석 에픽: [#434](https://github.com/skku-amang/main/issues/434), [#435](https://github.com/skku-amang/main/issues/435), [#436](https://github.com/skku-amang/main/issues/436) (PostHog 풀패키지 보류 유지)
- 본 PR이 가능하게 만들 후속: [#437 회원가입 CRO](https://github.com/skku-amang/main/issues/437) — `signup.completed`로 측정 가능

## ✅ 체크리스트

- [x] Conventional commits 형식 PR 제목
- [x] 관련 이슈 연결 (Refs #508)
- [x] `pnpm turbo check-types lint --filter=api` 통과 (12/12, 0 errors)
- [ ] 머지 후 staging 검증 (별도)
