### PR TITLE
build(web): 미사용 zod-form-data 의존성 제거

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,8 +67,7 @@
     "react-icons": "^5.6.0",
     "tailwind-merge": "^2.6.1",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2",
-    "zod-form-data": "^2.0.8"
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,9 +352,6 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      zod-form-data:
-        specifier: ^2.0.8
-        version: 2.0.8(zod@3.25.76)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -3310,9 +3307,6 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
-
-  '@rvf/set-get@7.0.1':
-    resolution: {integrity: sha512-GkTSn9K1GrTYoTUqlUs36k6nJnzjQaFBTTEIqUYmzBcsGsoJM8xG7EAx2WLHWAA4QzFjcwWUSHQ3vM3Fbw50Tg==}
 
   '@sentry-internal/browser-utils@10.47.0':
     resolution: {integrity: sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==}
@@ -8431,11 +8425,6 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
-  zod-form-data@2.0.8:
-    resolution: {integrity: sha512-X31GkEc8uk5/L387L4TVI1z7obBbN/0MRHBHfHW3uMOWkVJeSsa+grvkTvY9qyFbNshKEnqK+jLJNlY+d7jpLw==}
-    peerDependencies:
-      zod: '>= 3.11.0'
-
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -11311,8 +11300,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
-
-  '@rvf/set-get@7.0.1': {}
 
   '@sentry-internal/browser-utils@10.47.0':
     dependencies:
@@ -17320,11 +17307,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
-
-  zod-form-data@2.0.8(zod@3.25.76):
-    dependencies:
-      '@rvf/set-get': 7.0.1
-      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## 🚀 작업 내용

웹 앱에서 **쓰지 않는 라이브러리** `zod-form-data`를 제거합니다.

이 라이브러리는 "서비스에 필요한 목록"에 등록돼 있지만, 코드 어디에서도 불러 쓰지 않습니다. 폼 검증은 이미 다른 도구(`react-hook-form` + `@hookform/resolvers`)로 하고 있고, 그 경로는 이 라이브러리를 거치지 않습니다.

### 왜 지금 빼나

`zod-form-data`가 딸려 오는 하위 부품 `@rvf/set-get`에서 보안 경고(#180, 등급 high)가 떠 있었습니다. 실제로는 이 라이브러리 자체가 실행되지 않아 위험하지 않았지만, **안 쓰는 걸 두면 경고만 계속 쌓입니다.** 빼면 경고도 같이 사라집니다.

`shadcn` 제거(#555)와 같은 정리입니다 — 목록에만 있고 실제로는 안 쓰는 항목을 걷어내는 작업입니다.

| | |
| --- | --- |
| `pnpm-lock.yaml` | `zod-form-data`, `@rvf/set-get` 완전 제거 |
| 닫힐 보안 경고 | #180 (high) |

## 📸 스크린샷(선택)

화면 변경 없음 (부품 목록 정리).

검증:

```
pnpm check-types → Tasks: 9 successful, 9 total
```

## 🔗 관련 이슈

#549

## 🙏 리뷰어에게

- 폼을 다루는 화면(팀 신청, 프로필 수정 등)이 이 라이브러리를 정말 안 쓰는지 확인했습니다: `zfd` 심볼 사용 0건, 서버 액션(`use server`) 0건. 혹시 놓친 사용처가 있으면 알려 주세요.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
