### PR TITLE
ci: Dependabot 설정을 워크스페이스 매니페스트까지 확장

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 
 updates:
-  # pnpm workspace 전체 (루트 pnpm-lock.yaml 하나가 apps/*, packages/* 를 모두 관장)
+  # 알림 스캐너는 루트 pnpm-lock.yaml 하나만 읽지만, 수정 PR을 만드는 업데이터는
+  # package.json이 있는 디렉토리마다 별도 job을 띄운다. 루트만 선언하면 워크스페이스
+  # 패키지의 job이 설정 없는 기본값(그룹핑·prefix 없음)으로 돌아간다.
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/apps/*"
+      - "/packages/*"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -59,3 +64,8 @@ updates:
     groups:
       docker:
         patterns: ["*"]
+    ignore:
+      # Node 베이스 이미지 메이저는 런타임 교체다. LTS 여부 확인과 CI(node-version)·
+      # engines 동시 변경이 필요하므로 사람이 별도 PR로 진행한다.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 🚀 작업 내용

#550에서 넣은 Dependabot 설정이 **절반만 적용되고 있었습니다.** 이를 고칩니다.

### 무엇이 잘못됐나

설정에서 대상 위치를 프로젝트 최상위(`/`) 한 곳으로만 적어 뒀습니다. 그런데 실제 실행 기록을 보니, `apps/web` 폴더에 대한 작업은 **우리 설정을 무시하고 기본값으로** 돌고 있었습니다.

```
"source": { "directories": ["/apps/web"] },
"dependency-groups": [],                        ← 묶음 설정 안 먹음
"commit-message-options": { "prefix": null }    ← 커밋 제목 규칙 안 먹음
```

원인은 Dependabot 안에 **역할이 다른 두 부분**이 있기 때문입니다.

| 역할 | 읽는 파일 |
| --- | --- |
| 보안 문제를 찾아 알려 주는 쪽 | 최상위 `pnpm-lock.yaml` 하나 |
| 고치는 PR을 만드는 쪽 | `package.json`이 있는 **폴더마다 따로** |

앞쪽만 보고 "최상위 한 곳이면 충분하다"고 판단한 게 틀렸습니다.

### 고친 내용

1. **npm** — 대상 위치에 `/apps/*`, `/packages/*` 추가
2. **docker** — Node 이미지의 큰 버전 변경은 자동 PR에서 제외

### 2번을 왜 제외하나

#551이 Node를 22에서 **26**으로 올리자고 제안했는데, 두 가지 문제가 있습니다.

- Node 26은 아직 **장기 지원 버전이 아닙니다** (현재 "Current" 단계).
  Node 공식 문서: *"Production applications should only use Active LTS or Maintenance LTS releases."*
  지금 장기 지원 버전은 **24**입니다.
- 우리 테스트 환경(GitHub Actions) 4곳은 여전히 22로 고정돼 있습니다.
  머지하면 **테스트는 22에서, 실제 서비스는 26에서** 도는 상태가 됩니다.

Node 버전 올리기는 Dockerfile 3개 + 테스트 설정 4곳 + `engines` 를 **한 번에** 바꿔야 해서, 사람이 별도 PR로 하는 게 맞습니다. #551은 닫습니다.

## 📸 스크린샷(선택)

설정 파일 변경이라 화면 변경 없음.

## 🔗 관련 이슈

#549

## 🙏 리뷰어에게

- `/` 와 `/apps/*` 를 둘 다 넣어서 같은 라이브러리에 PR이 두 개 생길 가능성이 있습니다. 다음 주 월요일 실행 결과를 보고, 중복이 생기면 `/` 를 빼겠습니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
