### PR TITLE
feat(api): Trace-log correlation — pino 로그에 trace_id 자동 첨부

### DIFF
--- a/apps/api/src/common/logger/pino-logger.config.ts
+++ b/apps/api/src/common/logger/pino-logger.config.ts
@@ -6,6 +6,7 @@ import PinoPretty from "pino-pretty"
 import { format } from "sql-formatter"
 import { JwtService } from "@nestjs/jwt"
 import { JwtPayload } from "@repo/shared-types"
+import * as Sentry from "@sentry/nestjs"
 
 const jwtService = new JwtService()
 
@@ -38,6 +39,10 @@ export const pinoLoggerModuleOption: Params = {
     mixin(mergeObject: any) {
       if (!mergeObject.msg && mergeObject.message) {
         mergeObject = { ...mergeObject, msg: mergeObject.message }
+      }
+      const traceId = Sentry.getActiveSpan()?.spanContext().traceId
+      if (traceId) {
+        mergeObject = { ...mergeObject, trace_id: traceId }
       }
       return mergeObject
     },


### PR DESCRIPTION
## 🚀 작업 내용

[#495](https://github.com/skku-amang/main/issues/495) 구현 — BE pino 로그에 현재 Sentry active span의 `trace_id`를 자동 첨부.

ADR-0001 v3 ([#507](https://github.com/skku-amang/main/pull/507) 머지) 후속. 두 관측 스택(Sentry / Loki)을 trace_id 한 개로 봉합.

## 변경 사항

`apps/api/src/common/logger/pino-logger.config.ts`:

- `@sentry/nestjs` import 추가
- `mixin`에 `Sentry.getActiveSpan()?.spanContext().traceId` 첨부 (+4줄)
- `traceId` 없을 때 (request context 밖 — bootstrap log 등)는 `trace_id` 필드 미포함

총 +5줄.

## 작동

1. 모든 `logger.info/warn/error/...` 호출이 자동으로 `trace_id` 첨부
2. pino JSON 출력: `{"level":"info","msg":"...","userId":"...","trace_id":"abc123..."}`
3. Promtail이 stdout scrape → Loki 도달
4. LogQL: `{namespace="amang-api-production"} | json | trace_id="abc123"`
5. 같은 `trace_id`가 Sentry Issue/Trace Explorer에도 표시 → 양쪽 도구 jump 가능

## 설계 결정

- **`trace_id`는 Loki label이 아닌 JSON field**: high cardinality (요청당 unique). Loki label로 보내면 cardinality 폭발 → query 성능 저하 + storage 폭증. LogQL `| json |` parsing이 정답
- **부재 시 필드 미포함**: bootstrap 로그 등 request context 밖에서는 active span 없음 → `trace_id` 키 아예 생략. 빈 문자열보다 깔끔 (LogQL filter 시 명확)
- **`Sentry.getActiveSpan()`은 in-process API**: 비동기 컨텍스트 (async_hooks) 통해 자동으로 현재 요청의 span 추적. 추가 propagation 코드 불필요

## 🙏 리뷰어에게

검토 부탁:

**필드명 `trace_id` vs `traceId`** — pino 컨벤션은 snake_case (예: `userId` 이미 있음… 사실 camelCase). 일관성 측면에서 `traceId`로 가는 게 맞을지. 현재는 OTel SemConv standard `trace_id` (snake) 사용

## 검증 (머지 후 staging)

- [ ] staging api 호출 1회 → `kubectl logs amang-api-...` 출력에서 `trace_id` 필드 확인
- [ ] [Sentry Trace Explorer](https://amang-23.sentry.io/explore/traces/?project=4511134425677824)에서 같은 trace_id의 trace 보임
- [ ] [Grafana Loki](https://grafana.json-server.win) `{namespace="amang-api-production"} | json | trace_id="<위 trace_id>"` query → 같은 요청의 모든 로그 표시

## 🔗 관련 이슈

Refs [#495](https://github.com/skku-amang/main/issues/495)

- ADR v3 후속: [#507](https://github.com/skku-amang/main/pull/507)
- Sentry Logs (Beta)가 같은 incident 시점 로그를 inline 표시 — Loki는 historical aggregation, Sentry는 incident-context UI. 두 도구 보완

## ✅ 체크리스트

- [x] Conventional commits 형식 PR 제목
- [x] 관련 이슈 연결 (Refs #495)
- [x] `pnpm turbo check-types lint --filter=api` 통과 (12/12, 0 errors)
- [ ] 머지 후 staging 검증 (별도)
