### PR TITLE
docs: Diátaxis 문서 인프라 — 작성 규칙·ADR 템플릿·lint CI (#521)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,64 @@
+name: docs-lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**/*.md'
+      - '*.md'
+      - '.markdownlint.jsonc'
+      - 'lychee.toml'
+      - '.lycheeignore'
+      - '.github/workflows/docs-lint.yml'
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+      - '*.md'
+      - '.markdownlint.jsonc'
+      - 'lychee.toml'
+      - '.lycheeignore'
+      - '.github/workflows/docs-lint.yml'
+
+# 같은 PR/브랜치 연속 push 시 옛 run cancel
+concurrency:
+  group: docs-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: |
+            docs/**/*.md
+            *.md
+
+  link-check:
+    name: lychee link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
+      - name: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --cache
+            --no-progress
+            'docs/**/*.md'
+            './*.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,17 @@
+# lychee.toml 보조 — 정규식으로 검사 제외 도메인 명시.
+# 이유: 아래는 링크가 살아있으나 익명 접근 시 인증 wall로 4xx 응답 → false-fail 방지.
+
+# 인증 wall — 워크스페이스/계정 로그인 필요 (SaaS 콘솔)
+^https://amang-23\.sentry\.io
+^https://([a-z0-9-]+\.)?notion\.so
+^https://app\.slack\.com/client
+^https://www\.figma\.com/(design|board|file)
+
+# 로컬 개발 URL — CI 환경에서 검증 의미 없음
+^https?://localhost
+^https?://127\.0\.0\.1
+^https?://0\.0\.0\.0
+
+# placeholder URL (실제 도메인 아님 — 템플릿/예시 안)
+^https://github\.com/skku-amang/main/issues/000
+^https://github\.com/(owner|org)/repo

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,29 @@
+// AMANG docs markdown lint 룰
+{
+  "default": true,
+
+  // MD013 (line-length): 한국어 + table 셀에서 80자 한계는 비현실적. 잡음.
+  "MD013": false,
+
+  // MD024 (no-duplicate-heading): 섹션 내 sibling 중복만 금지 (ADR의 ## Context 등 재사용 허용)
+  "MD024": { "siblings_only": true },
+
+  // MD033 (no-inline-html): table 셀 안 <br> 등 필요. 비활성.
+  "MD033": false,
+
+  // MD034 (no-bare-urls): prettier가 자동 링크화. 충돌 회피.
+  "MD034": false,
+
+  // MD036 (no-emphasis-as-heading): 짧은 강조에 **굵게** 다수 사용. 정식 heading 강제 비현실.
+  "MD036": false,
+
+  // MD040 (fenced-code-language): plain output(diff/tree dump) 블록에 언어 미지정 허용.
+  "MD040": false,
+
+  // MD049/MD050 (emphasis/strong-style): _ vs * 선택은 prettier 영역. 충돌 회피.
+  "MD049": false,
+  "MD050": false,
+
+  // MD060 (table-column-style): pipe 좌우 공백 스타일은 prettier 영역. 잡음.
+  "MD060": false
+}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,3 @@
+# docs/
+
+문서 작성 규칙은 [`how-to/write-docs.md`](./how-to/write-docs.md) 참조.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,24 @@
 # AMANG 문서
 
-문서는 [Diátaxis](https://diataxis.fr/) 체계로 정리되어 있습니다 — **읽는 사람이 지금 무엇을 원하는지**에 따라 네 칸으로 나눕니다.
+> **For**: AMANG를 개발하는 사람(팀원·신규 합류자·AI 협업자).
+> **You'll be able to**: 원하는 정보가 어느 칸에 있는지 알고, 새 문서를 어디에 둘지 정한다.
 
-| 칸 | 언제 보나 | 문서 |
+문서는 [Diátaxis](https://diataxis.fr/) 체계로 정리되어 있습니다 — **읽는 사람이 지금 무엇을 원하는지**에 따라 네 칸으로 나눕니다. 각 칸을 클릭하면 GitHub이 그 안의 문서 목록을 보여줍니다.
+
+| 칸 | 언제 보나 | 목표 |
 | --- | --- | --- |
-| 📖 **Tutorials** — 배우기 | 처음이라 손잡고 따라하고 싶을 때 | [처음 시작하기](tutorials/getting-started.md) |
-| 🔧 **How-to** — 해내기 | 특정 작업 방법을 찾을 때 | [기여하기](how-to/contributing.md) |
-| 📚 **Reference** — 찾아보기 | 사실을 빠르게 조회할 때 | [명령어](reference/commands.md) · [도메인 모델](reference/domain-model.md) · [용어집](reference/glossary.md) |
-| 💡 **Explanation** — 이해하기 | 왜 이렇게 됐는지 배경을 알고 싶을 때 | [팀 분담](explanation/team.md) · [아키텍처 결정(ADR)](explanation/adr/) · [설계 문서](explanation/design/) |
+| 📖 [**Tutorials**](tutorials/) — 배우기 | 처음이라 손잡고 따라하고 싶을 때 | 초심자를 처음부터 끝까지 데려가는 "성공 경험" |
+| 🔧 [**How-to**](how-to/) — 해내기 | 특정 작업 방법을 찾을 때 | 이미 아는 사람이 한 작업을 끝내는 "레시피" |
+| 📚 [**Reference**](reference/) — 찾아보기 | 사실을 빠르게 조회할 때 | 명령어·스키마·용어의 "정확한 조회" |
+| 💡 [**Explanation**](explanation/) — 이해하기 | 왜 이렇게 됐는지 배경을 알 때 | 배경·근거·트레이드오프의 "이해" (운영 모델·ADR 포함) |
 
-## 어디에 무엇을 쓰나
+## 새 문서를 쓴다면
 
-새 문서를 추가할 때 아래 기준으로 칸을 고릅니다.
-
-- **Tutorials** — 초심자를 처음부터 끝까지 데려가는 학습 코스. "성공 경험"이 목표.
-- **How-to** — 이미 아는 사람이 특정 문제를 푸는 레시피. "작업 완료"가 목표.
-- **Reference** — 사실의 건조한 나열 (명령어, 스키마, 용어). "정확한 조회"가 목표.
-- **Explanation** — 배경·근거·트레이드오프. "이해"가 목표.
+작성 규칙은 [how-to/write-docs.md](how-to/write-docs.md)를 먼저 봅니다 — 어느 칸에 둘지, 어떻게 쓸지, 링크·ADR 규칙까지.
 
 한 문서가 두 칸에 걸치면 나눕니다 (예: 튜토리얼 안의 명령어 목록은 Reference로 분리).
+
+## 코드·명령어·컨벤션
+
+- 프로젝트 개요·기술 스택·명령어: 루트 [README.md](../README.md), [CLAUDE.md](../CLAUDE.md)
+- 이슈·브랜치·PR·커밋 규칙: [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/explanation/adr/0001-telemetry-routing.md
+++ b/docs/explanation/adr/0001-telemetry-routing.md
@@ -77,7 +77,7 @@ apps/api ──pinoIntegration (in-process)──→ Sentry   (incident-context 
 - **sentry-triage 스킬 ([#456](https://github.com/skku-amang/main/pull/456))이 FE+BE 모두에 적용**: BE error도 자동 트리아지
 - **N+1 / slow endpoint 자동 감지**: Sentry Performance가 trace 패턴 분석. NestJS+Prisma 환경에서 직접적 가치
 - **production stack trace symbolication 유지** ([#499](https://github.com/skku-amang/main/issues/499))
-- **NSM 측정 path 열림**: PostHog 보류 결정 ([project_analytics_epic.md](memory)) 우회 가능 — `Sentry.metrics.increment("team.formed")` 같은 1줄 추가로 측정 시작
+- **NSM 측정 path 열림**: PostHog 보류 결정 (`project_analytics_epic.md`) 우회 가능 — `Sentry.metrics.increment("team.formed")` 같은 1줄 추가로 측정 시작
 
 ### 잃는 것 (의식적)
 
@@ -125,7 +125,7 @@ apps/api ──pinoIntegration (in-process)──→ Sentry   (incident-context 
 본 ADR v3가 Accepted된 후:
 
 - [x] PR #502 (v2) close as superseded — 완료
-- [ ] **신규 이슈 — Sentry Application Metrics 도입** (`team.formed`, `signup.completed` counter 2개). [project_analytics_epic.md](memory) 분석 인프라 에픽 부분 재오픈
+- [ ] **신규 이슈 — Sentry Application Metrics 도입** (`team.formed`, `signup.completed` counter 2개). `project_analytics_epic.md` 분석 인프라 에픽 부분 재오픈
 - [ ] **신규 이슈 — Trace-log correlation 봉합**: pino mixin에 `Sentry.getActiveSpan()?.spanContext().traceId` 자동 첨부 → Loki query시 trace_id 라벨로 Sentry jump 가능
 - [ ] **신규 이슈 — sentry-triage 스킬 BE 적용 확장**: 현재 FE 위주 자동화를 BE 에러까지
 - [x] [#494 OTelcol Sentry exporter](https://github.com/skku-amang/main/issues/494) → close as not-planned (v2 잔재, 이미 close됨)

--- a/docs/explanation/adr/_template.md
+++ b/docs/explanation/adr/_template.md
@@ -1,0 +1,43 @@
+# ADR-XXXX: <결정 제목>
+
+**작성일**: YYYY-MM-DD
+**상태**: Proposed
+**작성자**: <이름> (+ 협업자)
+**관련 이슈**: [#000](https://github.com/skku-amang/main/issues/000)
+
+## Context
+
+이 결정이 왜 필요한가? 어떤 문제·제약·기회가 있는가? 결정 시점의 시스템 상태와 주요 고려 요소(성능·보안·비용·일정 등)를 짧게 기술.
+
+## Alternatives Considered
+
+### Option 1: <이름>
+
+- **장점**: ...
+- **단점**: ...
+
+### Option 2: <이름>
+
+- **장점**: ...
+- **단점**: ...
+
+## Decision
+
+선택한 옵션과 그 이유. 어느 요소를 우선했는지, 어떤 트레이드오프를 받아들였는지 명시.
+
+## Consequences
+
+- **좋은 결과**: ...
+- **나쁜 결과**: ...
+- **중립적 결과**: ...
+
+<!--
+작성 가이드 (새 ADR 작성 시 이 주석 블록 삭제)
+
+- 파일명: `<번호>-<kebab-case-제목>.md` (예: 0003-single-minio-bucket.md)
+- 번호: 4자리 zero-padded, 작성 순서, 영구. supersede돼도 번호 유지
+- 상태 전이: Proposed → Accepted → (Superseded by ADR-YYYY | Deprecated)
+- supersede 시: 새 ADR 본문에 "ADR-YYYY를 supersede" 명시 + 옛 ADR 상태를 `Superseded by ADR-XXXX`로 변경 (옛 본문은 역사 보존 위해 유지)
+- 언제 쓰나: 되돌리기 어려운 결정, 두 옵션 중 명시적 선택, 코드만 봐선 "왜"를 알 수 없는 결정
+- 작성 룰 상세: how-to/write-docs.md
+-->

--- a/docs/explanation/design/plans/2026-04-12-sentry-triage.md
+++ b/docs/explanation/design/plans/2026-04-12-sentry-triage.md
@@ -665,7 +665,7 @@ Expected: Collector가 Sentry MCP로 조회, Classifier가 라벨 붙여 출력,
 - 각 항목에 "근거" 줄이 2-3줄로 첨부됐는지 확인
 - URL/링크가 모두 클릭 가능한지 확인
 
-불일치 발견 시 [triage-criteria.md](.claude/skills/sentry-triage/triage-criteria.md) 조정하고 재실행.
+불일치 발견 시 `.claude/skills/sentry-triage/triage-criteria.md` 조정하고 재실행.
 
 - [ ] **Step 3: 실 실행 모드로 1-2건만 처리**
 
@@ -674,7 +674,7 @@ Expected: Collector가 Sentry MCP로 조회, Classifier가 라벨 붙여 출력,
 ```
 
 - 📝 또는 👀 중 **1-2건만** 승인하여 실제 액션 테스트
-- GH 이슈 생성 시 [issue-template.md](.claude/skills/sentry-triage/issue-template.md) 그대로 렌더됐는지 확인
+- GH 이슈 생성 시 `.claude/skills/sentry-triage/` 이슈 템플릿 그대로 렌더됐는지 확인
 - Sentry 태그 부착 시 Sentry 웹에서 `observing` 태그 확인
 
 - [ ] **Step 4: 검증 결과 기록**

--- a/docs/explanation/design/plans/2026-04-12-sentry-triage.md
+++ b/docs/explanation/design/plans/2026-04-12-sentry-triage.md
@@ -8,7 +8,6 @@
 
 **Tech Stack:** Bash + `gh` CLI (라벨 관리·이슈 생성), Claude Code Skill (Markdown), `amang-sentry` MCP (Sentry 접근).
 
-
 ---
 
 ## File Structure
@@ -31,6 +30,7 @@ skku-amang/main/
 ```
 
 **파일별 책임**:
+
 - `setup-labels.sh`: 선언적 라벨 매니페스트 정의 + `gh label create/edit`로 동기화. 멱등성 보장.
 - `migrate-old-labels.sh`: 기존 `type:*`, `scope:*`, `v0` 라벨을 이슈/PR에서 제거 후 삭제.
 - `CONTRIBUTING.md`: 새 라벨 체계 + 이슈/PR별 라벨 사용 규칙 문서화.
@@ -45,6 +45,7 @@ skku-amang/main/
 ### Task 1: 선언적 라벨 매니페스트 스크립트 작성
 
 **Files:**
+
 - Create: `scripts/setup-labels.sh`
 
 - [ ] **Step 1: 스크립트 작성**
@@ -144,6 +145,7 @@ git commit -m "chore(infra): 라벨 선언적 관리 스크립트 추가 (setup-
 ### Task 2: 기존 라벨 마이그레이션 스크립트
 
 **Files:**
+
 - Create: `scripts/migrate-old-labels.sh`
 
 - [ ] **Step 1: 스크립트 작성**
@@ -239,6 +241,7 @@ git commit -m "chore(infra): 기존 라벨 마이그레이션 스크립트 추�
 ### Task 3: CONTRIBUTING.md 라벨 섹션 재작성
 
 **Files:**
+
 - Modify: `CONTRIBUTING.md` (라벨 섹션 전체 교체)
 
 - [ ] **Step 1: 기존 "라벨" 섹션을 아래로 교체**
@@ -362,6 +365,7 @@ Expected: 기존 type:/scope:/v0 라벨 10개 제거 + 관련 이슈/PR에서도
 ### Task 5: 스킬 디렉토리 + triage-criteria.md 작성
 
 **Files:**
+
 - Create: `.claude/skills/sentry-triage/triage-criteria.md`
 
 - [ ] **Step 1: 디렉토리 생성**
@@ -441,6 +445,7 @@ git commit -m "feat(skill): sentry-triage 분류 기준 문서 추가"
 ### Task 6: issue-template.md 작성
 
 **Files:**
+
 - Create: `.claude/skills/sentry-triage/issue-template.md`
 
 - [ ] **Step 1: 템플릿 파일 작성**
@@ -497,6 +502,7 @@ git commit -m "feat(skill): sentry-triage GH 이슈 템플릿 추가"
 ### Task 7: SKILL.md 작성
 
 **Files:**
+
 - Create: `.claude/skills/sentry-triage/SKILL.md`
 
 - [ ] **Step 1: SKILL.md 작성**
@@ -570,12 +576,15 @@ Sentry의 unresolved 이슈와 User Feedback을 트리아지 프레임워크로 
 ### 5. 종료 요약
 
 ```
+
 요약: 처리 완료 N건 / 보류 M건 / 실패 K건
+
 - 🔥 N1건 → GH 이슈 #AAA, #BBB 생성됨
 - 📝 N2건 → GH 이슈 #CCC~#DDD 생성됨
 - 👀 N3건 → Sentry 태그 부착됨
 - 🚫 N4건 → 수동 archive 권장 목록 (아래 링크)
 - 💡 N5건 → GH N개, Notion N개
+
 ```
 
 ## 출력 형식
@@ -641,6 +650,7 @@ git commit -m "feat(skill): sentry-triage SKILL.md 추가 — 5단계 트리아�
 - [ ] **Step 1: 드라이런으로 스킬 호출**
 
 대화 창에서 다음 입력:
+
 ```
 /sentry-triage 드라이런
 ```
@@ -650,6 +660,7 @@ Expected: Collector가 Sentry MCP로 조회, Classifier가 라벨 붙여 출력,
 - [ ] **Step 2: 분류 결과 샘플 검증**
 
 출력된 5섹션에서:
+
 - 🔥/📝/👀/🚫/💡 각각이 최소 1건 있는지 확인 (실제 분포에 따라 없을 수 있음 — OK)
 - 각 항목에 "근거" 줄이 2-3줄로 첨부됐는지 확인
 - URL/링크가 모두 클릭 가능한지 확인

--- a/docs/explanation/team.md
+++ b/docs/explanation/team.md
@@ -18,21 +18,25 @@
 ## 영역별 상세
 
 ### 기획 (윤규성)
+
 - 사용자 시나리오 정의, 기능명세서 작성, 와이어프레임 (Figma)
 - 운영 정책 결정 (강제도, 알림 빈도 등)
 - 디자인·백엔드의 input
 
 ### 디자인 (김수연)
+
 - UI 디자인 (Figma)
 - 인터랙션·시각 일관성
 - 디자인 시스템 SSOT
 
 ### 백엔드 (남승민)
+
 - Prisma schema·ERD
 - NestJS API 구현
 - 데이터 모델 결정 (정규화·polymorphism·index 전략)
 
 ### 인프라 + 프론트 + AX (손장수)
+
 - K8s 클러스터, ArgoCD GitOps, MinIO·DB·인증 등 인프라
 - Next.js 웹 구현 (디자인 시안 기반)
 - **AX (AI Experience)** — AI 활용 차원. feature별 정의 다름:

--- a/docs/how-to/write-docs.md
+++ b/docs/how-to/write-docs.md
@@ -1,0 +1,70 @@
+# 문서 작성 규칙
+
+> **For**: `docs/`에 새 문서를 쓰거나 기존 문서를 정비하는 사람 (인간·AI).
+> **You'll be able to**: 새 문서를 어느 칸에 두고 어떻게 쓸지 정한다.
+
+새 문서를 쓰기 전 한 번 읽고, 모호할 때 다시 본다.
+
+## 1. Diátaxis 4분할
+
+[Diátaxis](https://diataxis.fr)는 문서를 **읽는 사람의 의도**에 따라 4칸으로 나눈다.
+
+| 칸 | 의도 | AMANG 예시 |
+| --- | --- | --- |
+| **Tutorial** | "처음이라 손잡고 배우고 싶다" | [tutorials/getting-started.md](../tutorials/getting-started.md) |
+| **How-to** | "X를 어떻게 하지?" | [how-to/contributing.md](./contributing.md), 본 문서 |
+| **Reference** | "X의 정확한 정의·규격은?" | [reference/glossary.md](../reference/glossary.md), [reference/commands.md](../reference/commands.md) |
+| **Explanation** | "왜 이렇게 됐지?" | [explanation/team.md](../explanation/team.md), [explanation/adr/](../explanation/adr/) |
+
+**한 문서 = 한 칸.** 두 칸이 섞이면 읽는 사람이 길을 잃는다 (예: 배포 절차를 읽다 갑자기 인프라 선택 이유가 나옴 — How-to를 원했는데 Explanation을 읽게 됨). 한 파일이 두 의도에 걸치면 나눈다.
+
+## 2. 문서 상단 메타데이터 (권장)
+
+문서 맨 위에 1차 독자와 얻는 것을 2줄로 밝히면 좋다. 이 두 줄을 못 쓰겠으면 → 그 문서 자체가 모호하다는 신호.
+
+```markdown
+> **For**: <누가 읽나>.
+> **You'll be able to**: <읽고 나면 무엇을 할 수 있나>.
+```
+
+## 3. 문서 간 링크는 마크다운으로
+
+다른 문서를 본문에서 가리킬 때 plain text 경로 금지, 항상 마크다운 링크.
+
+- ✅ `[용어집](../reference/glossary.md)`
+- ❌ `docs/reference/glossary.md 참조`
+
+**왜**: docs-lint의 lychee가 마크다운 링크·URL만 깨짐 검사한다. plain text 경로는 파일이 옮겨져도 자동 검출이 안 돼 stale 링크가 남는다.
+
+## 4. 중복하지 말고 참조
+
+이미 SSOT가 있는 내용은 복붙하지 말고 링크한다.
+
+- **이슈·브랜치·PR·커밋 규칙**: [CONTRIBUTING.md](../../CONTRIBUTING.md) (= [how-to/contributing.md](./contributing.md))
+- **외부 도구(Figma·Notion·Slack·Sentry 등) 계정·연동**: 루트 [CLAUDE.md](../../CLAUDE.md)의 외부 도구 컨텍스트 섹션
+- **도메인 용어 정의**: [reference/glossary.md](../reference/glossary.md)
+
+## 5. ADR 작성
+
+**ADR(Architecture Decision Record)**은 시스템 설계 결정을 영구 기록하는 짧은 문서다. PR 코멘트에 묻혀 사라지던 "왜 이렇게 했나"를 추적 가능하게 한다.
+
+**언제 쓰나** (하나라도 해당 시):
+
+- 되돌리기 어려운 결정 (DB 스키마, 외부 의존성 도입, public API 형태)
+- 두 옵션 사이 명시적 선택 (예: 쿠키 vs localStorage 인증)
+- 코드만 봐선 "왜"를 알 수 없는 결정
+
+**쓸 필요 없음**: 명백한 베스트 프랙티스, 코드가 self-documenting한 결정.
+
+**형식**: [explanation/adr/_template.md](../explanation/adr/_template.md) 복사해 사용. 파일명 `<번호>-<kebab-case-제목>.md`, 번호는 4자리 zero-padded 작성 순서(영구). 상태는 `Proposed → Accepted → (Superseded by ADR-YYYY | Deprecated)`.
+
+## 6. 디렉토리 구조
+
+`docs/` 아래 4칸(`tutorials/`·`how-to/`·`reference/`·`explanation/`) + 진입점 [docs/README.md](../README.md). ADR은 `explanation/adr/`, 설계 명세·계획은 `explanation/design/`. 파일 목록은 GitHub UI가 자동 표시하므로 인덱스를 손으로 유지하지 않는다.
+
+## 7. 자동 검증
+
+`.md` 변경 PR은 [docs-lint 워크플로](../../.github/workflows/docs-lint.yml)가 검사한다.
+
+- **markdownlint** — 마크다운 형식 (룰: [.markdownlint.jsonc](../../.markdownlint.jsonc))
+- **lychee** — 깨진 링크 (설정: [lychee.toml](../../lychee.toml), 인증 wall 제외: [.lycheeignore](../../.lycheeignore))

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -9,26 +9,35 @@
 엔티티의 정확한 필드는 [packages/database/prisma/schema.prisma](../../packages/database/prisma/schema.prisma) 참조.
 
 ### Performance / 공연
+
 음악 동아리의 행사 단위. AMANG의 한 공연 = 한 피드백 라이프사이클의 단위.
+
 - 데이터: `Performance` 엔티티 ([schema.prisma:96-112](../../packages/database/prisma/schema.prisma#L96-L112))
 - 한 공연 안에 다수의 Team
 
 ### Team / 팀
+
 한 공연 내 한 곡을 맡은 멤버 그룹. leader 1명 + 세션별 멤버.
+
 - 데이터: `Team` 엔티티
 - `Team.performanceId` → Performance에 종속
 
 ### Session / 세션
+
 보컬·기타·베이스·드럼·신디·현악기·관악기 등 **악기 역할**. ⚠️ 일반 IT의 "세션(HTTP session)"과 다름.
+
 - 데이터: `Session` 엔티티 + `SessionName` enum
 
 ### Generation / 기수
+
 동아리 입회 기수. User는 한 Generation에 종속. 기수마다 leader 1명 (= **기장**, 아래 운영·권한 어휘 참조).
 
 ### User
+
 동아리원. `User.isAdmin = true`이면 운영진.
 
 ### Equipment / EquipmentRental
+
 동아리 장비·대여. 본 문서 다른 도메인이라 짧게만.
 
 ---
@@ -38,29 +47,38 @@
 본 도메인은 **개발 중**.
 
 ### 곡 (Song)
+
 팀이 무대에 연주하기로 선정한 음악. **메타데이터로만 표현** — 제목, 원곡 아티스트, 장르, 길이 등.
+
 - 데이터: `Team.songName`, `Team.songArtist`
 - 시점: 공연 라이프사이클 RECRUITING 단계에 신청
 
 ### 녹음본 (Recording)
+
 팀이 피드백용으로 제출한 **음원·영상 파일**. **곡과 구분 필요** — 곡은 추상적 음악, 녹음본은 그 곡을 팀이 연주한 결과물 파일.
+
 - 데이터 (계획): MinIO `recordingFileKey`. 기존 운영은 `Team.songYoutubeVideoUrl`로 표현 (마이그레이션 대상).
 - 시점: SUBMISSION 단계에 업로드
 - 의미: **피드백의 직접 대상물**
 
 ### 피드백 (Feedback)
+
 피드백 작성자가 한 녹음본에 대해 입력하는 데이터 = **점수 + 코멘트**.
+
 - 점수: scoring=true 항목들의 numeric 값 → 채택 결정에 사용
 - 코멘트: scoring=false 텍스트 항목 → 작성팀에게 알림 전달 (점수와 분리)
 - EVALUATION 상태에서 입력. 시스템 이름 자체이기도 함.
 
 ### 피드백 작성자 (Reviewer)
+
 본 시스템에서 피드백을 입력하는 사람. 본인 팀 외 모든 신청 팀의 녹음본에 대해 입력 의무.
 
 ### Pay-to-vote
+
 peer review 패턴. 본인 팀 외 모든 팀에 피드백 미참여 시 본인 팀 채택 후보에서 페널티. 학술 리뷰·GitHub PR 리뷰의 호혜 메커니즘과 동일. v0.1은 팀 단위 강제.
 
 ### 공연 라이프사이클 6단계
+
 `PREPARING → RECRUITING → SUBMISSION → EVALUATION 🔒 → DECISION → DONE`. EVALUATION 진입 시 팀 구성·곡 메타·녹음본 모두 freeze.
 
 > 코드 식별자(`EVALUATION` 등)는 영문 enum 유지. 한국어 본문은 "피드백 단계" 등 풀어서 사용.
@@ -70,12 +88,15 @@ peer review 패턴. 본인 팀 외 모든 팀에 피드백 미참여 시 본인 
 ## 운영·권한 어휘
 
 ### 운영진
+
 `User.isAdmin = true`인 사용자. 공연 셋업·채택 결정 권한.
 
 ### 회장 (President)
+
 동아리 최고 운영 권한자. **현재 schema에 별도 모델 없음** — v0.1은 isAdmin 단일 레이어, 운영 컨벤션으로 "회장이 합의 게이트 누름". v2에서 별도 role 컬럼 또는 RBAC 모델링 계획.
 
 ### 기장 (Generation Leader)
+
 한 Generation(기수)의 대표 **타이틀 역할**. `Generation.leader` 필드. **권한 추가 없음** — 회장과 완전 독립. 명예직.
 
 > 따라서 합의 게이트 권한자 식별에 `Generation.leader` 활용 불가. v2에서 별도 모델링 필요.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,22 @@
+# lychee — 마크다운 안 깨진 링크 자동 검출
+# docs: https://lychee.cli.rs/usage/config/
+
+# 검사 대상
+include_verbatim = true     # 코드 블록 안 링크도 검사
+include_mail = false        # mailto: 검사 제외
+
+# 동작
+max_redirects = 5
+max_concurrency = 32
+timeout = 20
+
+# HTTP: 외부 SaaS가 익명에 4xx 응답하는 경우 false-fail 방지
+accept = [200, 204, 206, 301, 302, 304, 307, 308, 401, 403, 429]
+
+# 반복 run 시 외부 호출 캐시
+cache = true
+max_cache_age = "1d"
+
+# 출력
+no_progress = true
+verbose = "warn"


### PR DESCRIPTION
## 🚀 작업 내용

[#519](https://github.com/skku-amang/main/pull/519)에서 문서를 목적별 네 칸(Diátaxis)으로 나눴는데, "새 문서를 **어디에·어떻게** 쓰나"라는 규칙과 자동 검사가 없었습니다. 이번에 그 두 가지를 채웁니다.

- **문서 작성 규칙** — [docs/how-to/write-docs.md](docs/how-to/write-docs.md): 어느 칸에 둘지, 한 문서엔 한 목적만, 다른 문서는 링크로 연결, 결정 기록(ADR) 쓰는 법
- **ADR 템플릿** — [docs/explanation/adr/\_template.md](docs/explanation/adr/_template.md): 설계 결정을 기록할 때 복사해서 채우는 양식 (기존 ADR-0001·0002 형식에 맞춤)
- **docs/CLAUDE.md** — 문서 폴더 안에서 작업할 때 위 규칙을 AI가 자동으로 참고하도록 하는 짧은 안내
- **문서 자동 검사(CI)** — `.md` 파일이 바뀐 PR에서 자동 실행:
  - **markdownlint**: 마크다운 형식 검사 (불필요하게 시끄러운 규칙은 꺼둠)
  - **lychee**: 깨진 링크 검출 (문서가 이동해도 끊긴 링크를 잡아냄). 로그인이 필요한 외부 주소는 검사 제외
- **docs/README.md**: 파일을 손으로 나열하던 목록을 없애고, 각 칸(폴더) 링크로 대체 — 파일 목록은 GitHub이 자동으로 보여주므로 손으로 관리하다 낡을 일이 없어집니다
- 기존 문서 몇 개는 markdownlint 자동 정리(제목·목록 주변 빈 줄)만 적용 — 내용 변화 없음

## 🔗 관련 이슈

Closes #521

## 🙏 리뷰어에게

- **머지 순서**: [#522](https://github.com/skku-amang/main/pull/522)(동아리 운영 모델)를 먼저 머지한 뒤 이 PR을 올리면 좋습니다. 둘 다 `docs/README.md`를 건드려 충돌 가능 — 이 PR이 그 목록을 통째로 없애므로, 충돌 시 이 PR 버전(목록 제거)을 택하면 됩니다. 새 문서는 폴더 링크로 계속 노출됩니다.
- markdownlint에서 꺼둔 규칙([.markdownlint.jsonc](.markdownlint.jsonc)에 각 사유 주석)이 과한지 봐주세요.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
