### PR TITLE
ci: Dependabot 설정 추가 (보안 업데이트 그룹핑)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  # pnpm workspace 전체 (루트 pnpm-lock.yaml 하나가 apps/*, packages/* 를 모두 관장)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      # 보안 업데이트는 open-pull-requests-limit 적용 대상이 아니므로 반드시 그룹핑한다.
+      # 프로덕션/개발을 나누는 이유: 프로덕션 PR은 작고 급하며, 개발 도구 PR은 크고 급하지 않다.
+      security-production:
+        applies-to: "security-updates"
+        dependency-type: "production"
+        patterns: ["*"]
+      security-development:
+        applies-to: "security-updates"
+        dependency-type: "development"
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: "version-updates"
+        update-types: ["minor", "patch"]
+    # 메이저는 그룹에 넣지 않고 개별 PR로 남긴다 (breaking change는 따로 검토).
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/apps/api"
+      - "/apps/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      docker:
+        patterns: ["*"]


### PR DESCRIPTION
## 🚀 작업 내용

의존성 보안 알림을 자동으로 고쳐 주는 **Dependabot**을 쓰기 위한 설정 파일(`.github/dependabot.yml`)을 추가합니다.

Dependabot은 우리가 쓰는 외부 라이브러리에 보안 문제가 생기면 안전한 버전으로 올리는 PR을 대신 만들어 주는 GitHub 기능입니다. 지금은 꺼져 있어서 알림만 62건 쌓여 있습니다.

이 PR은 **설정만 추가**하고, 기능 켜기는 머지 후에 따로 합니다.

### 왜 설정을 먼저 넣나요

보안 수정 PR은 **개수 제한이 없습니다**. 설정 없이 기능부터 켜면 PR이 30개 넘게 한꺼번에 생깁니다. 이 설정 파일이 그 PR들을 몇 개로 묶어 주는 역할을 합니다.

### 어떻게 묶었나요

| 묶음 | 내용 | 이유 |
| --- | --- | --- |
| 보안 · 서비스용 | 실제 서비스에 들어가는 라이브러리 | 양이 적고 급함 → 빨리 머지 |
| 보안 · 개발용 | 빌드·테스트 도구 | 양이 많고 안 급함 → 천천히 |
| 일반 · 소규모 업데이트 | 자잘한 버전 올림 | 한 PR로 묶어 소음 감소 |
| 큰 버전 업데이트 | (묶지 않음) | 동작이 바뀔 수 있어 하나씩 검토 |

일반 업데이트 PR은 최대 5개까지만, 매주 월요일 오전 9시(한국 시간)에 생성됩니다. npm 라이브러리 외에 GitHub Actions와 Dockerfile도 같이 관리합니다.

## 📸 스크린샷(선택)

설정 파일 추가라 화면 변경 없음. 첫 자동 PR이 생성되면 이 PR에 코멘트로 결과를 남기겠습니다.

## 🔗 관련 이슈

Closes #549

## 🙏 리뷰어에게

- 서비스용/개발용 분류는 GitHub이 자동으로 합니다. 그런데 우리 레포는 pnpm workspace 구조라 이 분류가 정확하지 않은 걸 확인했습니다 (예: 빌드 도구인 vite를 "서비스용"으로 표시). 첫 PR이 나오면 분류가 맞는지 같이 봐 주세요. 틀리면 그룹 기준을 바꾸겠습니다.
- 매주 월요일 오전 9시가 적당한 주기인지 봐 주세요.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
