### PR TITLE
feat(web): 팀 CSV에 세션별 참여자 명단 추가 (#525)

### DIFF
--- a/apps/web/app/(admin)/_components/data-table/DataTable.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTable.tsx
@@ -180,11 +180,40 @@ function DataTableInner<TData, TValue>({
   useEffect(() => {
     try {
       const stored = localStorage.getItem(visibilityStorageKey)
-      if (stored) setColumnVisibility(JSON.parse(stored))
+      // Merge (not replace) so columns absent from stored state keep their
+      // defaults — e.g. alwaysExport columns added after this key was saved.
+      if (stored)
+        setColumnVisibility((prev) => ({
+          ...prev,
+          ...(JSON.parse(stored) as VisibilityState)
+        }))
     } catch {
       /* ignore */
     }
   }, [visibilityStorageKey])
+
+  // alwaysExport columns are meant for CSV only — hide them from the table by
+  // default. Runs on column changes too, so dynamically added export columns
+  // (e.g. per-session roster slots) also start hidden.
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const next = { ...prev }
+      let changed = false
+      for (const col of columns) {
+        const id =
+          "id" in col && col.id
+            ? col.id
+            : "accessorKey" in col && typeof col.accessorKey === "string"
+              ? col.accessorKey
+              : undefined
+        if (id && col.meta?.alwaysExport && !(id in next)) {
+          next[id] = false
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [columns])
 
   const handleColumnVisibilityChange: OnChangeFn<VisibilityState> = useCallback(
     (updaterOrValue) => {

--- a/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
+++ b/apps/web/app/(admin)/_components/data-table/DataTableToolbar.tsx
@@ -39,18 +39,21 @@ interface DataTableToolbarProps<TData> {
 }
 
 function exportToCsv<TData>(table: Table<TData>) {
-  const visibleColumns = table
+  const exportColumns = table
     .getAllColumns()
     .filter(
-      (col) => col.getIsVisible() && col.id !== "select" && col.id !== "actions"
+      (col) =>
+        col.id !== "select" &&
+        col.id !== "actions" &&
+        (col.getIsVisible() || col.columnDef.meta?.alwaysExport)
     )
 
-  const headers = visibleColumns.map(
+  const headers = exportColumns.map(
     (col) => col.columnDef.meta?.label ?? col.id
   )
 
   const rows = table.getFilteredRowModel().rows.map((row) =>
-    visibleColumns.map((col) => {
+    exportColumns.map((col) => {
       const value = row.getValue(col.id)
       if (value == null) return ""
       const str = String(value)

--- a/apps/web/app/(admin)/_components/data-table/types.ts
+++ b/apps/web/app/(admin)/_components/data-table/types.ts
@@ -15,6 +15,8 @@ declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string
+    // Include this column in CSV export even when hidden from the table.
+    alwaysExport?: boolean
     editable?: {
       type:
         | "text"

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -17,6 +17,11 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import ROUTES from "@/constants/routes"
+import {
+  SESSION_DISPLAY_NAME,
+  SESSION_NAMES,
+  type SessionNameValue
+} from "@/constants/session"
 import { TeamList } from "@repo/shared-types"
 
 type TeamItem = TeamList[number]
@@ -24,6 +29,31 @@ type TeamItem = TeamList[number]
 interface ColumnActions {
   onDelete: (team: TeamItem) => void
 }
+
+// 팀의 특정 세션에 배정된 멤버 이름을 index 순으로 나열 (CSV 정산·명단 대조용)
+function sessionRoster(team: TeamItem, sessionName: SessionNameValue): string {
+  return team.teamSessions
+    .filter((ts) => ts.session.name === sessionName)
+    .flatMap((ts) => ts.members)
+    .map((m) => m.user.name)
+    .join(", ")
+}
+
+// 세션별 참여자 명단 컬럼 — 테이블에서는 기본 숨김, CSV export에는 항상 포함
+const sessionColumns: ColumnDef<TeamItem>[] = Object.values(SESSION_NAMES).map(
+  (sessionName) => ({
+    id: `session_${sessionName}`,
+    accessorFn: (row) => sessionRoster(row, sessionName),
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title={SESSION_DISPLAY_NAME[sessionName]}
+      />
+    ),
+    meta: { label: SESSION_DISPLAY_NAME[sessionName], alwaysExport: true },
+    cell: ({ getValue }) => (getValue() as string) || "-"
+  })
+)
 
 export function getColumns(
   actions: ColumnActions,
@@ -181,6 +211,7 @@ export function getColumns(
         )
       }
     },
+    ...sessionColumns,
     {
       accessorKey: "isFreshmenFixed",
       header: ({ column }) => (

--- a/apps/web/app/(admin)/admin/teams/_components/columns.tsx
+++ b/apps/web/app/(admin)/admin/teams/_components/columns.tsx
@@ -30,33 +30,47 @@ interface ColumnActions {
   onDelete: (team: TeamItem) => void
 }
 
-// 팀의 특정 세션에 배정된 멤버 이름을 index 순으로 나열 (CSV 정산·명단 대조용)
-function sessionRoster(team: TeamItem, sessionName: SessionNameValue): string {
+// 팀의 특정 세션에 배정된 멤버를 index 순으로 (여러 TeamSession이 같은 세션명일 수 있어 합산)
+function sessionMembers(team: TeamItem, sessionName: SessionNameValue) {
   return team.teamSessions
     .filter((ts) => ts.session.name === sessionName)
     .flatMap((ts) => ts.members)
-    .map((m) => m.user.name)
-    .join(", ")
 }
 
-// 세션별 참여자 명단 컬럼 — 테이블에서는 기본 숨김, CSV export에는 항상 포함
-const sessionColumns: ColumnDef<TeamItem>[] = Object.values(SESSION_NAMES).map(
-  (sessionName) => ({
-    id: `session_${sessionName}`,
-    accessorFn: (row) => sessionRoster(row, sessionName),
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title={SESSION_DISPLAY_NAME[sessionName]}
-      />
-    ),
-    meta: { label: SESSION_DISPLAY_NAME[sessionName], alwaysExport: true },
-    cell: ({ getValue }) => (getValue() as string) || "-"
+/**
+ * 세션별 참여자 명단을 슬롯 단위 컬럼으로 (보컬1·보컬2·기타1…).
+ * 슬롯 수는 전체 팀 중 해당 세션 최대 인원으로 결정 — 데이터 손실 없이 간부진 시트 레이아웃과 일치.
+ * 최대 1명이면 번호 생략(베이스·드럼), 2명 이상이면 번호 부여.
+ * 테이블에서는 기본 숨김(alwaysExport), CSV export에만 항상 포함.
+ */
+function buildSessionColumns(teams: TeamItem[]): ColumnDef<TeamItem>[] {
+  return Object.values(SESSION_NAMES).flatMap((sessionName) => {
+    const maxSlots = teams.reduce(
+      (max, team) => Math.max(max, sessionMembers(team, sessionName).length),
+      0
+    )
+    return Array.from({ length: maxSlots }, (_, i) => {
+      const label =
+        maxSlots === 1
+          ? SESSION_DISPLAY_NAME[sessionName]
+          : `${SESSION_DISPLAY_NAME[sessionName]}${i + 1}`
+      return {
+        id: `session_${sessionName}_${i}`,
+        accessorFn: (row: TeamItem) =>
+          sessionMembers(row, sessionName)[i]?.user.name ?? "",
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={label} />
+        ),
+        meta: { label, alwaysExport: true },
+        cell: ({ getValue }) => (getValue() as string) || "-"
+      } satisfies ColumnDef<TeamItem>
+    })
   })
-)
+}
 
 export function getColumns(
   actions: ColumnActions,
+  teams: TeamItem[],
   performanceMap?: Map<number, string>
 ): ColumnDef<TeamItem>[] {
   return [
@@ -211,7 +225,7 @@ export function getColumns(
         )
       }
     },
-    ...sessionColumns,
+    ...buildSessionColumns(teams),
     {
       accessorKey: "isFreshmenFixed",
       header: ({ column }) => (

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { useToast } from "@/components/hooks/use-toast"
 import { usePerformances } from "@/hooks/api/usePerformance"
 import { useAllTeams, useDeleteTeam, useUpdateTeam } from "@/hooks/api/useTeam"
+import { SESSION_NAMES } from "@/constants/session"
 import { formatGenerationOrder } from "@/lib/utils"
 import { TeamList } from "@repo/shared-types"
 
@@ -172,7 +173,11 @@ export default function TeamsAdminPage() {
         initialColumnVisibility={{
           name: false,
           isFreshmenFixed: false,
-          isSelfMade: false
+          isSelfMade: false,
+          // 세션별 참여자 컬럼: 테이블 기본 숨김, CSV export에는 항상 포함
+          ...Object.fromEntries(
+            Object.values(SESSION_NAMES).map((s) => [`session_${s}`, false])
+          )
         }}
         filters={[
           {

--- a/apps/web/app/(admin)/admin/teams/page.tsx
+++ b/apps/web/app/(admin)/admin/teams/page.tsx
@@ -9,7 +9,6 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { useToast } from "@/components/hooks/use-toast"
 import { usePerformances } from "@/hooks/api/usePerformance"
 import { useAllTeams, useDeleteTeam, useUpdateTeam } from "@/hooks/api/useTeam"
-import { SESSION_NAMES } from "@/constants/session"
 import { formatGenerationOrder } from "@/lib/utils"
 import { TeamList } from "@repo/shared-types"
 
@@ -84,9 +83,10 @@ export default function TeamsAdminPage() {
             setDeleteOpen(true)
           }
         },
+        teams ?? [],
         performanceMap
       ),
-    [performanceMap]
+    [teams, performanceMap]
   )
 
   const handleCellUpdate = async (
@@ -173,11 +173,7 @@ export default function TeamsAdminPage() {
         initialColumnVisibility={{
           name: false,
           isFreshmenFixed: false,
-          isSelfMade: false,
-          // 세션별 참여자 컬럼: 테이블 기본 숨김, CSV export에는 항상 포함
-          ...Object.fromEntries(
-            Object.values(SESSION_NAMES).map((s) => [`session_${s}`, false])
-          )
+          isSelfMade: false
         }}
         filters={[
           {


### PR DESCRIPTION
## 🚀 작업 내용

관리자 페이지에서 팀 목록을 CSV(엑셀로 열리는 표 파일)로 내려받을 때, 지금까지는 **누가 어느 세션(보컬·기타 등)을 맡았는지가 빠져** 있었습니다. 그래서 공연 정산, 참여자 명단 대조, 피드백 참여 확인을 손으로 다시 채워야 했어요.

이 변경으로 CSV에 **세션별 참여자 이름 칸**이 생깁니다. 간부진이 지금 쓰는 시트(보컬1·보컬2·기타1·기타2·신디1…)와 똑같이 **한 명씩 칸이 나뉘어** 나오도록 맞췄습니다.

예시:

| 곡명 | 아티스트 | … | 보컬1 | 보컬2 | 기타1 | 기타2 | 베이스 | 드럼 |
|---|---|---|---|---|---|---|---|---|
| 몽유병 | 로맨틱펀치 | … | 전세웅 |  | 박종현 | 이근종 | 이재준 | 김민서 |
| 용의자 | 한로로 | … | 김수민 |  | 윤하진 | 황인후 | 최서연 | 원운재 |

- 칸 개수는 **데이터를 보고 자동으로** 정해집니다. 어떤 세션에 최대 2명까지 있으면 `보컬1`·`보컬2`처럼 번호가 붙고, 한 명뿐인 세션(베이스·드럼 등)은 번호 없이 한 칸입니다. 그래서 사람이 아무리 많아도 이름이 잘리지 않습니다.
- 자리가 비면 빈 칸으로 남습니다.
- 화면의 표에는 이 칸들이 **기본으로 숨겨져** 있어 지저분해지지 않고, CSV를 뽑을 때만 자동으로 들어갑니다.

**왜 이렇게 했나요**: 원인은 "CSV가 화면에 보이는 칸만 내보내던 것"이었습니다. 화면은 깔끔하게, CSV는 빠짐없이 — 두 목적을 나누기 위해 "화면엔 숨겨도 CSV엔 항상 넣는 칸" 개념을 새로 넣었습니다. 앞으로 다른 관리자 표에도 재사용할 수 있어요. 필요한 데이터(팀별 세션·멤버)는 이미 서버가 내려주고 있어 **서버 쪽 변경은 없습니다.**

## 📸 스크린샷(선택)

생략 (CSV 파일 출력 변경 — 표 예시는 위 작업 내용 참고)

## 🔗 관련 이슈

Closes #525

## 🙏 리뷰어에게

- CSV 칸 순서는 시트와 동일하게 보컬 → 기타 → 베이스 → 신디 → 드럼 → 현악기 → 관악기 입니다.
- 시트의 "그 외" 칸은 현악기·관악기로 나눠 넣었습니다(있을 때만 칸 생성). 하나로 합치는 게 나으면 알려주세요.
- 한 세션에 여러 명일 때 이름 순서는 저장된 순서(index)를 따릅니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.