### PR TITLE
feat(api,skills): sentry-triage 스킬 BE 확장 (#509 Phase A)

### DIFF
--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -41,12 +41,15 @@ Sentry의 unresolved 이슈와 User Feedback을 트리아지 프레임워크로 
 
 - ID, 제목, 영향 유저 수, 이벤트 수, first_seen, last_seen
 - tags: url, browser, environment, release
+- 프로젝트 식별: `web` → FE 이슈, `api` → BE 이슈. 스택프레임 경로(`apps/web/**` vs `apps/api/**`)로 검증 가능
 - 에러의 경우: 메시지, 스택트레이스 상위 10줄
+- **BE 이슈의 경우**: `release` 태그가 git SHA로 박힘 (`apps/api/Dockerfile`이 `IMAGE_TAG` env로 주입 → `Sentry.init.release`). GH 이슈 생성 시 `sentry_auto.md` 템플릿이 commit URL을 자동 첨부
 - **User Feedback의 경우**: `event.contexts.feedback.message` 필드(= 유저가 입력한 **원문**)를 사용. 이슈 `description` 필드는 Sentry가 AI로 자동 생성한 영문 요약이므로 **분류·제목 용도로 쓰지 말 것**. 원문은 대부분 한국어
 
 ### 🌐 언어 주의
 
 amang 유저 피드백은 거의 한국어. AI 자동 요약 영문 title에 휘둘리지 말고 `feedback.message` 원문 기준으로:
+
 - 분류(💡 vs 📝) 판단
 - GH 이슈 제목 생성 시 원문 그대로 (또는 원문 요약) 사용 — 유저 목소리 번역 손실 방지
 
@@ -73,13 +76,13 @@ amang 유저 피드백은 거의 한국어. AI 자동 요약 영문 title에 휘
 
 각 항목마다 `[y/n/s]` 프롬프트 (y=실행 / n=건너뜀 / s=skip all). **승인받은 항목만** 실행.
 
-| 라벨 | 액션 |
-| --- | --- |
-| 🔥 | `gh issue create` — `kind: bug` + `priority: critical` + `from: sentry` 또는 `from: user-feedback`. body는 [.github/ISSUE_TEMPLATE/sentry_auto.md](../../../.github/ISSUE_TEMPLATE/sentry_auto.md) 적용. **제목은 자연어** (CC 포맷 금지) |
-| 📝 | `gh issue create` — `kind: bug` + `priority: high`(영향 유저 ≥3) 또는 `priority: low` + `from:*` |
-| 👀 | **별도 액션 없음** — Sentry는 unresolved 상태 유지. 다음 트리아지 라운드에 자연스레 다시 검토됨. (선택: 코멘트로 "observing - 다음 라운드 재평가" 추적 메모) |
-| 🚫 | **출력만** — "Sentry 웹에서 Archive 권장" 메시지. 자동 실행 안 함 |
-| 💡 | 사용자에게 대상 선택 프롬프트 (`g`=GH 이슈 / `n`=Notion / `s`=건너뜀). GH면 `kind: enhancement` + `from: user-feedback` + `priority: low`. Notion이면 `amang-notion` MCP로 아이디어 DB에 row 추가 |
+| 라벨 | 액션                                                                                                                                                                                                                                      |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🔥   | `gh issue create` — `kind: bug` + `priority: critical` + `from: sentry` 또는 `from: user-feedback`. body는 [.github/ISSUE_TEMPLATE/sentry_auto.md](../../../.github/ISSUE_TEMPLATE/sentry_auto.md) 적용. **제목은 자연어** (CC 포맷 금지) |
+| 📝   | `gh issue create` — `kind: bug` + `priority: high`(영향 유저 ≥3) 또는 `priority: low` + `from:*`                                                                                                                                          |
+| 👀   | **별도 액션 없음** — Sentry는 unresolved 상태 유지. 다음 트리아지 라운드에 자연스레 다시 검토됨. (선택: 코멘트로 "observing - 다음 라운드 재평가" 추적 메모)                                                                              |
+| 🚫   | **출력만** — "Sentry 웹에서 Archive 권장" 메시지. 자동 실행 안 함                                                                                                                                                                         |
+| 💡   | 사용자에게 대상 선택 프롬프트 (`g`=GH 이슈 / `n`=Notion / `s`=건너뜀). GH면 `kind: enhancement` + `from: user-feedback` + `priority: low`. Notion이면 `amang-notion` MCP로 아이디어 DB에 row 추가                                         |
 
 ### 5. 종료 요약
 
@@ -94,7 +97,7 @@ amang 유저 피드백은 거의 한국어. AI 자동 요약 영문 title에 휘
 
 ## 출력 형식
 
-~~~markdown
+```markdown
 ## Sentry Triage (YYYY-MM-DD)
 
 조회: web + api / prod / 7d / unresolved — 총 N건
@@ -107,19 +110,22 @@ amang 유저 피드백은 거의 한국어. AI 자동 요약 영문 title에 휘
    - [y/n/s] GH 이슈 생성 (`kind: bug`, `priority: critical`, `from: sentry`)
 
 ### 📝 이슈 등록 (N건)
+
 ...
 
 ### 👀 관찰 (N건)
+
 ...
 
 ### 🚫 무시 추천 (N건)
+
 ...
 
 ### 💡 기능 요청 (N건)
 
 1. "예약 목록을 엑셀로 내보낼 수 있었으면 좋겠어요" ([feedback link])
    - [g/n/s] g=GH 이슈 / n=Notion DB / s=건너뜀
-~~~
+```
 
 ## 에러 처리
 

--- a/.claude/skills/sentry-triage/triage-criteria.md
+++ b/.claude/skills/sentry-triage/triage-criteria.md
@@ -10,6 +10,7 @@
 - 최근 24시간 이벤트 수가 기저(지난 7일 평균) 대비 5배 이상
 - 핵심 flow 키워드가 스택트레이스·URL·메시지에 포함:
   `login`, `auth`, `signup`, `payment`, `reservation`, `booking`, `equipment`
+- **BE 시스템 결함**: 프로젝트 `api` + 스택프레임이 `apps/api/**`에서 발생한 unhandled exception (NestJS HttpException으로 명시 throw 안 한 케이스). 사용자 의도와 무관 → 즉시 조치
 
 ## 🚫 무시 추천 (priority: 없음, 사용자가 수동 archive)
 
@@ -20,6 +21,9 @@
 - 개발 환경(`environment: development` 또는 `local`)
 - **스택트레이스 전체가 서드파티 코드에서만 발생**: `_next-live/feedback/*`(Vercel Live Feedback), `_next/static/chunks/*`에서만 발생하고 우리 소스(`apps/web/**`, `apps/api/**`)는 한 프레임도 포함 안 됨 → 라이브러리 버그, 우리 소관 아님
 - `mechanism: auto.browser.browserapierrors.*` 태그가 붙은 자동 수집 브라우저 API 에러 (대개 사용자 조작 잡음)
+- **BE `/health` 503**: URL 끝이 `/health` (Blackbox Exporter가 별도 모니터링. `apps/api/src/instrument.ts`의 `beforeSend`가 막지만 safety net으로 명시)
+- **BE NestJS HttpException 4xx**: 우리가 명시 throw한 사용자 입력 검증·권한 에러 (`UnprocessableEntityError`, `BadRequestError`, `NotFoundError`, `ConflictError`, `ForbiddenError` 등). 시스템 결함 아니라 사용자 오작용
+- **BE Prisma `P2002` 단독 `ConflictError`**: 사용자가 중복 입력한 케이스 (이미 사용중인 이메일/닉네임 등). 도메인 정상 흐름
 
 ## 💡 기능 요청 (User Feedback 전용)
 

--- a/.github/ISSUE_TEMPLATE/sentry_auto.md
+++ b/.github/ISSUE_TEMPLATE/sentry_auto.md
@@ -31,7 +31,7 @@ assignees: ""
 - URL: {{url}}
 - 브라우저: {{browser}}
 - 환경: {{environment}}
-- 릴리스: {{release}}
+- 릴리스: [`{{release}}`](https://github.com/skku-amang/main/commit/{{release}})
 
 ## User Feedback (있을 경우)
 

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -4,6 +4,7 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node"
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
+  release: process.env.IMAGE_TAG,
 
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,


### PR DESCRIPTION
## 🚀 작업 내용

[#509](https://github.com/skku-amang/main/issues/509) Phase A 구현 — sentry-triage 스킬이 BE 이슈도 자동 트리아지 가능하도록 docs + 최소 코드 변경.

ADR-0001 v3 ([#507](https://github.com/skku-amang/main/pull/507)) 후속. BE Sentry 신호가 실제 production에서 흐르는 상태에서 (PR [#511](https://github.com/skku-amang/main/pull/511) / [#512](https://github.com/skku-amang/main/pull/512) / [#513](https://github.com/skku-amang/main/pull/513) 머지) 트리아지 자동화를 BE에도 적용.

## 변경 사항

### 코드 (1줄, `apps/api/src/instrument.ts`)

```diff
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
+  release: process.env.IMAGE_TAG,
   ...
 })
```

`IMAGE_TAG`는 Dockerfile이 `$GITHUB_SHA`로 박음 ([#507](https://github.com/skku-amang/main/pull/507)). Sentry events의 `release` tag가 git SHA로 박힘 → `sentry_auto.md` 템플릿이 commit URL 자동 생성.

### 스킬 정의 (`.claude/skills/sentry-triage/`)

**`triage-criteria.md`**:

- 🔥 즉시 수정에 **BE 시스템 결함** 추가
  - 프로젝트 `api` + 스택프레임 `apps/api/**` + unhandled exception (NestJS HttpException 명시 throw 아닌 케이스)
- 🚫 무시에 BE 특화 3개:
  - `/health` 503 (Blackbox safety net, `beforeSend`가 막지만 명시)
  - NestJS HttpException 4xx (`UnprocessableEntityError`, `BadRequestError`, `NotFoundError`, `ConflictError`, `ForbiddenError` — 사용자 입력 검증·권한, 시스템 결함 아님)
  - Prisma `P2002` 단독 `ConflictError` (이메일/닉네임 중복 등 도메인 정상 흐름)

**`SKILL.md`**:

- 조회 수집 항목에 **프로젝트 식별** 명시 (`web` = FE, `api` = BE, 스택프레임 경로로 검증)
- BE 이슈는 `release` tag가 git SHA → commit URL 자동 첨부 컨텍스트

### Issue 템플릿 (`.github/ISSUE_TEMPLATE/sentry_auto.md`)

```diff
- 릴리스: {{release}}
+ 릴리스: [`{{release}}`](https://github.com/skku-amang/main/commit/{{release}})
```

총 +21줄, -10줄 across 4 파일.

## Phase 분할

| Phase | 내용 | 상태 |
|---|---|---|
| **A (본 PR)** | 스킬 docs + release config | 진행 중 |
| **B (별도 후속)** | BE에 `Sentry.setUser({ id, username, email })` interceptor — JWT 디코드 → Sentry events에 user context 첨부 | 별도 이슈 / PR |

**Phase B 분리 이유**: 현재 pino mixin이 `userId`/`username`을 로그에는 첨부하지만 Sentry events에는 없음. Sentry.setUser interceptor 추가는 별도 작은 BE 코드 변경 — Phase A (docs only)와 review 단위 분리하는 게 깔끔.

## 🙏 리뷰어에게

- 🚫 무시 카테고리에 들어간 NestJS HttpException 4xx 리스트가 적절한지 (다른 명시 throw 에러 클래스 누락 있는지)
- 🔥 BE 시스템 결함의 "unhandled exception" 판단 기준 — `all-error.filter.ts`가 unhandled를 잡아 500을 throw하는 패턴이라 스킬이 어떻게 인식할지

## 검증 (머지 후)

- staging은 Sentry 비활성 (`NODE_ENV=development`)이라 검증 불가 — production에서 자연 트래픽 + 의도적 트리아지 1회로 확인
- `/sentry-triage` 호출 → BE 이슈 (있다면) 분류 + GH 이슈 자동 생성 시 commit URL 첨부 여부 확인

## 🔗 관련

- ADR v3: [#507](https://github.com/skku-amang/main/pull/507)
- sentry-triage 스킬 원본: [#456](https://github.com/skku-amang/main/pull/456)
- 이슈: [#509](https://github.com/skku-amang/main/issues/509)

## ✅ 체크리스트

- [x] Conventional commits 형식
- [x] `pnpm turbo check-types lint --filter=api` 통과 (12/12, 0 errors)
- [x] Prettier 통과 (markdown 자동 포맷 후 commit)
- [ ] 머지 후 production 검증 (별도)
