### PR TITLE
feat(api): 동방·장비 대여 활동 메트릭 — room.reserved + rental.created

### DIFF
--- a/apps/api/src/rental/rental.service.ts
+++ b/apps/api/src/rental/rental.service.ts
@@ -9,6 +9,7 @@ import {
 } from "@repo/api-client"
 import { Prisma } from "@repo/database"
 import { rentalLogWithUserInlcude } from "@repo/shared-types"
+import * as Sentry from "@sentry/nestjs"
 
 @Injectable()
 export class RentalService {
@@ -27,7 +28,7 @@ export class RentalService {
       throw new ConflictError("해당 시간에 이미 예약된 장비입니다.")
 
     try {
-      return await this.prisma.equipmentRental.create({
+      const rental = await this.prisma.equipmentRental.create({
         data: {
           startAt,
           endAt,
@@ -46,6 +47,16 @@ export class RentalService {
         },
         include: rentalLogWithUserInlcude
       })
+
+      if (rental.equipment.category === "ROOM") {
+        Sentry.metrics.count("room.reserved", 1)
+      } else {
+        Sentry.metrics.count("rental.created", 1, {
+          attributes: { category: rental.equipment.category }
+        })
+      }
+
+      return rental
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError) {
         if (err.code === "P2003" || err.code === "P2025")


### PR DESCRIPTION
## 🚀 작업 내용

후속 NSM 작업 — operational activity (일상 동아리 활동성) 측정.

ADR-0001 v3 ([#507](https://github.com/skku-amang/main/pull/507)) + [#511](https://github.com/skku-amang/main/pull/511) (team.formed/signup.completed) 패턴 연장.

## 도메인 모델링

AMANG의 EquipmentRental은 `EquipCategory.ROOM` (동방)과 그 외 장비를 같은 테이블로 처리. 두 활동은 다른 도메인 의미:

- **동방 예약** = 연습 세션. 팀 활동성 / 정기 활동의 직접 신호
- **장비 대여** = 행사/세션용 일회성 (기타/마이크 등 빌려가기)

이 분리는 코드의 `findAll(type?: "room" | "item", ...)` 파라미터와도 정합.

## 변경 사항

`apps/api/src/rental/rental.service.ts`:

- `@sentry/nestjs` import
- `RentalService.create()` Prisma create 성공 직후 category 분기:
  - `category === "ROOM"` → `Sentry.metrics.count("room.reserved", 1)`
  - 그 외 → `Sentry.metrics.count("rental.created", 1, { attributes: { category } })`
- `return await` → `const rental = await; ... return rental` (metric 분기 위해)

총 +12줄, -1줄.

## 설계 결정

- **2개 counter 분리** (room.reserved vs rental.created):
  - 단일 counter + category attribute 옵션 검토했으나, 두 활동의 도메인 의미 차이 우선
  - 향후 dashboard에서 별도 panel/위계 명확히 표시 가능
- **메트릭 위치**: Prisma create 성공 직후. 충돌(409) 또는 P2003/P2025는 metric 미발생 (정확)
- **attribute 최소화**: 첫 도입 단순화
  - `room.reserved`: attribute 없음
  - `rental.created`: `category`만 (GUITAR/BASS/DRUM 등 분기 가능)
  - 미포함: `duration_minutes` (필요 시 후속), `equipmentId` (high cardinality)

## NSM 위계

| 카테고리 | 메트릭 | 도입 |
|---|---|---|
| NSM 본체 | `team.formed` | [#511](https://github.com/skku-amang/main/pull/511) |
| Lead indicator | `signup.completed` | [#511](https://github.com/skku-amang/main/pull/511) |
| **Operational activity** | `room.reserved`, `rental.created` | **본 PR** |

## 🙏 리뷰어에게

- 2개 counter 분리 (vs 단일 + category) 결정 의견
- attribute 범위 (`category`만 vs duration 포함) 의견

## 검증 (머지 후 production)

- [ ] production에서 의도적 동방 예약 1회 → [Sentry Metrics](https://amang-23.sentry.io/explore/metrics/?project=4511134425677824)에서 `room.reserved` 1 증가
- [ ] production에서 의도적 장비 (기타 등) 대여 1회 → `rental.created` 1 증가 + attribute `category: "GUITAR"`

## 🔗 관련

- ADR v3: [#507](https://github.com/skku-amang/main/pull/507)
- NSM 측정 패턴 도입: [#508](https://github.com/skku-amang/main/issues/508), [#511](https://github.com/skku-amang/main/pull/511)
- 보류된 분석 에픽: [#434](https://github.com/skku-amang/main/issues/434), [#435](https://github.com/skku-amang/main/issues/435), [#436](https://github.com/skku-amang/main/issues/436) (PostHog 보류 유지)

## ✅ 체크리스트

- [x] Conventional commits 형식
- [x] `pnpm turbo check-types lint --filter=api` 통과 (12/12, 0 errors)
- [ ] 머지 후 production 검증 (별도)
