### PR TITLE
fix(web): 보안 응답 헤더 추가 (#537)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -41,7 +41,26 @@ const nextConfig = {
     ],
     unoptimized: true
   },
-  output: "standalone"
+  output: "standalone",
+  async headers() {
+    const securityHeaders = [
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=31536000; includeSubDomains"
+      },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "X-Frame-Options", value: "SAMEORIGIN" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()"
+      },
+      // 전체 CSP(script-src 등)는 Sentry·next-auth·인라인과 충돌 위험 → 후속 이슈에서 Report-Only로 도입.
+      // 지금은 클릭재킹 방어(frame-ancestors)만 안전하게 적용.
+      { key: "Content-Security-Policy", value: "frame-ancestors 'self'" }
+    ]
+    return [{ source: "/:path*", headers: securityHeaders }]
+  }
 }
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
## 목적

[#537] 보안 응답 헤더 부재 해소 — web tier.

## 변경

`apps/web/next.config.mjs`에 `headers()` 추가 (모든 라우트 적용):

| 헤더 | 값 | 목적 |
|---|---|---|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HTTPS 강제 |
| `X-Content-Type-Options` | `nosniff` | MIME 스니핑 차단 |
| `X-Frame-Options` | `SAMEORIGIN` | 클릭재킹 차단 (구형 브라우저) |
| `Content-Security-Policy` | `frame-ancestors 'self'` | 클릭재킹 차단 (표준) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | 리퍼러 유출 최소화 |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 미사용 기능 차단 |

## 범위 밖 (후속)

- **전체 CSP**(`script-src`/`style-src` 등)는 Sentry·next-auth·인라인과 충돌 위험 → **Report-Only로 별도 도입** 예정
- **API helmet + `x-powered-by` 제거**는 같은 [#537]의 BE 몫 (@nhjbest22)

## 검증

- [x] `next.config.mjs` 구문 체크 통과
- [ ] CI 빌드
- [ ] 배포 후 `curl -I https://amang.json-server.win`로 헤더 적용 확인

## 주의 (HSTS)

`includeSubDomains`는 `amang.json-server.win` 서브트리에 HTTPS를 강제한다. 현재 `api`/`s3`/`minio`.amang 전부 HTTPS라 안전. 이 서브트리에 HTTP-only 서비스를 추가할 계획이면 재검토. `preload`는 비가역(브라우저 preload 리스트 등록)이라 의도적으로 제외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
